### PR TITLE
Add release GH Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get tag name
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: |
+          git tag -n 3 -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  # TODO: remove
+  pull_request:
 
 jobs:
   release:
@@ -25,14 +27,22 @@ jobs:
         run: |
           cat ${{ runner.temp }}/env.sample
 
+      - name: Get tag message
+        id: get_tag_message
+        run: |
+          git tag -n 3 -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
+          TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${{ env.tag }}")
+          echo "tag_message=$TAG_MESSAGE" >> $GITHUB_ENV
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          tag_name: ${{ env.tag }}
-          release_name: ${{ env.tag }}
-          body: ${{ github.event.head_commit.message }}
-          files: |
-            docker/compose.yml
-            ${{ runner.temp }}/env.sample
+    #   - name: Release
+    #    uses: softprops/action-gh-release@v2
+    #    if: startsWith(github.ref, 'refs/tags/')
+    #    with:
+    #      tag_name: ${{ env.tag }}
+    #      release_name: ${{ env.tag }}
+    #      body: ${{ env.tag_message }}
+    #     generate_release_notes: true
+    #    appendBody: true
+    #   files: |
+    #    docker/compose.yml
+    #   ${{ runner.temp }}/env.sample

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,23 +3,18 @@ name: Release on pushed tags
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+''
-  # TODO: remove
-  pull_request:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:
     runs-on: ubuntu-22.04
-    # TODO: remove
-    env:
-      tag: test.0.9.2
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      # TODO: uncomment
-      # - name: Get tag name
-      #   run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Get tag name
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |
@@ -31,15 +26,13 @@ jobs:
           cat ${{ runner.temp }}/env.sample
 
 
-      # - name: Release
-      #   uses: softprops/action-gh-release@v2
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   with:
-      #     tag_name: ${{ env.tag }}
-      #     release_name: ${{ env.tag }}
-      #     body: ${{ github.event.head_commit.message }}
-      #     files: |
-      #       docker/compose.yml
-      #       ${{ runner.temp }}/env.sample
-      #       ${{ runner.temp }}/${{ env.tag }}.zip
-      #       ${{ runner.temp }}/${{ env.tag }}.tar.gz
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          tag_name: ${{ env.tag }}
+          release_name: ${{ env.tag }}
+          body: ${{ github.event.head_commit.message }}
+          files: |
+            docker/compose.yml
+            ${{ runner.temp }}/env.sample

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,31 +4,29 @@ on:
   push:
     tags:
       - '*'
-
+  # TODO: remove
   pull_request:
-    branches:
-      - master
 
 jobs:
   release:
     runs-on: ubuntu-22.04
+    # TODO: remove
     env:
       tag: test.0.9.2
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+      # TODO: uncomment
       # - name: Get tag name
       #   run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |
-          sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' docker/env.sample
-          cat docker/env.sample
-          # cp docker/env.sample ${{ runner.temp }}
+          cp docker/env.sample ${{ runner.temp }}
+          sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' ${{ runner.temp }}/env.sample
       
-      - name: Compress action step
+      - name: Create tar.gz of repository
         uses: a7ul/tar-action@v1.2.0
         id: compress
         with:
@@ -37,14 +35,13 @@ jobs:
           outPath: ${{ runner.temp }}/${{ env.tag }}.tar.gz
 
       - name: Create zip of repository
-        run: |
-          zip -r "${{ runner.temp }}/${{ env.tag }}.zip" .
+        run: zip -r "${{ runner.temp }}/${{ env.tag }}.zip" .
 
 
       - name: Verify changes
         run: |
           echo "Tag: ${{ env.tag }}"
-          cat docker/env.sample
+          cat ${{ runner.temp }}/env.sample
           ls -l "${{ runner.temp }}/${{ env.tag }}.zip"
           ls -l "${{ runner.temp }}/${{ env.tag }}.tar.gz"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release on pushed tags
 on:
   push:
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+''
   # TODO: remove
   pull_request:
 
@@ -25,24 +25,11 @@ jobs:
         run: |
           cp docker/env.sample ${{ runner.temp }}
           sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' ${{ runner.temp }}/env.sample
-      
-      - name: Create tar.gz of repository
-        uses: a7ul/tar-action@v1.2.0
-        id: compress
-        with:
-          command: c
-          files: .
-          outPath: ${{ runner.temp }}/${{ env.tag }}.tar.gz
 
