### PR TITLE
Mock web_collector_url

### DIFF
--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -42,10 +42,10 @@ def news_item_upload_mock(requests_mock):
 
 @pytest.fixture
 def web_collector_url_mock(requests_mock):
-    from worker.tests.testdata import head_request
+    from worker.tests.testdata import web_collector_url, head_request
 
-    requests_mock.head("https://raw.example.com/testweb.html", json=head_request)
-    requests_mock.get("https://raw.example.com/testweb.html", text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
+    requests_mock.head(web_collector_url, json=head_request)
+    requests_mock.get(web_collector_url, text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
 
 
 @pytest.fixture

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -41,13 +41,21 @@ def news_item_upload_mock(requests_mock):
 
 
 @pytest.fixture
+def web_collector_url_mock(requests_mock):
+    from worker.tests.testdata import head_request
+
+    requests_mock.head("https://raw.example.com/testweb.html", json=head_request)
+    requests_mock.get("https://raw.example.com/testweb.html", text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
+
+
+@pytest.fixture
 def collectors_mock(osint_source_update_mock, news_item_upload_mock):
     pass
 
 
 @pytest.fixture
 def rss_collector_mock(requests_mock, collectors_mock):
-    from testdata import rss_collector_url, rss_collector_fav_icon_url, rss_collector_targets
+    from worker.tests.testdata import rss_collector_url, rss_collector_fav_icon_url, rss_collector_targets
 
     requests_mock.get(rss_collector_targets[0], json={})
     requests_mock.get(rss_collector_targets[1], json={})
@@ -57,12 +65,10 @@ def rss_collector_mock(requests_mock, collectors_mock):
 
 
 @pytest.fixture
-def simple_web_collector_mock(requests_mock, collectors_mock):
-    from testdata import web_collector_url, web_collector_fav_icon_url
+def simple_web_collector_mock(requests_mock, collectors_mock, web_collector_url_mock):
+    from worker.tests.testdata import web_collector_fav_icon_url
 
-    requests_mock.head(web_collector_url, json={})
     requests_mock.get(web_collector_fav_icon_url, json={})
-    requests_mock.get(web_collector_url, text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
 
 
 @pytest.fixture

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -1,10 +1,10 @@
 import pytest
 
-from testdata import news_items
+from worker.tests.testdata import news_items
 
 
 def test_rss_collector(rss_collector_mock, rss_collector):
-    from testdata import rss_collector_source_data
+    from worker.tests.testdata import rss_collector_source_data
 
     result = rss_collector.collect(rss_collector_source_data)
 
@@ -12,7 +12,7 @@ def test_rss_collector(rss_collector_mock, rss_collector):
 
 
 def test_rss_collector_digest_splitting(rss_collector_mock, rss_collector):
-    from testdata import rss_collector_source_data
+    from worker.tests.testdata import rss_collector_source_data
 
     rss_collector_source_data["parameters"]["DIGEST_SPLITTING"] = "true"
     rss_collector_source_data["parameters"]["DIGEST_SPLITTING_LIMIT"] = 2
@@ -22,7 +22,7 @@ def test_rss_collector_digest_splitting(rss_collector_mock, rss_collector):
 
 
 def test_simple_web_collector_basic(simple_web_collector_mock, simple_web_collector):
-    from testdata import web_collector_source_data
+    from worker.tests.testdata import web_collector_source_data
 
     result = simple_web_collector.collect(web_collector_source_data)
 
@@ -30,7 +30,7 @@ def test_simple_web_collector_basic(simple_web_collector_mock, simple_web_collec
 
 
 def test_simple_web_collector_xpath(simple_web_collector_mock, simple_web_collector):
-    from testdata import web_collector_source_data, web_collector_source_xpath
+    from worker.tests.testdata import web_collector_source_data, web_collector_source_xpath
 
     web_collector_source_data["parameters"]["XPATH"] = web_collector_source_xpath
     result = simple_web_collector.collect(web_collector_source_data)
@@ -56,8 +56,8 @@ def test_rt_collector_ticket_transaction(rt_mock, rt_collector):
     assert result == "1"
 
 
-def test_simple_web_collector_collect(simple_web_collector):
-    from testdata import web_collector_url, web_collector_result_title, web_collector_result_content
+def test_simple_web_collector_collect(simple_web_collector_mock, simple_web_collector):
+    from worker.tests.testdata import web_collector_url, web_collector_result_title, web_collector_result_content
 
     result_item = simple_web_collector.news_item_from_article(web_collector_url, "test_source")
 
@@ -68,7 +68,7 @@ def test_simple_web_collector_collect(simple_web_collector):
 
 @pytest.mark.parametrize("input_news_items", [news_items, news_items[2:], news_items[:: len(news_items) - 1], [news_items[-1]]])
 def test_filter_by_word_list_empty_wordlist(rss_collector, input_news_items):
-    from testdata import source_empty_wordlist
+    from worker.tests.testdata import source_empty_wordlist
 
     emptylist_results = rss_collector.filter_by_word_list(input_news_items, source_empty_wordlist)
 
@@ -80,7 +80,7 @@ def test_filter_by_word_list_empty_wordlist(rss_collector, input_news_items):
     [(news_items, news_items[:2]), (news_items[2:], []), (news_items[:: len(news_items) - 1], [news_items[0]]), ([news_items[-1]], [])],
 )
 def test_filter_by_word_list_include_list(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_include_list
+    from worker.tests.testdata import source_include_list
 
     include_list_results = rss_collector.filter_by_word_list(input_news_items, source_include_list)
 
@@ -97,7 +97,7 @@ def test_filter_by_word_list_include_list(rss_collector, input_news_items, expec
     ],
 )
 def test_filter_by_word_list_exclude_list(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_exclude_list
+    from worker.tests.testdata import source_exclude_list
 
     exclude_list_results = rss_collector.filter_by_word_list(input_news_items, source_exclude_list)
 
@@ -109,7 +109,7 @@ def test_filter_by_word_list_exclude_list(rss_collector, input_news_items, expec
     [(news_items, news_items[:2]), (news_items[2:], []), (news_items[:: len(news_items) - 1], [news_items[0]]), ([news_items[-1]], [])],
 )
 def test_filter_by_word_list_include_multiple_list(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_include_multiple_list
+    from worker.tests.testdata import source_include_multiple_list
 
     include_list_results = rss_collector.filter_by_word_list(input_news_items, source_include_multiple_list)
 
@@ -126,7 +126,7 @@ def test_filter_by_word_list_include_multiple_list(rss_collector, input_news_ite
     ],
 )
 def test_filter_by_word_list_exclude_multiple_list(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_exclude_multiple_list
+    from worker.tests.testdata import source_exclude_multiple_list
 
     exclude_list_results = rss_collector.filter_by_word_list(input_news_items, source_exclude_multiple_list)
 
@@ -138,7 +138,7 @@ def test_filter_by_word_list_exclude_multiple_list(rss_collector, input_news_ite
     [(news_items, [news_items[0]]), (news_items[2:], []), (news_items[:: len(news_items) - 1], [news_items[0]]), ([news_items[-1]], [])],
 )
 def test_filter_by_word_list_include_exclude_list(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_include_list_exclude_list
+    from worker.tests.testdata import source_include_list_exclude_list
 
     include_exclude_list_results = rss_collector.filter_by_word_list(input_news_items, source_include_list_exclude_list)
 
@@ -150,7 +150,7 @@ def test_filter_by_word_list_include_exclude_list(rss_collector, input_news_item
     [(news_items, [news_items[0]]), (news_items[2:], []), (news_items[:: len(news_items) - 1], [news_items[0]]), ([news_items[-1]], [])],
 )
 def test_filter_by_word_list_include_exclude_multiple_lists(rss_collector, input_news_items, expected_news_items):
-    from testdata import source_include_multiple_list_exclude_multiple_list
+    from worker.tests.testdata import source_include_multiple_list_exclude_multiple_list
 
     include_exclude_list_results = rss_collector.filter_by_word_list(input_news_items, source_include_multiple_list_exclude_multiple_list)
 

--- a/src/worker/worker/tests/testdata.py
+++ b/src/worker/worker/tests/testdata.py
@@ -411,10 +411,10 @@ source_exclude_multiple_list = {
     "parameters": {"FEED_URL": ""},
 }
 
-web_collector_url = "https://raw.githubusercontent.com/taranis-ai/taranis-ai/master/src/worker/worker/tests/collectors/testweb.html"
+web_collector_url = "https://raw.example.com/testweb.html"
 web_collector_result_content = "In an era where digital security is paramount, the role of National Computer Emergency Response Teams (CERTs) has never been more critical."
-web_collector_fav_icon_url = "https://raw.githubusercontent.com/favicon.ico"
-web_collector_source_data = {"id": 1, "parameters": {"WEB_URL": f"{web_collector_url}"}}
+web_collector_fav_icon_url = "https://raw.example.com/favicon.ico"
+web_collector_source_data = {"id": 1, "parameters": {"WEB_URL": "https://raw.example.com/testweb.html"}}
 web_collector_source_xpath = "/html/body/div/div[3]"
 web_collector_result_title = "National CERT Importance"
 
@@ -426,3 +426,29 @@ rss_collector_targets = [
     "https://greentechnews.org/blog/2024/2/green-tech-energy-sector",
     "https://space-eu.org/blog/2024/3/european-space-exploration",
 ]
+
+head_request = {
+    "Connection": "keep-alive",
+    "Content-Length": "1111",
+    "Server": "example.com",
+    "Content-Type": "text/html; charset=utf-8",
+    "Last-Modified": "Mon, 1 Jan 2000 12:00:00 GMT",
+    "Access-Control-Allow-Origin": "*",
+    "Strict-Transport-Security": "max-age=11111111",
+    "ETag": 'W/"11111111-1111"',
+    "expires": "Mon, 1 Jan 2000 12:00:00 GMT",
+    "Cache-Control": "max-age=111",
+    "Content-Encoding": "gzip",
+    "x-proxy-cache": "MISS",
+    "X-Example-Request-Id": "1111:111111:1111111:1111111:11111111",
+    "Accept-Ranges": "bytes",
+    "Date": "Mon, 1 Jan 2000 00:00:00 GMT",
+    "Via": "1.1 varnish",
+    "Age": "1",
+    "X-Served-By": "cache-vie1111-VIE",
+    "X-Cache": "HIT",
+    "X-Cache-Hits": "1",
+    "X-Timer": "S1111111111.111111,VS0,VE2",
+    "Vary": "Accept-Encoding",
+    "X-Fastly-Request-ID": "aa11111111111111111111111111111111111111",
+}


### PR DESCRIPTION
 `web_collector_url` in `testdata.py` is kept because of justified usage in `test_simple_web_collector_collect()`

- [x] mock `web_collector_url` now separately
- [x] add content to `requests.head()` mock
- [x] improve imports
- [x] Use example address instead of Github URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced testing environment with new fixtures and HTTP request mocks for more robust testing of web and RSS collectors.
	- Reorganized import paths to align with updated module structures in test files.
- **Bug Fixes**
	- Updated URLs and domains in test data to ensure accuracy and relevance in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->