### PR TITLE
remove quote in workflow build core

### DIFF
--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -53,6 +53,7 @@ jobs:
             src/gui/pnpm-lock.yaml
       
       - name: Set Artifact Name
+        shell: bash
         run: echo "TRACES_ARTIFACT_NAME=playwright-traces-build-core" >> ${GITHUB_ENV}
 
       - name: e2e tests

--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -53,7 +53,7 @@ jobs:
             src/gui/pnpm-lock.yaml
       
       - name: Set Artifact Name
-        run: echo "TRACES_ARTIFACT_NAME="playwright-traces-build-core" >> ${GITHUB_ENV}
+        run: echo "TRACES_ARTIFACT_NAME=playwright-traces-build-core" >> ${GITHUB_ENV}
 
       - name: e2e tests
         id: e2e_tests

--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -51,16 +51,15 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: |
             src/gui/pnpm-lock.yaml
-      
+
       - name: Set Artifact Name
-        shell: bash
         run: echo "TRACES_ARTIFACT_NAME=playwright-traces-build-core" >> ${GITHUB_ENV}
 
       - name: e2e tests
         id: e2e_tests
         working-directory: src/core
         run: uv run pytest --e2e-ci
-      
+
       - name: Upload a e2e-test trace
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.e2e_tests.outcome == 'failure' }}

--- a/.github/workflows/build_worker.yaml
+++ b/.github/workflows/build_worker.yaml
@@ -60,7 +60,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        working-directory: src/core
+        working-directory: src/worker
         run: uv python install
 
       - name: build


### PR DESCRIPTION
fix quote in workflow

## Summary by Sourcery

CI:
- Fix the syntax error in the GitHub Actions workflow by removing unnecessary quotes in the environment variable assignment.