### PR TITLE
Fix pdf viewer visibility

### DIFF
--- a/src/gui/src/components/publish/ProductItem.vue
+++ b/src/gui/src/components/publish/ProductItem.vue
@@ -107,6 +107,7 @@
             <span v-if="render_html" v-dompurify-html="renderedProduct"></span>
 
             <object
+              v-if="renderedProductMimeType === 'application/pdf'"
               class="pdf-container"
               :data="'data:application/pdf;base64,' + renderedProduct"
               type="application/pdf"


### PR DESCRIPTION
The PDF viewer is visible with any kind of product type. It should be visible only if it is a PDF presenter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where non-PDF files were incorrectly rendered, now only PDF files are displayed properly in the product item view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->