### PR TITLE
Refactor bot API bugfix and improvement

### DIFF
--- a/src/core/core/api/bots.py
+++ b/src/core/core/api/bots.py
@@ -88,6 +88,7 @@ class StoryAttributes(MethodView):
                 current_story.patch_attributes(input_data)
             else:
                 return {"error": "No data provided"}, 400
+            return {"message": f"Story {story_id} updated"}, 200
         return {"error": f"Story {story_id} not found"}, 404
 
 

--- a/src/core/core/api/bots.py
+++ b/src/core/core/api/bots.py
@@ -127,7 +127,11 @@ def initialize(app: Flask):
         view_func=UpdateNewsItemAttributes.as_view("update_news_item_attributes"),
     )
     bots_bp.add_url_rule(
-        "/stories/<string:story_id>/attributes",
+        "/story/<string:story_id>",
+        view_func=UpdateStory.as_view("update_story"),
+    )
+    bots_bp.add_url_rule(
+        "/story/<string:story_id>/attributes",
         view_func=StoryAttributes.as_view("story_attributes"),
     )
     bots_bp.add_url_rule(
@@ -142,9 +146,4 @@ def initialize(app: Flask):
         "/stories/ungroup",
         view_func=BotUnGroupAction.as_view("ungroup_stories_bot"),
     )
-    bots_bp.add_url_rule(
-        "/story/<string:story_id>",
-        view_func=UpdateStory.as_view("update_story"),
-    )
-
     app.register_blueprint(bots_bp)

--- a/src/core/core/api/bots.py
+++ b/src/core/core/api/bots.py
@@ -91,7 +91,7 @@ class StoryAttributes(MethodView):
         return {"error": f"Story {story_id} not found"}, 404
 
 
-class UpdateStorySummary(MethodView):
+class UpdateStory(MethodView):
     @api_key_required
     def put(self, story_id):
         return story.Story.update(story_id, request.json)
@@ -143,8 +143,8 @@ def initialize(app: Flask):
         view_func=BotUnGroupAction.as_view("ungroup_stories_bot"),
     )
     bots_bp.add_url_rule(
-        "/story/<string:story_id>/summary",
-        view_func=UpdateStorySummary.as_view("update_story_summary"),
+        "/story/<string:story_id>",
+        view_func=UpdateStory.as_view("update_story"),
     )
 
     app.register_blueprint(bots_bp)

--- a/src/core/tests/conftest.py
+++ b/src/core/tests/conftest.py
@@ -110,7 +110,7 @@ def auth_header(access_token):
 
 @pytest.fixture
 def api_header():
-    return {"Authorization": "Bearer test_key", "Content-type": "application/json"}
+    return {"Authorization": f"Bearer {os.getenv("API_KEY")}", "Content-type": "application/json"}
 
 
 @pytest.fixture(scope="session")

--- a/src/core/tests/functional/conftest.py
+++ b/src/core/tests/functional/conftest.py
@@ -151,7 +151,7 @@ def cleanup_story_update_data():
         "comments": "This is an updated comment",
         "tags": ["tag1", "tag2", "tag3"],
         "summary": "This is an updated summary of the story",
-        "attributes": [{"key": "priority", "value": "high"}, {"key": "tech", "value": "in_progress"}],
+        "attributes": [{"key": "priority", "value": "high"}],
         "links": [
             "https://example.com/1",
             "http://example.com/2",

--- a/src/core/tests/functional/conftest.py
+++ b/src/core/tests/functional/conftest.py
@@ -139,3 +139,21 @@ def cleanup_product(app):
         }
 
         Product.delete_all()
+
+
+@pytest.fixture(scope="session")
+def cleanup_story_update_data():
+    yield {
+        "important": True,
+        "read": True,
+        "title": "Updated Test Story Title",
+        "description": "This is an updated test description",
+        "comments": "This is an updated comment",
+        "tags": ["tag1", "tag2", "tag3"],
+        "summary": "This is an updated summary of the story",
+        "attributes": [{"key": "priority", "value": "high"}, {"key": "tech", "value": "in_progress"}],
+        "links": [
+            "https://example.com/1",
+            "http://example.com/2",
+        ],
+    }

