### PR TITLE
Feature/221 product render e2e test

### DIFF
--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -42,8 +42,7 @@ class Task(MethodView):
         elif task_id.startswith("cleanup_token_blacklist"):
             TokenBlacklist.delete_older(datetime.now() - timedelta(days=1))
         elif task_id.startswith("presenter_task"):
-            task_data = {"id": result.get("product_id"), "result": result.get("message"), "status": status}
-            Product.update_render_for_id(task_data["id"], task_data["result"].encode("utf-8"))
+            Product.update_render_for_id(result.get("product_id"), result.get("render_result", "").encode("utf-8"))
         else:
             task_data = {"id": task_id, "result": result, "status": status}
             TaskModel.add_or_update(task_data)

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -7,6 +7,7 @@ from core.model.task import Task as TaskModel
 from core.log import logger
 from core.model.word_list import WordList
 from core.model.token_blacklist import TokenBlacklist
+from core.model.product import Product
 from core.config import Config
 
 
@@ -29,6 +30,11 @@ class Task(MethodView):
 
         if not result or not status or "error" in result:
             logger.error(f"{task_id=} - {result=} - {status=}")
+
+            # failed presenter_tasks are saved in the tasks table
+            if result and task_id.startswith("presenter_task"):
+                task_data = {"id": result.get("product_id"), "result": result.get("message"), "status": status}
+                TaskModel.add_or_update(task_data)
             return {"status": "error"}, 400
 
         if task_id.startswith("gather_word_list"):
@@ -37,7 +43,7 @@ class Task(MethodView):
             TokenBlacklist.delete_older(datetime.now() - timedelta(days=1))
         elif task_id.startswith("presenter_task"):
             task_data = {"id": result.get("product_id"), "result": result.get("message"), "status": status}
-            TaskModel.add_or_update(task_data)
+            Product.update_render_for_id(task_data["id"], task_data["result"].encode("utf-8"))
         else:
             task_data = {"id": task_id, "result": result, "status": status}
             TaskModel.add_or_update(task_data)

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -27,7 +27,6 @@ class Task(MethodView):
         task_id = data.get("task_id")
         result = data.get("result")
         status = data.get("status")
-
         if not result or not status or "error" in result:
             logger.error(f"{task_id=} - {result=} - {status=}")
 
@@ -42,7 +41,9 @@ class Task(MethodView):
         elif task_id.startswith("cleanup_token_blacklist"):
             TokenBlacklist.delete_older(datetime.now() - timedelta(days=1))
         elif task_id.startswith("presenter_task"):
-            Product.update_render_for_id(result.get("product_id"), result.get("render_result", "").encode("utf-8"))
+            # the value of "render_result" in result is a dict of form {"mime_type": str, "data": bytes}
+            rendered_product = result.get("render_result", {}).get("data", "")
+            Product.update_render_for_id(result.get("product_id"), rendered_product.encode("utf-8"))
         else:
             task_data = {"id": task_id, "result": result, "status": status}
             TaskModel.add_or_update(task_data)

--- a/src/core/core/model/product.py
+++ b/src/core/core/model/product.py
@@ -98,13 +98,14 @@ class Product(BaseModel):
             "report_items": [report_item.to_product_dict() for report_item in self.report_items if report_item],
         }
 
-    def update_render(self, render_result):
+    def update_render(self, render_result: bytes):
         try:
             self.last_rendered = datetime.now()
             self.render_result = b64encode(render_result).decode("ascii")
             db.session.commit()
             return True
         except Exception:
+            logger.exception()
             db.session.rollback()
             return False
 

--- a/src/core/tests/playwright/conftest.py
+++ b/src/core/tests/playwright/conftest.py
@@ -946,7 +946,6 @@ def create_html_render(app):
     def get_product_to_render():
         with app.app_context():
             from core.model.product import Product
-            from core.model.task import Task
             from core.managers.db_manager import db
 
             # get id of first product in product table
@@ -958,9 +957,8 @@ def create_html_render(app):
                 product_id = "test"
 
             # test html for product rendering
