### PR TITLE
Feature/390 conditional request

### DIFF
--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -120,6 +120,12 @@ class BaseWebCollector(BaseCollector):
         published_date = self.get_last_modified(response)
         if text := response.text:
             return text, published_date
+
+        if response.status_code == 304:  # content was not modified
+            logger.info(f"Content of {web_url} was not modified since {modified_since}")
+        else:
+            logger.error(f"No content found for url: {web_url}")
+
         return "", published_date
 
     def xpath_extraction(self, html_content, xpath: str, get_content: bool = True) -> str | None:
@@ -172,7 +178,6 @@ class BaseWebCollector(BaseCollector):
             content = extract(web_content, url=web_url)
 
         if not content or not web_content:
-            logger.error(f"No content found for url: {web_url}")
             return {"author": "", "title": "", "content": "", "published_date": None, "language": "", "review": ""}
 
         author, title = self.extract_meta(web_content, web_url)

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -24,6 +24,7 @@ class BaseWebCollector(BaseCollector):
 
         self.proxies = None
         self.timeout = 60
+        self.last_attempted = None
         self.headers = {}
         self.osint_source_id: str
 
@@ -108,12 +109,12 @@ class BaseWebCollector(BaseCollector):
         self.core_api.update_osint_source_icon(osint_source_id, icon_content)
         return None
 
-    def fetch_article_content(self, web_url: str, xpath: str = "", modified_since: str = "") -> tuple[str, datetime.datetime | None]:
+    def fetch_article_content(self, web_url: str, xpath: str = "") -> tuple[str, datetime.datetime | None]:
         if self.browser_mode == "true" and self.playwright_manager:
             return self.playwright_manager.fetch_content_with_js(web_url, xpath), None
 
         # send GET request to web_url
-        response = self.send_get_request(web_url, modified_since)
+        response = self.send_get_request(web_url, self.last_attempted)
         if response is None:
             return "", None  # failure case
 
@@ -121,8 +122,9 @@ class BaseWebCollector(BaseCollector):
         if text := response.text:
             return text, published_date
 
-        if response.status_code == 304:  # content was not modified
-            logger.info(f"Content of {web_url} was not modified since {modified_since}")
+        if response.status_code == 304:
+            logger.info(f"Content of {web_url} was not modified since:"
+                        f"{self.last_attempted if self.last_attempted else ''}")
         else:
             logger.error(f"No content found for url: {web_url}")
 
@@ -169,8 +171,8 @@ class BaseWebCollector(BaseCollector):
             review=web_content["review"],
         )
 
-    def extract_web_content(self, web_url, xpath: str = "", modified_since: str = "") -> dict[str, Any]:
-        web_content, published_date = self.fetch_article_content(web_url, modified_since)
+    def extract_web_content(self, web_url, xpath: str = "") -> dict[str, Any]:
+        web_content, published_date = self.fetch_article_content(web_url)
         content = ""
         if xpath:
             content = self.xpath_extraction(web_content, xpath)

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -108,12 +108,12 @@ class BaseWebCollector(BaseCollector):
         self.core_api.update_osint_source_icon(osint_source_id, icon_content)
         return None
 
-    def fetch_article_content(self, web_url: str, xpath: str = "") -> tuple[str, datetime.datetime | None]:
+    def fetch_article_content(self, web_url: str, xpath: str = "", modified_since: str = "") -> tuple[str, datetime.datetime | None]:
         if self.browser_mode == "true" and self.playwright_manager:
             return self.playwright_manager.fetch_content_with_js(web_url, xpath), None
 
         # send GET request to web_url
-        response = self.send_get_request(web_url)
+        response = self.send_get_request(web_url, modified_since)
         if response is None:
             return "", None  # failure case
 
@@ -163,8 +163,8 @@ class BaseWebCollector(BaseCollector):
             review=web_content["review"],
         )
 
