### PR TITLE
Update foreign key constraints

### DIFF
--- a/src/core/core/model/acl_entry.py
+++ b/src/core/core/model/acl_entry.py
@@ -162,10 +162,10 @@ class ACLEntry(BaseModel):
 
 
 class ACLEntryUser(BaseModel):
-    acl_entry_id = db.Column(db.Integer, db.ForeignKey("acl_entry.id"), primary_key=True)
+    acl_entry_id = db.Column(db.Integer, db.ForeignKey("acl_entry.id", ondelete="CASCADE"), primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="CASCADE"), primary_key=True)
 
 
 class ACLEntryRole(BaseModel):
-    acl_entry_id = db.Column(db.Integer, db.ForeignKey("acl_entry.id"), primary_key=True)
-    role_id = db.Column(db.Integer, db.ForeignKey("role.id"), primary_key=True)
+    acl_entry_id = db.Column(db.Integer, db.ForeignKey("acl_entry.id", ondelete="CASCADE"), primary_key=True)
+    role_id = db.Column(db.Integer, db.ForeignKey("role.id", ondelete="CASCADE"), primary_key=True)

--- a/src/core/core/model/news_item.py
+++ b/src/core/core/model/news_item.py
@@ -1125,12 +1125,12 @@ class NewsItemAttribute(BaseModel):
 
 class NewsItemDataNewsItemAttribute(BaseModel):
     news_item_data_id = db.Column(db.String, db.ForeignKey("news_item_data.id"), primary_key=True)
-    news_item_attribute_id = db.Column(db.Integer, db.ForeignKey("news_item_attribute.id"), primary_key=True)
+    news_item_attribute_id = db.Column(db.Integer, db.ForeignKey("news_item_attribute.id", ondelete="CASCADE"), primary_key=True)
 
 
 class NewsItemAggregateNewsItemAttribute(BaseModel):
     news_item_aggregate_id = db.Column(db.Integer, db.ForeignKey("news_item_aggregate.id"), primary_key=True)
-    news_item_attribute_id = db.Column(db.Integer, db.ForeignKey("news_item_attribute.id"), primary_key=True)
+    news_item_attribute_id = db.Column(db.Integer, db.ForeignKey("news_item_attribute.id", ondelete="CASCADE"), primary_key=True)
 
 
 class ReportItemNewsItemAggregate(BaseModel):


### PR DESCRIPTION
@b3n4kh  please double check news_item_attribute 

see issue #26 for details 

 no changes were made for: 
- news_item_aggregate because it was unclear what happens with news_item. currently, news items are deleted when the aggregate only has one item. However, when there are multiple items, in an aggregate, all are deleted but the item with the same id as the aggregate 
- parameter_value as this was wrongly marked



user_profile see: https://github.com/taranis-ai/taranis-ai/issues/132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved database integrity by ensuring related data is automatically removed when a primary record is deleted, enhancing the maintenance and consistency of user access controls and news item attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->