### PR TITLE
Add time to StoryMetaInfo.vue

### DIFF
--- a/src/gui/src/components/assess/card/NewsMetaInfo.vue
+++ b/src/gui/src/components/assess/card/NewsMetaInfo.vue
@@ -29,7 +29,6 @@
 </template>
 
 <script>
-import { getCleanHostname } from '@/utils/helpers.js'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SourceInfo from '@/components/assess/card/SourceInfo.vue'
@@ -56,16 +55,6 @@ export default {
       return props.newsItem.news_item_data?.author
     })
 
-    const source = computed(() => {
-      return props.newsItem.news_item_data
-        ? {
-            name: getCleanHostname(props.newsItem.news_item_data.source),
-            link: props.newsItem.news_item_data.link,
-            type: props.newsItem.news_item_data.osint_source_id
-          }
-        : null
-    })
-
     const collected_date = computed(() => {
       return props.newsItem.news_item_data?.collected
         ? d(new Date(props.newsItem.news_item_data.collected), 'long')
@@ -75,7 +64,6 @@ export default {
     return {
       published_date,
       author,
-      source,
       collected_date
     }
   }

--- a/src/gui/src/components/assess/card/NewsMetaInfo.vue
+++ b/src/gui/src/components/assess/card/NewsMetaInfo.vue
@@ -14,16 +14,7 @@
             {{ collected_date }}
           </v-col>
         </v-row>
-        <v-row>
-          <v-col style="max-width: 110px" class="py-0">
-            <strong>{{ $t('assess.source') }}:</strong>
-          </v-col>
-          <v-col class="py-0" @click.stop>
-            <a :href="source?.link" target="_blank">
-              {{ source?.name }}
-            </a>
-          </v-col>
-        </v-row>
+        <SourceInfo :news-item="newsItem" />
         <v-row>
           <v-col style="max-width: 110px" class="py-0">
             <strong>{{ $t('assess.author') }}:</strong>
@@ -41,9 +32,11 @@
 import { getCleanHostname } from '@/utils/helpers.js'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import SourceInfo from '@/components/assess/card/SourceInfo.vue'
 
 export default {
   name: 'NewsMetaInfo',
+  components: { SourceInfo },
   props: {
     newsItem: {
       type: Object,

--- a/src/gui/src/components/assess/card/SourceInfo.vue
+++ b/src/gui/src/components/assess/card/SourceInfo.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-row>
+    <v-col style="max-width: 110px" class="py-0">
+      <strong>{{ $t('assess.source') }}:</strong>
+    </v-col>
+    <v-col class="py-0" @click.stop>
+      <a :href="source?.link" target="_blank">
+        {{ source?.name }}
+      </a>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { getCleanHostname } from '@/utils/helpers.js'
+import { computed } from 'vue'
+
+export default {
+  name: 'SourceInfo',
+  props: {
+    newsItem: {
+      type: Object,
+      required: true
+    }
+  },
+  setup(props) {
+    const source = computed(() => {
+      return props.newsItem.news_item_data
+        ? {
+            name: getCleanHostname(props.newsItem.news_item_data.source),
+            link: props.newsItem.news_item_data.link,
+            type: props.newsItem.news_item_data.osint_source_id
+          }
+        : null
+    })
+
+    return {
+      source
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/gui/src/components/assess/card/SourceInfo.vue
+++ b/src/gui/src/components/assess/card/SourceInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <v-col style="max-width: 110px" class="py-0">
-      <strong>{{ $t('assess.source') }}:</strong>
+      <strong>{{ $t('assess.article') }}:</strong>
     </v-col>
     <v-col class="py-0" @click.stop>
       <a :href="source?.link" target="_blank">

--- a/src/gui/src/components/assess/card/SourceInfo.vue
+++ b/src/gui/src/components/assess/card/SourceInfo.vue
@@ -41,4 +41,3 @@ export default {
 }
 </script>
 
-<style scoped></style>

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -42,6 +42,7 @@
             {{ story.relevance }}
           </v-col>
         </v-row>
+        <SourceInfo :news-item="story.news_items[0]" />
       </v-col>
       <v-col
         :cols="detailView ? 10 : 6"
@@ -68,10 +69,12 @@ import { useI18n } from 'vue-i18n'
 import { computed } from 'vue'
 import { useDisplay } from 'vuetify'
 import { storeToRefs } from 'pinia'
+import SourceInfo from '@/components/assess/card/SourceInfo.vue'
 
 export default {
   name: 'StoryMetaInfo',
   components: {
+    SourceInfo,
     TagList,
     WeekChart
   },

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -126,9 +126,9 @@ export default {
 
     const getPublishedDate = computed(() => {
       const pubDateNew = new Date(published_dates.value[0])
-      const pubDateNewStr = d(pubDateNew, 'short')
+      const pubDateNewStr = d(pubDateNew, 'long')
       const pubDateOld = new Date(published_dates.value[1])
-      const pubDateOldStr = d(pubDateOld, 'short')
+      const pubDateOldStr = d(pubDateOld, 'long')
       if (pubDateNew && pubDateOld) {
         return pubDateNewStr === pubDateOldStr
           ? pubDateNewStr

--- a/src/gui/src/i18n/de/messages.js
+++ b/src/gui/src/i18n/de/messages.js
@@ -473,6 +473,7 @@ export const messages_de = {
     }
   },
   assess: {
+    article: 'Artikel',
     source: 'Quelle',
     comments: 'Kommentare',
     collected: 'Gesammelt',

--- a/src/gui/src/i18n/en/messages.js
+++ b/src/gui/src/i18n/en/messages.js
@@ -522,6 +522,7 @@ export const messages_en = {
   },
 
   assess: {
+    article: 'Article',
     source: 'Source',
     comments: 'Comments',
     collected: 'Collected',


### PR DESCRIPTION
resolves #108 

Changing time format from "short" to "long" in story view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `SourceInfo` component to display news source information with a link and type.
- **Enhancements**
	- Improved the date formatting in news stories from 'short' to 'long' format for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->