-            test_html = "<div>Test</div>"
-            result_data = {"mime_type": "text/html", "data": test_html}
-            task_data = {"id": product_id, "result": result_data, "status": "success"}
-            Task.add_or_update(task_data)
+            test_html = "Thanks to Cybersecurity experts, the world of IT is now safe."
+
+            Product.update_render_for_id(product_id, test_html.encode("utf-8"))
 
     return get_product_to_render

--- a/src/core/tests/playwright/conftest.py
+++ b/src/core/tests/playwright/conftest.py
@@ -861,3 +861,30 @@ def news_items_list(app, fake_source):
             "published": "2024-05-03T08:30:00+01:00",
         },
     ]
+
+@pytest.fixture(scope="session")
+def create_html_render(app):
+
+    # fixture returns a callable, so that we can choose the time to execute it
+    def get_product_to_render():
+        
+        with app.app_context():
+            from core.model.product import Product
+            from core.model.task import Task
+            from core.managers.db_manager import db
+
+            # get id of first product in product table
+            product = Product.get_first(db.select(Product))
+
+            try:
+                product_id = product.id
+            except AttributeError:
+                product_id = "test"
+
+            # test html for product rendering
+            test_html = "<div>Test</div>"
+            result_data = {"mime_type": "text/html", "data": test_html}
+            task_data = {"id": product_id, "result": result_data, "status": "success"}
+            Task.add_or_update(task_data)
+
+    return get_product_to_render

--- a/src/core/tests/playwright/conftest.py
+++ b/src/core/tests/playwright/conftest.py
@@ -145,13 +145,25 @@ def random_timestamp_last_5_days() -> str:
     return (start_time + timedelta(seconds=random.randint(0, int((now - start_time).total_seconds())))).isoformat()
 
 
+def random_timestamp_last_shift() -> str:
+    ### Add a random timestamp between now and yesterday 18:00
+    now = datetime.now()
+    start_time = now - timedelta(days=1)
+    start_time = start_time.replace(hour=18, minute=0, second=0, microsecond=0)
+    return (start_time + timedelta(seconds=random.randint(0, int((now - start_time).total_seconds())))).isoformat()
+
+
 @pytest.fixture(scope="session")
 def stories(app, news_items_list):
     from core.model.story import Story
     from core.model.user import User
 
     def _renew_story_timestamps():
-        for item in news_items_list:
+        for item in news_items_list[:-5]:
+            new_time = random_timestamp_last_shift()
+            item.update({"published": new_time})
+            item.update({"collected": new_time})
+        for item in news_items_list[-5:]:
             new_time = random_timestamp_last_5_days()
             item.update({"published": new_time})
             item.update({"collected": new_time})
@@ -860,14 +872,78 @@ def news_items_list(app, fake_source):
             "osint_source_id": fake_source,
             "published": "2024-05-03T08:30:00+01:00",
         },
