### PR TITLE
Update E2E to new analyze and publish buttons

### DIFF
--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -370,7 +370,7 @@ class TestEndToEndUser:
             expect(page).to_have_title("Taranis AI | Analyze")
 
         def report_1():
-            self.highlight_element(page.get_by_role("button", name="New Report")).click()
+            self.highlight_element(page.get_by_role("button", name="New Report").first).click()
             self.highlight_element(page.get_by_role("combobox")).click()
 
             expect(page.get_by_role("listbox")).to_contain_text("CERT Report")
@@ -489,7 +489,7 @@ class TestEndToEndUser:
         self.highlight_element(page.get_by_role("link", name="Publish").first).click()
         page.wait_for_url("**/publish", wait_until="domcontentloaded")
         expect(page).to_have_title("Taranis AI | Publish")
-        self.highlight_element(page.get_by_role("button", name="New Product")).click()
+        self.highlight_element(page.get_by_role("button", name="New Product").first).click()
         self.highlight_element(page.get_by_role("combobox").locator("div").filter(has_text="Product Type").locator("div")).click()
         self.highlight_element(page.get_by_role("option", name="Default TEXT Presenter")).click()
         self.highlight_element(page.get_by_label("Title")).click()


### PR DESCRIPTION
Update e2e tests for new analyze and publish buttons when empty (introduced in #267)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved end-to-end test reliability by refining element access methods in user tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->