### PR TITLE
Fix error handling in the Simple Web Collector and other

### DIFF
--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -4,7 +4,7 @@ import hashlib
 import requests
 import lxml.html
 import dateutil.parser as dateparser
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 from trafilatura import extract, extract_metadata
 from bs4 import BeautifulSoup
 
@@ -69,12 +69,16 @@ class BaseWebCollector(BaseCollector):
 
     def xpath_extraction(self, html_content, xpath: str, get_content: bool = True) -> str | None:
         document = lxml.html.fromstring(html_content)
+        xpath_check = document.xpath(xpath)
+        logger.debug(f"Checking result for XPATH {xpath}: {xpath_check}")
         if not document.xpath(xpath):
             logger.error(f"No content found for XPath: {xpath}")
             return None
         first_element = document.xpath(xpath)[0]
         if get_content:
             return first_element.text_content()
+
+        # logger.debug(f"Content found with XPATH: {lxml.html.tostring(first_element).decode()}")
 
         return lxml.html.tostring(first_element).decode()
 
@@ -140,7 +144,8 @@ class BaseWebCollector(BaseCollector):
 
     def get_urls(self, html_content: str) -> list:
         soup = BeautifulSoup(html_content, "html.parser")
-        return [a["href"] for a in soup.find_all("a", href=True)]
+        a = [a['href'] for a in soup.find_all("a", href=True)]
+        return [self.check_relative_url(url) for url in a]
     
     def check_relative_url(self, url: str):
         if not url.startswith("/"):
@@ -148,15 +153,14 @@ class BaseWebCollector(BaseCollector):
         parsed_url = urlparse(self.web_url)
         base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
         logger.warning(f"Relative URL found: {url}, manually trying to prepend the base URL ({base_url}). This may not work.")
-        return base_url + url
+        return urljoin(base_url, url)
 
     def parse_digests(self) -> list[NewsItem] | str:
         news_items = []
         max_elements = min(len(self.split_digest_urls), self.digest_splitting_limit)
         for split_digest_url in self.split_digest_urls[:max_elements]:
-            absolute_url = self.check_relative_url(split_digest_url)
             try:
-                news_items.append(self.news_item_from_article(absolute_url))
+                news_items.append(self.news_item_from_article(split_digest_url))
             except ValueError as e:
                 logger.warning(f"{self.type}: {self.osint_source_id} failed to parse the digest with error: {str(e)}")
                 continue

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -69,16 +69,13 @@ class BaseWebCollector(BaseCollector):
 
     def xpath_extraction(self, html_content, xpath: str, get_content: bool = True) -> str | None:
         document = lxml.html.fromstring(html_content)
-        xpath_check = document.xpath(xpath)
-        logger.debug(f"Checking result for XPATH {xpath}: {xpath_check}")
+        logger.debug(f"Checking result for XPATH {xpath}: {document.xpath(xpath)}")
         if not document.xpath(xpath):
             logger.error(f"No content found for XPath: {xpath}")
             return None
         first_element = document.xpath(xpath)[0]
         if get_content:
             return first_element.text_content()
-
-        # logger.debug(f"Content found with XPATH: {lxml.html.tostring(first_element).decode()}")
 
         return lxml.html.tostring(first_element).decode()
 
@@ -144,16 +141,9 @@ class BaseWebCollector(BaseCollector):
 
     def get_urls(self, html_content: str) -> list:
         soup = BeautifulSoup(html_content, "html.parser")
-        a = [a['href'] for a in soup.find_all("a", href=True)]
-        return [self.check_relative_url(url) for url in a]
-    
-    def check_relative_url(self, url: str):
-        if not url.startswith("/"):
-            return url
-        parsed_url = urlparse(self.web_url)
-        base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        logger.warning(f"Relative URL found: {url}, manually trying to prepend the base URL ({base_url}). This may not work.")
-        return urljoin(base_url, url)
+        urls = [a['href'] for a in soup.find_all("a", href=True)]
+        return [urljoin(self.web_url, url) for url in urls]
+
 
     def parse_digests(self) -> list[NewsItem] | str:
         news_items = []

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -216,7 +216,7 @@ class RSSCollector(BaseWebCollector):
 
         logger.info(f"RSS-Feed {source['id']} returned feed with {len(feed['entries'])} entries")
 
