### PR TITLE
Add nginx reverse proxy & local.taranis.ai

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -111,6 +111,14 @@ npm install
 pnpm run dev
 ```
 
+# optionally start scheduler
+
+```
+cd ../taranis-scheduler # the directory, where your taranis-scheduler repository is present
+start_dev.sh
+```
+
+
 ## Technology stack
 
 ### Backend

--- a/dev/README.md
+++ b/dev/README.md
@@ -111,10 +111,10 @@ npm install
 pnpm run dev
 ```
 
-# optionally start scheduler
+## Optionally start scheduler (another repository) in tmux
 
-```
-cd ../taranis-scheduler # the directory, where your taranis-scheduler repository is present
+```bash
+cd ../taranis-scheduler # your taranis-scheduler directory
 start_dev.sh
 ```
 

--- a/dev/env.dev
+++ b/dev/env.dev
@@ -4,7 +4,7 @@ COMPOSE_PROJECT_NAME=taranis
 TARANIS_TAG=latest
 DOCKER_IMAGE_NAMESPACE=ghcr.io/taranis-ai
 
-TARANIS_CORE_URL="http://127.0.0.1:5000/api"
+TARANIS_CORE_URL="http://local.taranis.ai/api"
 
 VITE_TARANIS_CONFIG_JSON="/config.local.json"
 DEBUG=True

--- a/dev/install_dependencies.sh
+++ b/dev/install_dependencies.sh
@@ -25,7 +25,8 @@ install_basic_utils() {
         build-essential \
         software-properties-common \
         libpq-dev \
-        clang
+        clang \
+        nginx
 }
 
 install_astral() {
@@ -51,6 +52,13 @@ setup_nodejs() {
     sudo apt-get install -y nodejs
 }
 
+# setup local.taranis.ai
+setup_nginx() {
+    sudo cp dev/nginx.conf /etc/nginx/sites-available/local.taranis.ai
+    sudo ln -s /etc/nginx/sites-available/local.taranis.ai /etc/nginx/sites-enabled/local.taranis.ai
+    sudo nginx -t && sudo systemctl restart nginx
+}
+
 
 main() {
     [[ -f ./dev/.installed ]] && exit 0
@@ -60,6 +68,7 @@ main() {
     install_astral
     install_docker
     setup_nodejs
+    setup_nginx
     touch ./dev/.installed
 }
 

--- a/dev/install_dependencies.sh
+++ b/dev/install_dependencies.sh
@@ -54,9 +54,11 @@ setup_nodejs() {
 
 # setup local.taranis.ai
 setup_nginx() {
-    sudo cp dev/nginx.conf /etc/nginx/sites-available/local.taranis.ai
-    sudo ln -s /etc/nginx/sites-available/local.taranis.ai /etc/nginx/sites-enabled/local.taranis.ai
-    sudo nginx -t && sudo systemctl restart nginx
+    if [ ! -f "/etc/nginx/sites-available/local.taranis.ai" ]; then
+      sudo cp dev/nginx.conf /etc/nginx/sites-available/local.taranis.ai
+      sudo ln -s /etc/nginx/sites-available/local.taranis.ai /etc/nginx/sites-enabled/local.taranis.ai
+      sudo nginx -t && sudo systemctl restart nginx
+    fi
 }
 
 

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,0 +1,54 @@
+upstream guiupstream {
+  server 127.0.0.1:8081; 
+}
+
+upstream coreupstream {
+  server 127.0.0.1:5000;
+}
+
+upstream sseupstream {
+  server 127.0.0.1:8088;
+}
+
+upstream schedulerupstream {
+  server 127.0.0.1:5001;
+}
+
+server {
+    listen       80;
+    server_name  local.taranis.ai;
+
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass http://guiupstream;
+
+    }
+
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    location /api {
+        proxy_pass http://coreupstream;
+        proxy_redirect off;
+    }
+
+    location /sse {
+        proxy_pass http://sseupstream;
+        proxy_read_timeout 24h;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        proxy_buffering off;
+    }
+
+    location /scheduler {
+        proxy_pass http://schedulerupstream;
+    }
+
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,5 +1,5 @@
 upstream guiupstream {
-  server 127.0.0.1:8081; 
+  server 127.0.0.1:8081;
 }
 
 upstream coreupstream {


### PR DESCRIPTION
This dev (setup) enhancement is created together with https://github.com/taranis-ai/taranis-scheduler/pull/1

`local.taranis.ai` resolves in 127.0.0.1 (see e.g. `dig local.taranis.ai` for yourself)

Adds a nginx configuration for `local.taranis.ai`, acts as reverse proxy for core, gui (optional scheduler, sse maybe later)

## Summary by Sourcery

Set up Nginx to reverse proxy requests to core, GUI, and optionally scheduler and SSE.

Enhancements:
- Configure Nginx to act as a reverse proxy for local.taranis.ai, routing traffic to the appropriate backend services.

Build:
- Install Nginx.