### PR TITLE
Assess Filter: Add a ref to filter documentation

### DIFF
--- a/src/gui/src/views/nav/AssessNav.vue
+++ b/src/gui/src/views/nav/AssessNav.vue
@@ -64,8 +64,18 @@
       <v-divider class="my-2 mt-4"></v-divider>
 
       <v-row no-gutters class="ma-2 mb-0 px-2">
-        <v-col cols="12" class="py-1">
+        <v-col cols="7" class="py-1">
           <h4>Filter</h4>
+        </v-col>
+        <v-col>
+          <a
+            href="https://taranis.ai/docs/assess/#details"
+            target="_blank"
+            style="color: grey; text-decoration: none"
+          >
+            more details
+            <v-icon size="x-small" icon="mdi-open-in-new" />
+          </a>
         </v-col>
 
         <v-col cols="12" class="pt-1">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/77db4c45-b6b8-424b-bcbc-dee62ce05581)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a hyperlink in the AssessNav view to direct users to the filter documentation for additional information.

New Features:
- Add a link to the filter documentation in the AssessNav view, allowing users to access more details about the filter functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->