### PR TITLE
feat: add hotkey for important+read in assess

### DIFF
--- a/src/gui/src/components/assess/AssessSelectionToolbar.vue
+++ b/src/gui/src/components/assess/AssessSelectionToolbar.vue
@@ -179,8 +179,10 @@ export default {
         assessStore.ungroupStories()
       } else if (action === 'markAsRead') {
         assessStore.markSelectionAsRead()
+        assessStore.clearSelection()
       } else if (action === 'markAsImportant') {
         assessStore.markSelectionAsImportant()
+        assessStore.clearSelection()
       }
     }
 

--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -286,13 +286,11 @@ export const useAssessStore = defineStore(
       storySelection.value.forEach((id) => {
         markStoryAsRead(id)
       })
-      clearStorySelection()
     }
     function markSelectionAsImportant() {
       storySelection.value.forEach((id) => {
         markStoryAsImportant(id)
       })
-      clearStorySelection()
     }
     function sseNewsItemsUpdated() {
       console.debug('Triggerd News items update')

--- a/src/gui/src/utils/hotkeys.js
+++ b/src/gui/src/utils/hotkeys.js
@@ -52,12 +52,14 @@ export function assessHotkeys() {
     event.preventDefault()
     console.debug(`You pressed ${handler.key}`)
     assessStore.markSelectionAsRead()
+    assessStore.clearSelection()
   })
 
   useHotkeys('ctrl+i', (event, handler) => {
     event.preventDefault()
     console.debug(`You pressed ${handler.key}`)
     assessStore.markSelectionAsImportant()
+    assessStore.clearSelection()
   })
 
   useHotkeys('ctrl+shift+g', (event, handler) => {
@@ -108,6 +110,14 @@ export function assessHotkeys() {
     event.preventDefault()
     console.debug(`You pressed ${handler.key}`)
     router.push({ name: 'enter' })
+  })
+
+  useHotkeys('ctrl+j', (event, handler) => {
+    event.preventDefault()
+    console.debug(`You pressed ${handler.key}`)
+    assessStore.markSelectionAsImportant()
+    assessStore.markSelectionAsRead()
+    assessStore.clearSelection()
   })
 }
 


### PR DESCRIPTION
Close #275 

This MR contains the following changes:

- Add a hotkey for marking stories important and read in the Assess-view.

@b3n4kh: I was wondering wether we would also want a button "mark as important & read" in [AssessSelectionToolbar.vue](https://github.com/taranis-ai/taranis-ai/blob/master/src/gui/src/components/assess/AssessSelectionToolbar.vue).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new hotkey 'ctrl+j' to the Assess view for marking stories as important and read, and refactor existing hotkey functions to clear the story selection after performing actions.

New Features:
- Introduce a new hotkey 'ctrl+j' in the Assess view to mark stories as important and read simultaneously.

Enhancements:
- Refactor hotkey functions to clear the story selection after marking stories as read or important.

<!-- Generated by sourcery-ai[bot]: end summary -->