### PR TITLE
Added 'Clone report' functionality 

### DIFF
--- a/src/gui/src/components/analyze/ReportItem.vue
+++ b/src/gui/src/components/analyze/ReportItem.vue
@@ -22,15 +22,7 @@
         density="compact"
       />
       <v-btn
-        prepend-icon="mdi-content-save"
-        color="success"
-        variant="flat"
-        class="ml-4"
-        @click="saveReportItem"
-      >
-        {{ $t('button.save') }}
-      </v-btn>
-      <v-btn
+        v-if="isSaved"
         prepend-icon="mdi-content-copy"
         color="primary"
         variant="flat"
@@ -38,6 +30,15 @@
         @click="cloneReportItem"
       >
         Clone
+      </v-btn>
+      <v-btn
+        prepend-icon="mdi-content-save"
+        color="success"
+        variant="flat"
+        class="ml-4"
+        @click="saveReportItem"
+      >
+        {{ $t('button.save') }}
       </v-btn>
       <v-btn
         v-if="report_item.news_item_aggregates.length"
@@ -170,7 +171,7 @@ export default {
     const router = useRouter()
     const store = useAnalyzeStore()
     const form = ref(null)
-
+    const isSaved = ref(false)
     const verticalView = ref(useUserStore().split_view)
     const expand_panel_groups = ref([])
     const report_item = ref(props.reportItemProp)
@@ -218,6 +219,9 @@ export default {
       } else {
         createReportItem(report_item.value)
           .then((response) => {
+            if (response && response.data && response.data.id) {
+              isSaved.value = true
+            }
             router.push('/report/' + response.data.id)
             emit('reportcreated', response.data.id)
             notifySuccess(`Report with ID ${response.data.id} created`)
@@ -260,6 +264,10 @@ export default {
     }
 
     const cloneReportItem = async () => {
+      if (!report_item.value.title || report_item.value.title.trim() === '') {
+        notifyFailure('Cannot clone the item: Title is required.')
+        return // Exit the function if the title is not provided
+      }
       try {
         console.log(
           'Attempting to clone report item with state:',
@@ -306,6 +314,7 @@ export default {
       report_item_types,
       report_type,
       container_title,
+      isSaved,
       saveReportItem,
       removeAllFromReport,
       removeFromReport,

--- a/src/gui/src/components/analyze/ReportItem.vue
+++ b/src/gui/src/components/analyze/ReportItem.vue
@@ -31,6 +31,15 @@
         {{ $t('button.save') }}
       </v-btn>
       <v-btn
+        prepend-icon="mdi-content-copy"
+        color="primary"
+        variant="flat"
+        class="ml-4"
+        @click="cloneReportItem"
+      >
+        Clone
+      </v-btn>
+      <v-btn
         v-if="report_item.news_item_aggregates.length"
         prepend-icon="mdi-delete-outline"
         color="error"
@@ -250,6 +259,44 @@ export default {
         })
     }
 
+    const cloneReportItem = async () => {
+      try {
+        console.log(
+          'Attempting to clone report item with state:',
+          report_item.value
+        )
+        // Prepare the data for cloning excluding fields we don't want duplicated
+        const cloneData = { ...report_item.value }
+        delete cloneData.id
+        delete cloneData.attributes
+        delete cloneData.created
+        delete cloneData.last_updated
+        delete cloneData.user_id
+        cloneData.uuid = null
+
+        console.log('Clone data before sending to backend:', cloneData)
+
+        const response = await createReportItem(cloneData)
+        notifySuccess(t('Clone created with ID:') + ` ${response.data.id}`)
+
+        const clonedItemId = response.data.id // Retrieve ID of the newly created item
+
+        // Prepare the update data with attributes
+        const updateData = {
+          attributes: report_item.value.attributes
+        }
+
+        // Update the newly created report item to include attributes
+        await updateReportItem(clonedItemId, updateData)
+        notifySuccess(`Attributes added to the clone with ID: ${clonedItemId}`)
+
+        router.push('/report/' + response.data.id)
+      } catch (error) {
+        console.error('Clone creation error:', error)
+        notifyFailure(t('Failed to clone report item'))
+      }
+    }
+
     return {
       verticalView,
       expand_panel_groups,
@@ -261,7 +308,8 @@ export default {
       container_title,
       saveReportItem,
       removeAllFromReport,
-      removeFromReport
+      removeFromReport,
+      cloneReportItem
     }
   }
 }


### PR DESCRIPTION
Fixes: #35 

This PR implements the "Clone report" functionality to the `ReportItem` component. allowing users to duplicate an existing report. 
The cloning process is split into two main steps: creating a new report item without attributes and then updating the new report item with the cloned attributes. 
This process avoids current limitations in the backend when copying report attributes.

### Implementation
- Added a new button `Clone report` next to the existing `Save` button. 
- **Cloning Logic**:  `cloneReportItem`  handles the cloning process in the following way:
  - Clones the current report's data, excluding fields like `id`, `attributes`, `created`, `last_updated`, and `user_id` which will get new values
  - Creates a new report item via `createReportItem` without attributes to avoid current backend constraints.
  - Once the report is successfully created, it is updated with the original report's attributes through `updateReportItem`. This step creates new attributes.

The reason for the extra step of updating the report is to workaround a potential backend bug that causes an error when attempting to clone the item attributes directly. (Error message: `Error adding report item: core.model.report_item.ReportItemAttribute() argument after ** must be a mapping, not str.`).  

Note:
This is not the preffered method for cloning the report items but makes the functionality availible untill the backend issue is resolved.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Added functionality to clone report items, enabling users to duplicate items with modified attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->