### PR TITLE
Feature/frontend improvements

### DIFF
--- a/src/core/core/model/user.py
+++ b/src/core/core/model/user.py
@@ -44,7 +44,7 @@ class User(BaseModel):
             "compact_view": False,
             "show_charts": False,
             "infinite_scroll": True,
-            "end_of_shift": "18:00",
+            "end_of_shift": { "hours": 18, "minutes": 0 },
             "language": "en",
         }
 

--- a/src/gui/src/components/analyze/AttributeStory.vue
+++ b/src/gui/src/components/analyze/AttributeStory.vue
@@ -6,6 +6,7 @@
     :items="report_item_stories[reportItemId]"
     :multiple="multiple"
     closable-chips
+    chips
     center-affix
     clearable
     variant="outlined"

--- a/src/gui/src/components/analyze/ReportItem.vue
+++ b/src/gui/src/components/analyze/ReportItem.vue
@@ -171,6 +171,9 @@ export default {
     const { report_item_types, report_item_stories } = storeToRefs(store)
 
     const used_story_ids = computed(() => {
+      if (!report_item.value || !report_item.value.attributes) {
+        return []
+      }
       const report_item_attributes =
         'Data' in report_item.value.attributes
           ? Object.values(report_item.value.attributes.Data)

--- a/src/gui/src/components/common/HotKeysDialog.vue
+++ b/src/gui/src/components/common/HotKeysDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog v-model="hotkeyDialogVisible" max-width="600px">
-    <HotKeysLegend />
+    <HotKeysLegend :show-close-button="true" />
   </v-dialog>
 </template>
 

--- a/src/gui/src/i18n/en/messages.json
+++ b/src/gui/src/i18n/en/messages.json
@@ -214,7 +214,7 @@
         "acls": "ACL",
         "attributes": "Attributes",
         "bots": "Bots",
-        "dashboard": "Dashboard",
+        "dashboard": "Admin Dashboard",
         "openapi": "OpenAPI",
         "organizations": "Organizations",
         "osint_source_groups": "Source Groups",

--- a/src/gui/src/stores/UserStore.js
+++ b/src/gui/src/stores/UserStore.js
@@ -94,7 +94,7 @@ export const useUserStore = defineStore(
       show_charts.value = profile.show_charts
       dark_theme.value = profile.dark_theme
       language.value = profile.language
-      end_of_shift.value = profile.end_of_shift
+      end_of_shift.value = profile.end_of_shift || { hours: 18, minutes: 0 }
       infinite_scroll.value = profile.infinite_scroll
 
       i18n.global.locale.value = profile.language

--- a/src/gui/src/views/Home.vue
+++ b/src/gui/src/views/Home.vue
@@ -6,6 +6,7 @@
         class="mb-1"
         variant="tonal"
         selected-class="active-toggle"
+        mandatory
         @update:model-value="toggleScope"
       >
         <v-btn value="0">

--- a/src/gui/src/views/users/settings/HotKeysLegend.vue
+++ b/src/gui/src/views/users/settings/HotKeysLegend.vue
@@ -34,7 +34,7 @@ export default {
   props: {
     showCloseButton: {
       type: Boolean,
-      default: false // Default value if not passed
+      default: false
     }
   },
   setup() {

--- a/src/gui/src/views/users/settings/HotKeysLegend.vue
+++ b/src/gui/src/views/users/settings/HotKeysLegend.vue
@@ -1,8 +1,9 @@
 <template>
   <v-card class="pa-5">
     <v-card-title>
-      Keyboard Shurtcuts
+      Keyboard Shortcuts
       <v-icon
+        v-if="showCloseButton"
         icon="mdi-close"
         class="float-right"
         right
@@ -30,6 +31,12 @@ import { storeToRefs } from 'pinia'
 
 export default {
   name: 'HotKeysLegend',
+  props: {
+    showCloseButton: {
+      type: Boolean,
+      default: false // Default value if not passed
+    }
+  },
   setup() {
     const { hotkeyDialogVisible } = storeToRefs(useMainStore())
 

--- a/src/gui/src/views/users/settings/UserSettings.vue
+++ b/src/gui/src/views/users/settings/UserSettings.vue
@@ -87,6 +87,7 @@
             {{ $t('settings.end_of_shift') }}
             <VueDatePicker
               v-model="end_of_shift"
+              :clearable="false"
               time-picker
               auto-apply
               :label="$t('settings.end_of_shift')"


### PR DESCRIPTION
- close button removed in userSettings
- Dashboard renamed to Admin Dashboard
- fix New Report bug #324
- fix end of shift default value bug
- User dashboard buttons made persistently clicked

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the frontend by adding a conditional close button to the HotKeysLegend component, renaming the Dashboard to Admin Dashboard, and improving time configuration in user settings. Fix a bug in the ReportItem component related to null attribute access.

New Features:
- Introduce a prop to conditionally display the close button in the HotKeysLegend component.

Bug Fixes:
- Fix a bug in the ReportItem component where accessing attributes of a null report item could cause errors.

Enhancements:
- Rename 'Dashboard' to 'Admin Dashboard' in the i18n messages to better reflect its purpose.
- Update the end_of_shift configuration to use an object with hours and minutes for better time representation.

<!-- Generated by sourcery-ai[bot]: end summary -->