### PR TITLE
Variable error messages when updating bots

### DIFF
--- a/src/gui/src/views/admin/BotsView.vue
+++ b/src/gui/src/views/admin/BotsView.vue
@@ -150,15 +150,14 @@ export default {
         })
     }
 
-    const updateItem = (item) => {
-      updateBot(item)
-        .then(() => {
-          notifySuccess(`Successfully updated ${item.name}`)
-          updateData()
-        })
-        .catch(() => {
-          notifyFailure(`Failed to update ${item.name}`)
-        })
+    async function updateItem(item) {
+      try {
+        const result = await updateBot(item)
+        notifySuccess(result.data.message)
+        updateData()
+      } catch (error) {
+        notifyFailure(error)
+      }
     }
 
     const selectionChange = (new_selection) => {


### PR DESCRIPTION
When updating a Bot failed, the user only got the template error message: "Failed to update <bot_id>"
By making the updateItem a function in BotView.vue, we can print more meaningful error messages that help the user figure out what the problem was without looking into the python logs.

E.g.: When giving an invalid REFRESH_INTERVAL
![image](https://github.com/user-attachments/assets/e025d0e5-3e05-48fc-81ca-498b3d882b07)

![image](https://github.com/user-attachments/assets/56d507d9-d1f4-4e80-aaf1-566ec7d45af9)

## Summary by Sourcery

Improve bot update error messages to provide more specific information about the failure.

Bug Fixes:
- Display more informative error messages when updating bots, instead of a generic message.

Enhancements:
- Refactor the `updateItem` method in `BotView.vue` to use async/await.