+        {
+            "id": "5f730743-5eec-42b1-95b6-0ececbe1d2bb",
+            "content": "Security researchers have identified a new ransomware variant that specifically targets cloud storage services.",
+            "source": "https://www.cybersecurityinsights.com/RSSNewsfeed.xml",
+            "title": "New Ransomware Targets Cloud Environments",
+            "author": "James Corwin",
+            "collected": "2000-12-07T00:59:12",
+            "hash": "abce201fc86f06adad8a6a83c0492d9f616246d19c8659b8f2c55466dd98db84",
+            "review": "",
+            "link": "https://www.cybersecurityinsights.com/new-cloud-ransomware-2000.html",
+            "osint_source_id": fake_source,
+            "published": "2000-07-09T17:23:53",
+        },
+        {
+            "id": "48f1e64f-f69f-4057-809a-48f706746fac",
+            "content": "A critical zero-day vulnerability has been discovered in a widely-used web server, potentially exposing millions of websites.",
+            "source": "https://www.infosecurityalerts.com/RSSNewsfeed.xml",
+            "title": "Zero-Day Exploit Found in Popular Web Server",
+            "author": "Alice Johnson",
+            "collected": "2000-05-28T19:41:16",
+            "hash": "42cf38bfa93f10105907cc5e38122d751711867560216bda3c085ac94598524c",
+            "review": "",
+            "link": "https://www.infosecurityalerts.com/web-server-zero-day-2000.html",
+            "osint_source_id": fake_source,
+            "published": "2000-10-30T23:40:15",
+        },
+        {
+            "id": "78f04d84-2c69-4c79-9e9c-39bf0dabd652",
+            "content": "Reports indicate that a nation-state-backed hacking group attempted to compromise a major power grid system.",
+            "source": "https://www.criticalinfrastructuredefense.com/RSSNewsfeed.xml",
+            "title": "Nation-State Attack Targets Power Grid",
+            "author": "Robert Fields",
+            "collected": "2000-10-28T23:49:51",
+            "hash": "ee860310326d121df31939d4983109e4e3e09eaf043563f2f63162a5611d916a",
+            "review": "",
+            "link": "https://www.criticalinfrastructuredefense.com/power-grid-attack-2000.html",
+            "osint_source_id": fake_source,
+            "published": "2000-04-23T15:12:08",
+        },
+        {
+            "id": "11e1f348-d53b-4542-ae1d-2674be32184c",
+            "content": "Hackers have leaked sensitive financial records from multiple banking institutions in a major data breach.",
+            "source": "https://www.financialcybernews.com/RSSNewsfeed.xml",
+            "title": "Massive Data Breach Affects Financial Institutions",
+            "author": "Emma Thompson",
+            "collected": "2000-12-07T09:38:04",
+            "hash": "aa1e774c2472536492d1de70dad65e7d052df1e524051c5075dd6fb0ece09b7b",
+            "review": "",
+            "link": "https://www.financialcybernews.com/banking-data-breach-2000.html",
+            "osint_source_id": fake_source,
+            "published": "2000-04-27T01:51:09",
+        },
+        {
+            "id": "e300742f-124f-4e2f-ab3f-bb80b34b1d01",
+            "content": "Researchers have discovered malware embedded in popular open-source libraries used by thousands of applications.",
+            "source": "https://www.softwaresecuritywatch.com/RSSNewsfeed.xml",
+            "title": "Malware Hidden in Open-Source Libraries",
+            "author": "Michael Carter",
+            "collected": "2000-07-30T09:59:45",
+            "hash": "9e238034dfedd2fa790822818a13014fbd62c9b4b16c3e8ff7b54da29b68e7c4",
+            "review": "",
+            "link": "https://www.softwaresecuritywatch.com/open-source-malware-2000.html",
+            "osint_source_id": fake_source,
+            "published": "2000-03-14T08:58:59",
+        },
     ]
+
 
 @pytest.fixture(scope="session")
 def create_html_render(app):
-
     # fixture returns a callable, so that we can choose the time to execute it
     def get_product_to_render():
-        
         with app.app_context():
             from core.model.product import Product
             from core.model.task import Task

--- a/src/core/tests/playwright/test_e2e_workflow.py
+++ b/src/core/tests/playwright/test_e2e_workflow.py
@@ -343,7 +343,10 @@ class TestUserWorkflow(PlaywrightHelpers):
         self.highlight_element(page.get_by_label("Description")).click()
         self.highlight_element(page.get_by_label("Description")).fill("Test Description")
         self.highlight_element(page.get_by_role("button", name="Save")).click()
-        self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product"))
-        # mock worker rendering the product
+        # wait for 1s until the product is saved, mock the rendering
+        self.short_sleep(duration=1)
         create_html_render()
+        # click on Render Product, wait 6s until the rendered product is fetched
+        self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product")).click()
+        self.short_sleep(duration=6)
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/core/tests/playwright/test_e2e_workflow.py
+++ b/src/core/tests/playwright/test_e2e_workflow.py
@@ -3,6 +3,7 @@ import re
 import time
 import pytest
 from playwright.sync_api import expect, Page
