### PR TITLE
Disable markAsRead button on AssessView

### DIFF
--- a/src/gui/src/components/assess/CardStory.vue
+++ b/src/gui/src/components/assess/CardStory.vue
@@ -130,6 +130,7 @@
 
           <v-list class="extraActionsList" dense>
             <v-list-item
+              v-if="detailView || reportView"
               :prepend-icon="
                 !story.read ? 'mdi-eye-outline' : 'mdi-eye-off-outline'
               "


### PR DESCRIPTION
Fixes bug: mark as read button displayed twice in assess view's news items