--- a/src/core/tests/functional/test_bots.py
+++ b/src/core/tests/functional/test_bots.py
@@ -15,6 +15,18 @@ class TestBotsApi(BaseTest):
         assert response.status_code == 200
         assert story_id == stories[0], "Response ID should match request ID"
 
+    def test_attribute_update(self, client, stories, api_header):
+        """
+        This test queries the story update authenticated.
+        It expects a valid data and a valid status-code
+        """
+        response = client.patch(
+            f"{self.base_uri}/story/{stories[0]}/attributes", json={"key": "tech", "value": "in_progress"}, headers=api_header
+        )
+        print(response.get_json())
+        assert response.status_code == 200
+
+    def check_updated_story(self, client, stories, cleanup_story_update_data, auth_header):
         # Check if the update was successful
         response = client.get(f"api/assess/story/{stories[0]}", headers=auth_header)
 

--- a/src/core/tests/functional/test_bots.py
+++ b/src/core/tests/functional/test_bots.py
@@ -1,0 +1,38 @@
+from tests.functional.helpers import BaseTest
+
+
+class TestBotsApi(BaseTest):
+    base_uri = "/api/bots"
+
+    def test_story_update(self, client, stories, cleanup_story_update_data, api_header, auth_header):
+        """
+        This test queries the story update authenticated.
+        It expects a valid data and a valid status-code
+        """
+        response = client.put(f"{self.base_uri}/story/{stories[0]}", json=cleanup_story_update_data, headers=api_header)
+        story_id = response.get_json().get("id")
+
+        assert response.status_code == 200
+        assert story_id == stories[0], "Response ID should match request ID"
+
+        # Check if the update was successful
+        response = client.get(f"api/assess/story/{stories[0]}", headers=auth_header)
+
+        assert response.status_code == 200
+        assert response.get_json().get("important") == cleanup_story_update_data["important"]
+        assert response.get_json().get("read") == cleanup_story_update_data["read"]
+        assert response.get_json().get("title") == cleanup_story_update_data["title"]
+        assert response.get_json().get("description") == cleanup_story_update_data["description"]
+        assert response.get_json().get("comments") == cleanup_story_update_data["comments"]
+        assert response.get_json().get("summary") == cleanup_story_update_data["summary"]
+
+        updated_tag_names = [tag["name"] for tag in response.get_json().get("tags")]
+        assert set(updated_tag_names) == set(cleanup_story_update_data["tags"])
+
+        assert len(response.get_json().get("links")) == len(cleanup_story_update_data["links"])
+        assert all(link in cleanup_story_update_data["links"] for link in response.get_json().get("links"))
+
+        # Compare attributes using sets to ignore order
+        updated_attrs_set = {(attr["key"], attr["value"]) for attr in response.get_json().get("attributes")}
+        expected_attrs_set = {(attr["key"], attr["value"]) for attr in cleanup_story_update_data["attributes"]}
+        assert updated_attrs_set == expected_attrs_set, f"Attributes don't match:\nGot: {updated_attrs_set}\nExpected: {expected_attrs_set}"

--- a/src/worker/worker/core_api.py
+++ b/src/worker/worker/core_api.py
@@ -132,9 +132,10 @@ class CoreApi:
     def update_story_summary(self, story_id, summary: str) -> dict | None:
         try:
             data = {"summary": summary}
-            return self.api_put(url=f"/bots/story/{story_id}/summary", json_data=data)
+            return self.api_put(url=f"/bots/story/{story_id}", json_data=data)
         except Exception:
             return None
+
     def update_news_item_attributes(self, news_id: str, attributes) -> dict | None:
         try:
             return self.api_put(url=f"/bots/news-item/{news_id}/attributes", json_data=attributes)


### PR DESCRIPTION
- added loading the API key from the environment

- BUG - The endpoint [bots/stories/string:story_id/attributes](https://github.com/taranis-ai/taranis-ai/blob/master/src/core/core/api/bots.py#L130) had a call URL mismatch with the [core_api.py](https://github.com/taranis-ai/taranis-ai/blob/master/src/worker/worker/core_api.py#L152) (`/story/` vs. `/stories/` in the URL)
- BUG - The story attributes patch endpoint was missing a positive response.
- The endpoint class was `UpdateStorySummary` and the URL was ending with `/summary`, which is not the best, because all the endpoint does is, it triggers the `Story.update()` function

This is a refactor proposal.