### PR TITLE
Fix broken attributes addition in frontend StoryEdit

### DIFF
--- a/src/gui/src/components/assess/StoryEdit.vue
+++ b/src/gui/src/components/assess/StoryEdit.vue
@@ -208,6 +208,9 @@ export default {
     }
     const filteredStoryAttributes = computed({
       get() {
+        if (!story.value || !story.value.attributes) {
+          return []
+        }
         if (showallattributes.value) {
           return story.value.attributes
         }

--- a/src/gui/src/components/assess/StoryEdit.vue
+++ b/src/gui/src/components/assess/StoryEdit.vue
@@ -206,21 +206,22 @@ export default {
     const rules = {
       required: (v) => !!v || 'Required'
     }
-
-    const filteredStoryAttributes = computed(() => {
-      if (!story.value || !story.value.attributes) {
-        return []
+    const filteredStoryAttributes = computed({
+      get() {
+        if (showallattributes.value) {
+          return story.value.attributes
+        }
+        return story.value.attributes.filter((attr) => {
+          return (
+            Object.prototype.hasOwnProperty.call(attr, 'key') &&
+            attr.key !== 'sentiment' &&
+            !attr.key.includes('_BOT_')
+          )
+        })
+      },
+      set(newAttributes) {
+        story.value.attributes = newAttributes
       }
-      if (showallattributes.value) {
-        return story.value.attributes
-      }
-      return story.value.attributes.filter((attr) => {
-        return (
-          Object.prototype.hasOwnProperty.call(attr, 'key') &&
-          attr.key !== 'sentiment' &&
-          !attr.key.includes('_BOT_')
-        )
-      })
     })
 
     const hasRtId = computed(() => {


### PR DESCRIPTION
Attributes couldn't be added to the stories from the StoryEdit view because the property was a `computed()` and therefore read-only.
- [ ] write e2e tests

## Summary by Sourcery

Bug Fixes:
- Fix an issue where attributes could not be added to stories in the StoryEdit view.