+from typing import Callable
 
 from playwright_helpers import PlaywrightHelpers
 
@@ -328,7 +329,7 @@ class TestUserWorkflow(PlaywrightHelpers):
         go_to_assess()
         check_reports_items_by_tag()
 
-    def test_e2e_publish(self, taranis_frontend: Page):
+    def test_e2e_publish(self, taranis_frontend: Page, create_html_render: Callable):
         page = taranis_frontend
 
         self.highlight_element(page.get_by_role("link", name="Publish").first).click()
@@ -343,4 +344,6 @@ class TestUserWorkflow(PlaywrightHelpers):
         self.highlight_element(page.get_by_label("Description")).fill("Test Description")
         self.highlight_element(page.get_by_role("button", name="Save")).click()
         self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product"))
+        # mock worker rendering the product
+        create_html_render()
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/worker/worker/core_api.py
+++ b/src/worker/worker/core_api.py
@@ -220,6 +220,7 @@ class CoreApi:
         try:
             return self.api_post(url="/tasks/", json_data=data)
         except Exception:
+            logger.exception("Cannot store task result")
             return None
 
     def get_task(self, task_id) -> requests.Response:

--- a/src/worker/worker/presenters/base_presenter.py
+++ b/src/worker/worker/presenters/base_presenter.py
@@ -11,7 +11,7 @@ class BasePresenter:
     def print_exception(self, error):
         logger.exception(f"[{self.name}] {error}")
 
-    def generate(self, product, template) -> dict[str, bytes | str]:
+    def generate(self, product, template) -> dict[str, str]:
         env = jinja2.Environment(autoescape=False)
         tmpl = env.from_string(template)
         product["current_date"] = datetime.datetime.now().strftime("%Y-%m-%d")

--- a/src/worker/worker/presenters/base_presenter.py
+++ b/src/worker/worker/presenters/base_presenter.py
@@ -16,6 +16,6 @@ class BasePresenter:
         tmpl = env.from_string(template)
         product["current_date"] = datetime.datetime.now().strftime("%Y-%m-%d")
 
-        output_text = tmpl.render(data=product).encode("utf-8")
+        output_text = tmpl.render(data=product)
 
         return {"mime_type": product["mime_type"], "data": output_text}

--- a/src/worker/worker/presenters/presenter_tasks.py
+++ b/src/worker/worker/presenters/presenter_tasks.py
@@ -90,9 +90,4 @@ class PresenterTask(Task):
         if not rendered_product:
             self.raise_error("Presenter returned no content", product_id)
 
-        # this line should be obsolete now
-        # self.core_api.upload_rendered_product(
-        #     product_id,
-        #     rendered_product,
-        # )
-        return {"product_id": product_id, "message": f"Product: {product_id} rendered successfully"}
+        return {"product_id": product_id, "message": f"Product: {product_id} rendered successfully", "render_result": rendered_product}

--- a/src/worker/worker/presenters/presenter_tasks.py
+++ b/src/worker/worker/presenters/presenter_tasks.py
@@ -90,8 +90,9 @@ class PresenterTask(Task):
         if not rendered_product:
             self.raise_error("Presenter returned no content", product_id)
 
-        self.core_api.upload_rendered_product(
-            product_id,
-            rendered_product,
-        )
+        # this line should be obsolete now
+        # self.core_api.upload_rendered_product(
+        #     product_id,
+        #     rendered_product,
+        # )
         return {"product_id": product_id, "message": f"Product: {product_id} rendered successfully"}


### PR DESCRIPTION
1. Add pytest fixture for simulating a worker rendering a report, adapt e2e_test_publish test case in test_e2e_workflow.py
2. Fix failing e2e test cases test_assess and test_reports (credit to @b3n4kh & @not4Pedro )
3. Change /tasks POST method, so that only failed presenter_tasks are stored in the tasks table

## Summary by Sourcery

Tests:
- Add a pytest fixture to simulate a worker rendering a report and adapt the `e2e_test_publish` test case.