### PR TITLE
Bugfix/383 string interval

### DIFF
--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -312,10 +312,15 @@ class Bots(MethodView):
 
     @auth_required("CONFIG_BOT_UPDATE")
     def put(self, bot_id):
-        if updated_bot := bot.Bot.update(bot_id, request.json):
-            logger.debug(f"Successfully updated {updated_bot}")
-            return {"message": f"Successfully upated {updated_bot.name}", "id": f"{updated_bot.id}"}, 200
-        return {"error": f"Error updateing {bot_id}"}, 500
+        if not (update_data := request.json):
+            return {"error": "No update data passed"}, 400
+        try:
+            if updated_bot := bot.Bot.update(bot_id, update_data):
+                logger.debug(f"Successfully updated {updated_bot}")
+                return {"message": f"Successfully upated {updated_bot.name}", "id": f"{updated_bot.id}"}, 200
+        except ValueError as e:
+            return {"error": str(e)}, 500
+        return {"error": f"Bot with ID: {bot_id} not found"}, 404
 
     @auth_required("CONFIG_BOT_CREATE")
     def post(self):

--- a/src/core/core/model/bot.py
+++ b/src/core/core/model/bot.py
@@ -110,8 +110,16 @@ class Bot(BaseModel):
         return {"message": f"Schedule for bot {self.id} removed"}, 200
 
     def get_schedule(self) -> int | None:
