### PR TITLE
Render product only if product is created

### DIFF
--- a/src/gui/src/components/publish/ProductItem.vue
+++ b/src/gui/src/components/publish/ProductItem.vue
@@ -12,6 +12,7 @@
         <span>{{ $t('product.download') }}</span>
       </v-btn>
       <v-btn
+        v-if="edit"
         variant="outlined"
         prepend-icon="mdi-eye-outline"
         @click="rerenderProduct()"


### PR DESCRIPTION
Enhance experience by displaying the render product button only if it makes sense = when product is created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the product item display to include an edit button, visible only when in edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->