-      - name: Create zip of repository
-        run: zip -r ${{ runner.temp }}/${{ env.tag }}.zip .
-
-
-      - name: Verify new assets
+      - name: Verify new env.sample
         run: |
           cat ${{ runner.temp }}/env.sample
-          ls -l ${{ runner.temp }}/${{ env.tag }}.zip
-          ls -l ${{ runner.temp }}/${{ env.tag }}.tar.gz
+
 
       # - name: Release
       #   uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get tag name
         run: |
-          git tag -n 3 -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
+          git tag -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
@@ -32,7 +32,6 @@ jobs:
       - name: Get tag message
         id: get_tag_message
         run: |
-          git tag -n 3 -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
           TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${{ env.tag }}")
           echo "tag_message=$TAG_MESSAGE" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
-          git tag -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
+          git tag -a 2.1.0 -m "xyz feature is released in this tag." -m "Signed-off-by: xyz" -m "Some text" -m "Some more text"
           echo "tag_message=$(git tag -n3 --format='%(contents)' 2.1.0)" >> $GITHUB_ENV
           
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,13 +14,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Get tag name
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |
           cp docker/env.sample ${{ runner.temp }}
-          sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' ${{ runner.temp }}/env.sample
+          sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.TAG }}/' ${{ runner.temp }}/env.sample
 
       - name: Verify new env.sample
         run: |
@@ -37,7 +38,7 @@ jobs:
         run: echo ${{ env.TAG_MESSAGE }}
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.0.6
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,31 +10,43 @@ on:
       - master
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-22.04
+    env:
+      tag: test.0.9.2
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       
-      - name: Get tag name
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      # - name: Get tag name
+      #   run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |
           sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' docker/env.sample
+          cat docker/env.sample
+          # cp docker/env.sample ${{ runner.temp }}
+      
+      - name: Compress action step
+        uses: a7ul/tar-action@v1.2.0
+        id: compress
+        with:
+          command: c
+          files: .
+          outPath: ${{ runner.temp }}/${{ env.tag }}.tar.gz
 
       - name: Create zip of repository
-        run: zip -r "${{ env.tag }}.zip" .
+        run: |
+          zip -r "${{ runner.temp }}/${{ env.tag }}.zip" .
 
-      - name: Create tar.gz of repository
-        run: tar -czvf "${{ env.tag }}.tar.gz" .
 
       - name: Verify changes
         run: |
           echo "Tag: ${{ env.tag }}"
           cat docker/env.sample
-          ls -l "${{ env.tag }}.zip"
-          ls -l "${{ env.tag }}.tar.gz"
+          ls -l "${{ runner.temp }}/${{ env.tag }}.zip"
+          ls -l "${{ runner.temp }}/${{ env.tag }}.tar.gz"
 
       # - name: Release
       #   uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,27 +4,18 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  # TODO: remove
-  pull_request:
 
 jobs:
   release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Get tag name
-        run: |
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-          git tag -a 2.1.0 -m 'xyz feature is released in this tag.
-          > My favourite text
-          > Some text 
-          > Some more text'
-          echo "tag_message=$(git tag -n3 --format='%(contents)' 2.1.0)" >> $GITHUB_ENV
-          
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Update env.sample
         run: |
@@ -36,20 +27,22 @@ jobs:
           cat ${{ runner.temp }}/env.sample
 
       - name: Get tag message
-        id: get_tag_message
         run: |
-          TAG_MESSAGE=$(git for-each-ref --format='%(contents)' "refs/tags/${{ env.tag }}")
-          echo "tag_message=$TAG_MESSAGE" >> $GITHUB_ENV
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          echo "TAG_MESSAGE<<EOF" >> $GITHUB_ENV
+          echo "$(git tag -l --format='%(contents)' ${GITHUB_REF#refs/*/})" >> $GITHUB_ENV   
+          echo "EOF" >> $GITHUB_ENV       
 