-        refresh_interval = ParameterValue.find_value_by_parameter(self.parameters, "REFRESH_INTERVAL")
-        return convert_interval(refresh_interval)
+        refresh_interval_str = ParameterValue.find_value_by_parameter(self.parameters, "REFRESH_INTERVAL")
+
+        # for bots, REFRESH_INTERVAL needs to be set
+        if refresh_interval_str == "":
+            raise ValueError("REFRESH_INTERVAL needs to be set for Bots")
+
+        refresh_interval = convert_interval(refresh_interval_str)
+        if refresh_interval is None:
+            raise ValueError(f"Invalid REFRESH_INTERVAL: {refresh_interval_str}")
+        return refresh_interval
 
     def to_task_dict(self, interval: int):
         return {

--- a/src/core/core/model/bot.py
+++ b/src/core/core/model/bot.py
@@ -36,24 +36,19 @@ class Bot(BaseModel):
         bot = cls.get(bot_id)
         if not bot:
             return None
+        if name := data.get("name"):
+            bot.name = name
 
-        try:
-            if name := data.get("name"):
-                bot.name = name
-
-            bot.description = data.get("description")
-            if parameters := data.get("parameters"):
-                update_parameter = ParameterValue.get_or_create_from_list(parameters)
-                bot.parameters = ParameterValue.get_update_values(bot.parameters, update_parameter)
-            if index := data.get("index"):
-                if not Bot.index_exists(index):
-                    bot.index = index
-            db.session.commit()
-            bot.schedule_bot()
-            return bot
-        except Exception:
-            logger.exception("Update Bot Parameters Failed")
-            return None
+        bot.description = data.get("description")
+        if parameters := data.get("parameters"):
+            update_parameter = ParameterValue.get_or_create_from_list(parameters)
+            bot.parameters = ParameterValue.get_update_values(bot.parameters, update_parameter)
+        if index := data.get("index"):
+            if not Bot.index_exists(index):
+                bot.index = index
+        db.session.commit()
+        bot.schedule_bot()
+        return bot
 
     @classmethod
     def get_highest_index(cls):

--- a/src/core/core/model/bot.py
+++ b/src/core/core/model/bot.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import Select
 from core.log import logger
 from core.managers.db_manager import db
 from core.model.base_model import BaseModel
-from core.model.parameter_value import ParameterValue
+from core.model.parameter_value import ParameterValue, convert_interval
 from core.model.worker import BOT_TYPES, Worker
 from core.managers.schedule_manager import Scheduler
 
@@ -109,15 +109,15 @@ class Bot(BaseModel):
         logger.info(f"Schedule for bot {self.id} removed")
         return {"message": f"Schedule for bot {self.id} removed"}, 200
 
-    def get_schedule(self) -> str | None:
+    def get_schedule(self) -> int | None:
         refresh_interval = ParameterValue.find_value_by_parameter(self.parameters, "REFRESH_INTERVAL")
-        return refresh_interval or None
+        return convert_interval(refresh_interval)
 
-    def to_task_dict(self, interval: str):
+    def to_task_dict(self, interval: int):
         return {
             "id": self.to_task_id(),
             "name": f"{self.type}_{self.name}",
-            "jobs_params": {"trigger": "interval", "minutes": int(interval), "max_instances": 1},
+            "jobs_params": {"trigger": "interval", "minutes": interval, "max_instances": 1},
             "celery": {
                 "name": "bot_task",
                 "args": [self.id],

--- a/src/core/core/model/bot.py
+++ b/src/core/core/model/bot.py
@@ -106,10 +106,14 @@ class Bot(BaseModel):
 
     def get_schedule(self) -> int | None:
         refresh_interval_str = ParameterValue.find_value_by_parameter(self.parameters, "REFRESH_INTERVAL")
+        run_after_collector = ParameterValue.find_value_by_parameter(self.parameters, "RUN_AFTER_COLLECTOR")
 
-        # for bots, REFRESH_INTERVAL needs to be set
+        # for bots, REFRESH_INTERVAL needs to be given unless RUN_AFTER_COLLECTOR is set
         if refresh_interval_str == "":
-            raise ValueError("REFRESH_INTERVAL needs to be set for Bots")
+            if run_after_collector == "false":
+                raise ValueError("Need to give REFRESH_INTERVAL for Bots if RUN_AFTER_COLLECTOR is not set")
+            else:
+                return None
 
         refresh_interval = convert_interval(refresh_interval_str)
         if refresh_interval is None:

--- a/src/core/core/model/osint_source.py
+++ b/src/core/core/model/osint_source.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql import Select
 from core.managers.db_manager import db
 from core.log import logger
 from core.model.role_based_access import RoleBasedAccess, ItemType
-from core.model.parameter_value import ParameterValue
+from core.model.parameter_value import ParameterValue, convert_interval
 from core.model.word_list import WordList
 from core.model.base_model import BaseModel
 from core.managers.schedule_manager import Scheduler
@@ -121,15 +121,15 @@ class OSINTSource(BaseModel):
     def to_task_id(self) -> str:
         return f"{self.type}_{self.id}"
 
-    def get_schedule(self) -> str:
+    def get_schedule(self) -> int | None:
         refresh_interval = ParameterValue.find_value_by_parameter(self.parameters, "REFRESH_INTERVAL")
-        return refresh_interval or "480"
+        return convert_interval(refresh_interval)
 
-    def to_task_dict(self):
+    def to_task_dict(self, interval: int):
         return {
             "id": self.to_task_id(),
             "name": f"{self.type}_{self.name}",
-            "jobs_params": {"trigger": "interval", "minutes": int(self.get_schedule()), "max_instances": 1},
+            "jobs_params": {"trigger": "interval", "minutes": interval, "max_instances": 1},
             "celery": {
                 "name": "collector_task",
                 "args": [self.id],
@@ -215,7 +215,14 @@ class OSINTSource(BaseModel):
     def schedule_osint_source(self):
         if self.type == COLLECTOR_TYPES.MANUAL_COLLECTOR:
             return {"message": "Manual collector does not need to be scheduled"}, 200
-        entry = self.to_task_dict()
+
+        # use default interval (480 min = 8h) if not REFERESH_INTERVAL was set
+        interval = self.get_schedule()
+        if interval is None:
+            logger.info(f"REFRESH_INTERVAL for source {self.id} set to default value (8 hours)")
+            interval = 480
+
+        entry = self.to_task_dict(interval)
         Scheduler.add_celery_task(entry)
         logger.info(f"Schedule for source {self.id} updated with - {entry}")
         return {"message": f"Schedule for source {self.id} updated"}, 200

--- a/src/core/core/model/parameter_value.py
+++ b/src/core/core/model/parameter_value.py
@@ -20,6 +20,23 @@ class PARAMETER_TYPES(StrEnum):
     TABLE = auto()
 
 
+def convert_interval(interval: str) -> int | None:
+    """Convert the REFRESH_INTERVAL string to int"""
+
+    # TODO add support for specific time (see: https://github.com/taranis-ai/taranis-ai/issues/401)
+
+    interval_map = {"hourly": 60, "daily": 1440, "weekly": 10080}
+
+    try:
+        # check if interval can be cast to int directly
+        interval_minutes = int(interval)
+    except ValueError:
+        # allow leading/trailing spaces, quotes and make case insensitive
+        interval_minutes = interval_map.get(interval.strip().replace("'", "").replace('"', "").lower(), None)
+
+    return interval_minutes
+
+
 class ParameterValue(BaseModel):
     __tablename__ = "parameter_value"
 

--- a/src/core/tests/functional/config/test_config.py
+++ b/src/core/tests/functional/config/test_config.py
@@ -260,6 +260,7 @@ class TestBotConfigApi(BaseTest):
             "name": cleanup_bot["name"],
             "type": cleanup_bot["type"],
             "description": "Boty McBotFace",
+            "parameters": {"REFRESH_INTERVAL": "480"},
         }
         bot_id = cleanup_bot["id"]
         response = self.assert_put_ok(client, uri=f"bots/{bot_id}", json_data=bot_data, auth_header=auth_header)


### PR DESCRIPTION
Addresses: https://github.com/taranis-ai/taranis-ai/issues/383

- Include mapping of string intervals "hourly", "daily", "weekly" to minutes
- Collector tasks accept empty REFRESH_INTERVAL and use default of 8h
- Bot tasks do not accept empty REFRESH_INTERVAL unless RUN_AFTER_COLLECTOR = True