-    def extract_web_content(self, web_url, xpath: str = "") -> dict[str, Any]:
-        web_content, published_date = self.fetch_article_content(web_url)
+    def extract_web_content(self, web_url, xpath: str = "", modified_since: str = "") -> dict[str, Any]:
+        web_content, published_date = self.fetch_article_content(web_url, modified_since)
         content = ""
         if xpath:
             content = self.xpath_extraction(web_content, xpath)

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -43,12 +43,10 @@ class BaseWebCollector(BaseCollector):
            If modified_since is given, make request conditional with If-Modified-Since"""
 
         # transform modified_since datetime object to str that is accepted by If-Modified-Since
-        modified_since = modified_since.strftime("%a, %d %b %Y %H:%M:%S GMT") if modified_since else ""
+        request_headers = self.headers.copy()
 
         if modified_since:
-            request_headers = dict(self.headers, **{"If-Modified-Since": modified_since})
-        else:
-            request_headers = self.headers
+           request_headers["If-Modified-Since"] = modified_since.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
         try:
             logger.debug(f"Sending GET request to {url}")

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -125,7 +125,7 @@ class BaseWebCollector(BaseCollector):
         # differentiate between no content returned due to not-modified or other reasons
         if response.status_code == 304:
             logger.info(f"Content of {web_url} was not modified since:"
-                        f"{self.last_attempted if self.last_attempted else ''}")
+                        f"{self.last_attempted or ''}")
         else:
             logger.error(f"No content found for url: {web_url}")
 

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -54,7 +54,7 @@ class BaseWebCollector(BaseCollector):
             logger.info(f"Sending GET request to {url}")
             response = requests.get(url, headers=request_headers, proxies=self.proxies, timeout=self.timeout)
             response.raise_for_status()
-        except requests.exceptions.ConnectionError as e:
+        except requests.exceptions.RequestException as e:
             logger.error(f"Failed to connect to {url}. Error: {e}")
             return None
 

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -122,6 +122,7 @@ class BaseWebCollector(BaseCollector):
         if text := response.text:
             return text, published_date
 
+        # differentiate between no content returned due to not-modified or other reasons
         if response.status_code == 304:
             logger.info(f"Content of {web_url} was not modified since:"
                         f"{self.last_attempted if self.last_attempted else ''}")

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -51,7 +51,7 @@ class BaseWebCollector(BaseCollector):
             request_headers = self.headers
 
         try:
-            logger.info(f"Sending GET request to {url}")
+            logger.debug(f"Sending GET request to {url}")
             response = requests.get(url, headers=request_headers, proxies=self.proxies, timeout=self.timeout)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -211,6 +211,11 @@ class RSSCollector(BaseWebCollector):
 
         # get the content of the RSS feed only if it was modified since the last attempt
         modified_since = last_attempted.strftime("%a, %d %b %Y %H:%M:%S GMT") if last_attempted else ""
+
+        # if collecting was manually triggered, ignore time of last modification
+        if manual:
+            modified_since = ""
+
         feed = self.get_feed(modified_since)
 
         if not last_attempted:

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -91,8 +91,7 @@ class RSSCollector(BaseWebCollector):
         if content_from_feed:
             content = str(feed_entry[content_location])
         if link:
-            # get the content of the RSS feed entry only if it was modified since the last attempt
-            web_content = self.extract_web_content(link, self.xpath, self.last_attempted)
+            web_content = self.extract_web_content(link, self.xpath)
             content = content if content_from_feed else str(web_content.get("content"))
             author = author or str(web_content.get("author"))
             title = title or str(web_content.get("title"))

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -192,8 +192,8 @@ class RSSCollector(BaseWebCollector):
         modified_since = self.last_attempted if not manual else None
         self.feed_content = self.send_get_request(self.feed_url, modified_since)
 
-        # request returned OK, but no content
-        if self.feed_content.ok and not self.feed_content.content:
+        # request returned 200 OK, but no content
+        if self.feed_content.status_code == 200 and not self.feed_content.content:
             logger.info(f"RSS-Feed {self.feed_url} returned no content")
             raise ValueError("RSS returned no content")
 

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -189,7 +189,7 @@ class RSSCollector(BaseWebCollector):
         """Send GET request to URL of RSS feed."""
 
         # if manual flag is set, ignore if the feed was not modified
-        modified_since = self.last_attempted if not manual else None
+        modified_since = None if manual else self.last_attempted
         self.feed_content = self.send_get_request(self.feed_url, modified_since)
 
         # request returned 200 OK, but no content

--- a/src/worker/worker/collectors/simple_web_collector.py
+++ b/src/worker/worker/collectors/simple_web_collector.py
@@ -17,7 +17,7 @@ class SimpleWebCollector(BaseWebCollector):
         self.news_items = []
         self.web_url: str
         self.xpath: str
-        self.last_modified = None
+        self.last_attempted = None
         self.digest_splitting_limit: int
         logger_trafilatura = logging.getLogger("trafilatura")
         logger_trafilatura.setLevel(logging.WARNING)
@@ -81,14 +81,9 @@ class SimpleWebCollector(BaseWebCollector):
             logger.info(f"Website {source['id']} returned no content")
             raise ValueError("Website returned no content")
 
-        last_attempted = self.get_last_attempted(source)
-        if not last_attempted:
+        self.last_attempted = self.get_last_attempted(source)
+        if not self.last_attempted:
             self.update_favicon(self.web_url, self.osint_source_id)
-        last_modified = self.get_last_modified(response)
-        self.last_modified = last_modified
-        if last_modified and last_attempted and last_modified < last_attempted and not manual:
-            logger.debug(f"Last-Modified: {last_modified} < Last-Attempted {last_attempted} skipping")
-            return "Last-Modified < Last-Attempted"
 
         try:
             self.news_items = self.gather_news_items()

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -66,9 +66,9 @@ def collectors_mock(osint_source_update_mock, news_item_upload_mock):
 
 @pytest.fixture
 def base_web_collector_mock(requests_mock):
-    requests_mock.get("https://test.org", text="Hello World")
-    requests_mock.get("https://test.org/comments", text="", status_code=304)
-    requests_mock.get("https://test.org/archive", text="", status_code=404)
+    requests_mock.get("https://test.org/200", text="200 OK")
+    requests_mock.get("https://test.org/304", text="", status_code=304)
+    requests_mock.get("https://test.org/404", text="", status_code=404)
 
 
 @pytest.fixture

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -96,6 +96,8 @@ def rt_mock(requests_mock, collectors_mock):
     import worker.tests.collectors.rt_testdata as rt_testdata
 
     requests_mock.get(rt_testdata.rt_ticket_search_url, json=rt_testdata.rt_ticket_search_result)
+    requests_mock.get(rt_testdata.rt_no_tickets_url, json={"items": []})
+    requests_mock.get(rt_testdata.rt_malformed_json_url, json=None)
     requests_mock.get(rt_testdata.rt_ticket_url, json=rt_testdata.rt_ticket_1)
     requests_mock.get(rt_testdata.rt_ticket_attachments_url, json=rt_testdata.rt_ticket_attachments)
     requests_mock.get(rt_testdata.rt_attachment_1_url, json=rt_testdata.rt_ticket_attachment_1)

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -18,8 +18,7 @@ def file_loader(filename):
 
 @pytest.fixture
 def base_web_collector():
-    collector = BaseWebCollector()
-    yield collector
+    yield BaseWebCollector()
 
 
 @pytest.fixture

--- a/src/worker/worker/tests/collectors/rt_testdata.py
+++ b/src/worker/worker/tests/collectors/rt_testdata.py
@@ -24,6 +24,28 @@ rt_ticket_search_result = {
     "pages": 1,
 }
 
+rt_no_tickets_url = f"{rt_base_url}tickets?query=Started%20%3E%20'2018-04-04'%20AND%20Started%20%3C%20'2018-04-06'"
+rt_collector_no_tickets_source_data = {
+    "id": 1,
+    "parameters": {
+        "BASE_URL": f"{rt_base_url}",
+        "RT_TOKEN": "1-11-11111111111111111111111111111111",
+        "SEARCH_QUERY": "Started > '2018-04-04' AND Started < '2018-04-06'",
+        "FIELDS_TO_INCLUDE": "One, Two, Three, Four",
+    }
+}
+
+rt_malformed_json_url = f"{rt_base_url}tickets?query=Started%20%3E%20'2018-04-04'%20AND%20Started%20%3C%20''"
+rt_malformed_json_source_data = {
+    "id": 1,
+    "parameters": {
+        "BASE_URL": f"{rt_base_url}",
+        "RT_TOKEN": "1-11-11111111111111111111111111111111",
+        "SEARCH_QUERY": "Started > '2018-04-04' AND Started < ''",
+        "FIELDS_TO_INCLUDE": "",
+    }
+}
+
 rt_ticket_url = f"{rt_base_url}ticket/1"
 rt_ticket_1 = {
     "Type": "ticket",

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -7,12 +7,16 @@ def test_base_web_collector_conditional_request(base_web_collector_mock, base_we
 
     import datetime
 
-    result = base_web_collector.send_get_request("https://test.org/comments",
+    result = base_web_collector.send_get_request("https://test.org/200")
+    assert result.text == "200 OK"
+    assert result.status_code == 200
+
+    result = base_web_collector.send_get_request("https://test.org/304",
                                                   datetime.datetime(2020, 3, 20, 12))
     assert result.text == ""
     assert result.status_code == 304
 
-    result = base_web_collector.send_get_request("https://test.org/archive")
+    result = base_web_collector.send_get_request("https://test.org/404")
     assert result is None
 
 

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -27,18 +27,14 @@ def test_rss_collector(rss_collector_mock, rss_collector):
 
     assert result is None
 
-def test_rss_collector_not_modified(rss_collector_mock, rss_collector):
+def test_rss_collector_get_feed(rss_collector_mock, rss_collector):
     from worker.tests.testdata import rss_collector_source_data_not_modified
-
-    result = rss_collector.collect(rss_collector_source_data_not_modified)
-
-    assert result == "RSS not modified"
-
-def test_rss_collector_no_content(rss_collector_mock, rss_collector):
     from worker.tests.testdata import rss_collector_source_data_no_content
 
-    result = rss_collector.collect(rss_collector_source_data_no_content)
+    result = rss_collector.collect(rss_collector_source_data_not_modified)
+    assert result == "RSS not modified"
 
+    result = rss_collector.collect(rss_collector_source_data_no_content)
     assert result == "RSS returned no content"
 
 

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -169,6 +169,28 @@ def test_rt_collector_collect(rt_mock, rt_collector):
     assert result is None
 
 
+def test_rt_collector_no_tickets_error(rt_mock, rt_collector):
+    import worker.tests.collectors.rt_testdata as rt_testdata
+    
+    # query did not return tickets
+    error_msg = f"RT Collector not available {rt_testdata.rt_base_url} with exception: "\
+                f"No tickets available for {rt_testdata.rt_base_url}"
+    
+    with pytest.raises(RuntimeError) as exception:
+        _ = rt_collector.collect(rt_testdata.rt_collector_no_tickets_source_data)
+    assert str(exception.value) == error_msg
+
+def test_rt_collector_malformed_json_error(rt_mock, rt_collector):
+    import worker.tests.collectors.rt_testdata as rt_testdata
+
+    # query response contains malformed json
+    error_msg = f"RT Collector not available {rt_testdata.rt_base_url} with exception: "\
+                f"Could not decode result of query as JSON"
+    
+    with pytest.raises(RuntimeError) as exception:
+        _ = rt_collector.collect(rt_testdata.rt_malformed_json_source_data)
+    assert str(exception.value) == error_msg
+
 @pytest.mark.parametrize("input_news_items", [news_items, news_items[2:], news_items[:: len(news_items) - 1], [news_items[-1]]])
 def test_filter_by_word_list_empty_wordlist(rss_collector, input_news_items):
     emptylist_results = rss_collector.filter_by_word_list(input_news_items, [])

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -3,12 +3,39 @@ import pytest
 from worker.tests.testdata import news_items
 
 
+def test_base_web_collector_conditional_request(base_web_collector_mock, base_web_collector):
+
+    import datetime
+
+    result = base_web_collector.send_get_request("https://test.org/comments",
+                                                  datetime.datetime(2020, 3, 20, 12))
+    assert result.text == ""
+    assert result.status_code == 304
+
+    result = base_web_collector.send_get_request("https://test.org/archive")
+    assert result is None
+
+
 def test_rss_collector(rss_collector_mock, rss_collector):
     from worker.tests.testdata import rss_collector_source_data
 
     result = rss_collector.collect(rss_collector_source_data)
 
     assert result is None
+
+def test_rss_collector_not_modified(rss_collector_mock, rss_collector):
+    from worker.tests.testdata import rss_collector_source_data_not_modified
+
+    result = rss_collector.collect(rss_collector_source_data_not_modified)
+
+    assert result == "RSS not modified"
+
+def test_rss_collector_no_content(rss_collector_mock, rss_collector):
+    from worker.tests.testdata import rss_collector_source_data_no_content
+
+    result = rss_collector.collect(rss_collector_source_data_no_content)
+
+    assert result == "RSS returned no content"
 
 
 def test_rss_collector_digest_splitting(rss_collector_mock, rss_collector):

--- a/src/worker/worker/tests/testdata.py
+++ b/src/worker/worker/tests/testdata.py
@@ -311,6 +311,12 @@ rss_collector_source_data_complex = {
     "type": "rss_collector",
     "word_lists": [],
 }
+rss_collector_url_not_modified = "https://rss.example.com/en/archive/feed/"
+rss_collector_source_data_not_modified = {"id": 1, "parameters": {"FEED_URL": f"{rss_collector_url_not_modified}"}}
+
+rss_collector_url_no_content = "https://rss.example.com/en/wrong-feed"
+rss_collector_source_data_no_content = {"id": 1, "parameters": {"FEED_URL": f"{rss_collector_url_no_content}"}}
+
 rss_collector_fav_icon_url = "https://rss.example.com/favicon.ico"
 rss_collector_targets = [
     "https://ai-policy.eu/blog/2024/1/ai-regulation-framework",


### PR DESCRIPTION
Add conditional request feature to Web Collectors

- BaseWebCollector has new send_get_request method, which allows sending GET requests with If-Modified-Since header and uses conditional requests in fetch_article_content method
- RSSCollector checks for entire non-modified RSS feeds and non-modified feed entries
- RTCollector checks for non-modified Tickets, Ticket attachements and attachement values
- SimpleWebCollector uses conditional requests via the fetch_article_content method from BaseWebCollector

Add additional tests to test_collector.py, but not sure if these tests are aligned with the overall testing strategy.
@Reviewer, feel free to comment on that

## Summary by Sourcery

Implement conditional requests for web collectors to avoid fetching unchanged content.

New Features:
- Add support for conditional GET requests using the `If-Modified-Since` header to reduce the amount of data transferred when content has not changed since the last retrieval.

Tests:
- Add tests for conditional requests in `test_collector.py`.