### PR TITLE
Bug: patch_attributes() not commiting to DB

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -502,8 +502,9 @@ class Story(BaseModel):
             self.set_atrribute_by_key(key=attribute["key"], value=attribute["value"])
 
     def patch_attributes(self, attributes: dict):
-        for key, value in attributes.items():
-            self.set_atrribute_by_key(key=key, value=value)
+        for attribute in attributes:
+            self.set_atrribute_by_key(key=attribute["key"], value=attribute["value"])
+            db.session.commit()
 
     def set_atrribute_by_key(self, key, value):
         if not (attribute := NewsItemAttribute.get_by_key(self.attributes, key)):

--- a/src/core/tests/functional/test_bots.py
+++ b/src/core/tests/functional/test_bots.py
@@ -21,13 +21,12 @@ class TestBotsApi(BaseTest):
         It expects a valid data and a valid status-code
         """
         response = client.patch(
-            f"{self.base_uri}/story/{stories[0]}/attributes", json={"key": "tech", "value": "in_progress"}, headers=api_header
+            f"{self.base_uri}/story/{stories[0]}/attributes", json=[{"key": "tech", "value": "in_progress"}], headers=api_header
         )
-        print(response.get_json())
         assert response.status_code == 200
 
-    def check_updated_story(self, client, stories, cleanup_story_update_data, auth_header):
-        # Check if the update was successful
+    def test_check_updated_story(self, client, stories, cleanup_story_update_data, auth_header):
+        """Check if the update was successful"""
         response = client.get(f"api/assess/story/{stories[0]}", headers=auth_header)
 
         assert response.status_code == 200
@@ -44,7 +43,5 @@ class TestBotsApi(BaseTest):
         assert len(response.get_json().get("links")) == len(cleanup_story_update_data["links"])
         assert all(link in cleanup_story_update_data["links"] for link in response.get_json().get("links"))
 
-        # Compare attributes using sets to ignore order
-        updated_attrs_set = {(attr["key"], attr["value"]) for attr in response.get_json().get("attributes")}
-        expected_attrs_set = {(attr["key"], attr["value"]) for attr in cleanup_story_update_data["attributes"]}
-        assert updated_attrs_set == expected_attrs_set, f"Attributes don't match:\nGot: {updated_attrs_set}\nExpected: {expected_attrs_set}"
+        assert response.get_json().get("attributes")[0] == cleanup_story_update_data["attributes"][0]
+        assert response.get_json().get("attributes")[1] == {"key": "tech", "value": "in_progress"}

--- a/src/core/tests/functional/test_bots.py
+++ b/src/core/tests/functional/test_bots.py
@@ -29,6 +29,8 @@ class TestBotsApi(BaseTest):
         """Check if the update was successful"""
         response = client.get(f"api/assess/story/{stories[0]}", headers=auth_header)
 
+        print(response.get_json())
+
         assert response.status_code == 200
         assert response.get_json().get("important") == cleanup_story_update_data["important"]
         assert response.get_json().get("read") == cleanup_story_update_data["read"]
@@ -43,5 +45,5 @@ class TestBotsApi(BaseTest):
         assert len(response.get_json().get("links")) == len(cleanup_story_update_data["links"])
         assert all(link in cleanup_story_update_data["links"] for link in response.get_json().get("links"))
 
-        assert response.get_json().get("attributes")[0] == cleanup_story_update_data["attributes"][0]
         assert response.get_json().get("attributes")[1] == {"key": "tech", "value": "in_progress"}
+        assert response.get_json().get("attributes")[0] == cleanup_story_update_data["attributes"][0]


### PR DESCRIPTION
1. BUG - the patch_attributes() function called in [bots.py](https://github.com/taranis-ai/taranis-ai/blob/master/src/core/core/api/bots.py#L88) is not commiting to the database at all. 
2. IMP - `update` and `patch_attribute()` payload unified.  
3. one test missing prefix `test_`

### OPEN ISSUE
The test is flaky. Attributes on retrieval change order. Only the attributes were observed to change order.