-        news_items = self.get_news_items(feed, source)
+        self.news_items = self.get_news_items(feed, source)
 
-        self.publish(news_items, source)
+        self.publish(self.news_items, source)
         return None

--- a/src/worker/worker/collectors/simple_web_collector.py
+++ b/src/worker/worker/collectors/simple_web_collector.py
@@ -44,8 +44,8 @@ class SimpleWebCollector(BaseWebCollector):
 
     def preview_collector(self, source):
         self.parse_source(source)
-        news_items = self.gather_news_items(source)
-        return self.preview(news_items, source)
+        self.news_items = self.gather_news_items(source)
+        return self.preview(self.news_items, source)
 
     def handle_digests(self) -> list[NewsItem] | str:
         if not self.xpath:
@@ -82,24 +82,9 @@ class SimpleWebCollector(BaseWebCollector):
             return "Last-Modified < Last-Attempted"
 
         try:
-            news_items = self.gather_news_items(source)
+            self.news_items = self.gather_news_items(source)
         except ValueError as e:
             logger.error(f"Simple Web Collector for {self.web_url} failed with error: {str(e)}")
 
-        self.publish(news_items, source)
+        self.publish(self.news_items, source)
         return None
-
-if __name__ == "__main__":
-    collector = SimpleWebCollector()
-    # collector.collect({"id": "test", "parameters": {
-    #     "WEB_URL": "https://en.interfax.com.ua/news/latest.html",
-    #     "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-    #     "XPATH": "//div[@class='articles-section-view']",
-    #     "DIGEST_SPLITTING": "true"
-    #     }})
-    collector.collect({"id": "test", "parameters": {
-    "WEB_URL": "https://rubryka.com/en",
-    # "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-    "XPATH": "/html/body/main/section[1]/div/div[1]/div[2]/div[2]",
-    "DIGEST_SPLITTING": "true"
-    }})

--- a/src/worker/worker/collectors/simple_web_collector.py
+++ b/src/worker/worker/collectors/simple_web_collector.py
@@ -88,3 +88,18 @@ class SimpleWebCollector(BaseWebCollector):
 
         self.publish(news_items, source)
         return None
+
+if __name__ == "__main__":
+    collector = SimpleWebCollector()
+    # collector.collect({"id": "test", "parameters": {
+    #     "WEB_URL": "https://en.interfax.com.ua/news/latest.html",
+    #     "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+    #     "XPATH": "//div[@class='articles-section-view']",
+    #     "DIGEST_SPLITTING": "true"
+    #     }})
+    collector.collect({"id": "test", "parameters": {
+    "WEB_URL": "https://rubryka.com/en",
+    # "USER_AGENT": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+    "XPATH": "/html/body/main/section[1]/div/div[1]/div[2]/div[2]",
+    "DIGEST_SPLITTING": "true"
+    }})

--- a/src/worker/worker/collectors/simple_web_collector.py
+++ b/src/worker/worker/collectors/simple_web_collector.py
@@ -52,15 +52,16 @@ class SimpleWebCollector(BaseWebCollector):
             raise ValueError("No XPATH set for digest splitting")
 
         web_content, _ = self.web_content_from_article(self.web_url)
-        content = self.xpath_extraction(web_content, self.xpath, False)
-        logger.debug(content)
-        self.split_digest_urls = self.get_urls(content)
-        logger.info(f"RSS-Feed {self.osint_source_id} returned {len(self.split_digest_urls)} available URLs")
+        if content := self.xpath_extraction(web_content, self.xpath, False):
+            self.split_digest_urls = self.get_urls(content)
+            logger.info(f"Digest splitting {self.osint_source_id} returned {len(self.split_digest_urls)} available URLs")
 
