### PR TITLE
Fix word 'exactly' in templates

### DIFF
--- a/dev/template_dev/template.html
+++ b/dev/template_dev/template.html
@@ -1,5 +1,5 @@
 {% if data.report_items|length != 1 -%}
-This Template needs excatly one Report
+This Template needs exactly one Report
 {% else -%}
 {% set report = data.report_items[0].attributes -%}
 {% set stories = data.report_items[0].stories -%}

--- a/src/core/core/static/presenter_templates/cert_at_daily_report.html
+++ b/src/core/core/static/presenter_templates/cert_at_daily_report.html
@@ -1,5 +1,5 @@
 {% if data.report_items|length != 1 -%}
-This Template needs excatly one Report
+This Template needs exactly one Report
 {% else -%}
 {% set report = data.report_items[0].attributes -%}
 {% set stories = data.report_items[0].stories -%}

--- a/src/core/core/static/presenter_templates/cert_at_daily_report.txt
+++ b/src/core/core/static/presenter_templates/cert_at_daily_report.txt
@@ -1,5 +1,5 @@
 {% if data.report_items|length != 1 -%}
-This Template needs excatly one Report
+This Template needs exactly one Report
 {% else -%}
 {% set report = data.report_items[0].attributes -%}
 {% set stories = data.report_items[0].stories %}


### PR DESCRIPTION
3 spelling corrections discovered while watching @b3n4kh 's presentation about taransi-ai user stories.

## Summary by Sourcery

Bug Fixes:
- Correct the word "exactly" in template error messages.