-    #   - name: Release
-    #    uses: softprops/action-gh-release@v2
-    #    if: startsWith(github.ref, 'refs/tags/')
-    #    with:
-    #      tag_name: ${{ env.tag }}
-    #      release_name: ${{ env.tag }}
-    #      body: ${{ env.tag_message }}
-    #     generate_release_notes: true
-    #    appendBody: true
-    #   files: |
-    #    docker/compose.yml
-    #   ${{ runner.temp }}/env.sample
+      - name: Verify tag message
+        run: echo ${{ env.TAG_MESSAGE }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          append_body: true
+          body: ${{ env.TAG_MESSAGE }}
+          files: |
+            docker/compose.yml
+            ${{ runner.temp }}/env.sample

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,9 +20,9 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           git tag -a 2.1.0 -m 'xyz feature is released in this tag.
-          Signed-off-by: xyz 
-          Some text 
-          Some more text'
+          > My favourite text
+          > Some text 
+          > Some more text'
           echo "tag_message=$(git tag -n3 --format='%(contents)' 2.1.0)" >> $GITHUB_ENV
           
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,10 @@ jobs:
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
-          git tag -a 2.1.0 -m "xyz feature is released in this tag." -m "Signed-off-by: xyz" -m "Some text" -m "Some more text"
+          git tag -a 2.1.0 -m 'xyz feature is released in this tag.
+          Signed-off-by: xyz 
+          Some text 
+          Some more text'
           echo "tag_message=$(git tag -n3 --format='%(contents)' 2.1.0)" >> $GITHUB_ENV
           
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: Release on pushed tags
+
+on:
+  push:
+    tags:
+      - '*'
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Get tag name
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Update env.sample
+        run: |
+          sed -i 's/^TARANIS_TAG=.*/TARANIS_TAG=${{ env.tag }}/' docker/env.sample
+
+      - name: Create zip of repository
+        run: zip -r "${{ env.tag }}.zip" .
+
+      - name: Create tar.gz of repository
+        run: tar -czvf "${{ env.tag }}.tar.gz" .
+
+      - name: Verify changes
+        run: |
+          echo "Tag: ${{ env.tag }}"
+          cat docker/env.sample
+          ls -l "${{ env.tag }}.zip"
+          ls -l "${{ env.tag }}.tar.gz"
+
+      # - name: Release
+      #   uses: softprops/action-gh-release@v2
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   with:
+      #     tag_name: ${{ env.tag }}
+      #     release_name: ${{ env.tag }}
+      #     body: ${{ github.event.head_commit.message }}
+      #     files: |
+      #       dokcer/env.sample
+      #       docker/compose.yml
+      #       "${{ env.tag }}.zip"
+      #       "${{ env.tag }}.tar.gz"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,15 +35,14 @@ jobs:
           outPath: ${{ runner.temp }}/${{ env.tag }}.tar.gz
 
       - name: Create zip of repository
-        run: zip -r "${{ runner.temp }}/${{ env.tag }}.zip" .
+        run: zip -r ${{ runner.temp }}/${{ env.tag }}.zip .
 
 
-      - name: Verify changes
+      - name: Verify new assets
         run: |
-          echo "Tag: ${{ env.tag }}"
           cat ${{ runner.temp }}/env.sample
-          ls -l "${{ runner.temp }}/${{ env.tag }}.zip"
-          ls -l "${{ runner.temp }}/${{ env.tag }}.tar.gz"
+          ls -l ${{ runner.temp }}/${{ env.tag }}.zip
+          ls -l ${{ runner.temp }}/${{ env.tag }}.tar.gz
 
       # - name: Release
       #   uses: softprops/action-gh-release@v2
@@ -53,7 +52,7 @@ jobs:
       #     release_name: ${{ env.tag }}
       #     body: ${{ github.event.head_commit.message }}
       #     files: |
-      #       dokcer/env.sample
       #       docker/compose.yml
-      #       "${{ env.tag }}.zip"
-      #       "${{ env.tag }}.tar.gz"
+      #       ${{ runner.temp }}/env.sample
+      #       ${{ runner.temp }}/${{ env.tag }}.zip
+      #       ${{ runner.temp }}/${{ env.tag }}.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Get tag name
         run: |
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
           git tag -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
           echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,8 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           git tag -a 2.1.0 -m "xyz feature is released in this tag.\n\nSigned-off-by: xyz \n Some text"
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "tag_message=$(git tag -n3 --format='%(contents)' 2.1.0)" >> $GITHUB_ENV
+          
 
       - name: Update env.sample
         run: |


### PR DESCRIPTION
This workflow created this release https://github.com/not4Pedro/taranis-test-release/releases/tag/0.0.3
It prepends the multiline tag_message to a full change log.
If no tag message is provided, it falls back to the last commit message (by design).
The release name is implicitly taken from the pushed tag.