-        return self.parse_digests()
+            return self.parse_digests()
+        
+        return []
 
     def gather_news_items(self, source) -> list[NewsItem]:
-        digest_splitting = source["parameters"].get("DIGEST_SPLITTING", False)
+        digest_splitting = source["parameters"].get("DIGEST_SPLITTING", "false")
         if digest_splitting == "true":
             return self.handle_digests()
         return [self.news_item_from_article(self.web_url, self.xpath)]

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -47,10 +47,11 @@ def news_item_upload_mock(requests_mock):
 
 @pytest.fixture
 def web_collector_url_mock(requests_mock):
-    from worker.tests.testdata import web_collector_url, head_request
+    from worker.tests.testdata import web_collector_url, web_collector_ref_url, head_request
 
     requests_mock.head(web_collector_url, json=head_request)
     requests_mock.get(web_collector_url, text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
+    requests_mock.get(web_collector_ref_url, text=file_loader("testweb.html"), headers={"Content-Type": "text/html"})
 
 
 @pytest.fixture

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -65,6 +65,16 @@ def test_simple_web_collector_collect(simple_web_collector_mock, simple_web_coll
     # assert result_item.author == "John Doe"
     assert result_item.content.startswith(web_collector_result_content)
 
+def test_simple_web_collector_digest_splitting(simple_web_collector_mock, simple_web_collector):
+    from worker.tests.testdata import web_collector_source_data
+
+    web_collector_source_data["parameters"]["XPATH"] = "//*"
+    web_collector_source_data["parameters"]["DIGEST_SPLITTING"] = "true"
+    web_collector_source_data["parameters"]["DIGEST_SPLITTING_LIMIT"] = 2
+    result = simple_web_collector.collect(web_collector_source_data)
+
+    assert result is None
+
 
 @pytest.mark.parametrize("input_news_items", [news_items, news_items[2:], news_items[:: len(news_items) - 1], [news_items[-1]]])
 def test_filter_by_word_list_empty_wordlist(rss_collector, input_news_items):

--- a/src/worker/worker/tests/collectors/testweb.html
+++ b/src/worker/worker/tests/collectors/testweb.html
@@ -25,6 +25,9 @@
 
         <p>Today, the existence of a national CERT is not just a matter of technical necessity but a cornerstone of national security. Recognizing their indispensable role, governments worldwide continue to invest in these teams, ensuring they have the tools, skills, and resources needed to combat the ever-growing array of cyber threats.</p>
     </div>
+    <div style="text-align: center;">
+        <a href="test/url/index.html">Click here to go to latest news.</a>
+    </div>
 </div>
 
 </body>

--- a/src/worker/worker/tests/testdata.py
+++ b/src/worker/worker/tests/testdata.py
@@ -286,6 +286,7 @@ exclude_multiple_list = [
 ]
 
 web_collector_url = "https://raw.example.com/testweb.html"
+web_collector_ref_url = "https://raw.example.com/test/url/index.html"
 web_collector_result_content = "In an era where digital security is paramount, the role of National Computer Emergency Response Teams (CERTs) has never been more critical."
 web_collector_fav_icon_url = "https://raw.example.com/favicon.ico"
 web_collector_source_data = {"id": 1, "parameters": {"WEB_URL": "https://raw.example.com/testweb.html"}}


### PR DESCRIPTION
Bug: The digest splitting was initially designed for RSS collector, therefore, the relative URLs scraped by Simple Web Collector were handled incorrectly.
Bug2: the RSS and Simple WC don't use class variable `news_items`.


Solution: Simple Web Collector, RT Collector and RSS Collector now create the subsequent URLs correctly.

- **Bug Fixes**
  - Improved RSS collector to handle news items more efficiently and publish them correctly.
  - Enhanced web collector to process digests only when content is available, returning an empty list if no content exists.

- **Tests**
  - Updated test fixtures to include new URLs for web collector tests.
  - Added new test for the web collector's digest splitting functionality. 

- **Documentation**
  - Added a new example element in test HTML content to illustrate hyperlink usage.
