### PR TITLE
Refactor custom result backend

### DIFF
--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -50,6 +50,8 @@ def initialize(app: Flask):
 
 
 def serialize_result(result: Optional[dict | str] = None):
+    if result is None:
+        return None
 
     if "exc_message" in result:
         if isinstance(result["exc_message"], (list, tuple)):

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -9,7 +9,6 @@ from core.model.word_list import WordList
 from core.model.token_blacklist import TokenBlacklist
 from core.model.product import Product
 from core.config import Config
-from typing import Optional
 
 
 class Task(MethodView):

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -57,20 +57,20 @@ def serialize_result(result: Optional[dict | str] = None):
         if isinstance(result["exc_message"], (list, tuple)):
             return " ".join(result["exc_message"])
         return result["exc_message"]
-    
+
     if "message" in result:
         return result["message"]
     return result
 
 
-def handle_task_specific_result(task_id: str, result: Optional[dict | str] = None) -> bool:        
-        if task_id.startswith("gather_word_list"):
-            WordList.update_word_list(**result)
-        elif task_id.startswith("cleanup_token_blacklist"):
-            TokenBlacklist.delete_older(datetime.now() - timedelta(days=1))
-        elif task_id.startswith("presenter_task"):
-            rendered_product = result.get("render_result", {}).get("data", "")
-            Product.update_render_for_id(result.get("product_id"), rendered_product.encode("utf-8"))
-        else:
-            return False
-        return True
+def handle_task_specific_result(task_id: str, result: dict | str) -> bool:
+    if task_id.startswith("gather_word_list"):
+        WordList.update_word_list(**result)
+    elif task_id.startswith("cleanup_token_blacklist"):
+        TokenBlacklist.delete_older(datetime.now() - timedelta(days=1))
+    elif task_id.startswith("presenter_task"):
+        rendered_product = result.get("render_result", {}).get("data", "")
+        Product.update_render_for_id(result.get("product_id"), rendered_product.encode("utf-8"))
+    else:
+        return False
+    return True

--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -115,6 +115,14 @@ class TestEndToEndUser(PlaywrightHelpers):
             self.highlight_element(page.get_by_label("Value"), scroll=False).fill("dangerous")
             self.highlight_element(page.get_by_role("button", name="Add", exact=True), scroll=False).click()
 
+            # story should contain one attribute "test_key": "dangerous"
+            expect(page.locator("table > tbody > tr:nth-of-type(1) > td:nth-of-type(1) > div > div > div > div > input")).to_have_value(
+                "test_key"
+            )
+            expect(page.locator("table > tbody > tr:nth-of-type(1) > td:nth-of-type(2) > div > div > div > div > input")).to_have_value(
+                "dangerous"
+            )
+
             self.highlight_element(page.locator(".cm-activeLine").first, scroll=False).click()
             self.highlight_element(
                 page.locator("#form div").filter(has_text="Summary91›Enter your summary").get_by_role("textbox"), scroll=False
@@ -128,6 +136,41 @@ class TestEndToEndUser(PlaywrightHelpers):
             page.locator("div").filter(has_text="updated").nth(2).click()
             time.sleep(0.5)
             page.screenshot(path="./tests/playwright/screenshots/screenshot_edit_story_2.png")
+
+        def assert_edited_story():
+            self.highlight_element(page.locator('[class^="ml-auto mr-auto"] a')).click()
+
+            # title
+            expect(page.get_by_label("Title")).to_have_value("Genetic Engineering Data Theft by APT81")
+
+            # summary
+            expect(
+                page.locator("div").filter(has_text=re.compile(r"^Summary91")).get_by_role("textbox").locator(":first-child")
+            ).to_have_text("This story informs about the current security state.")
+
+            # comment
+            expect(
+                page.locator("div").filter(has_text=re.compile(r"^Comment91")).get_by_role("textbox").locator(":first-child")
+            ).to_have_text("I like this story, it needs to be reviewed.")
+
+            # tags
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(1) > span > div")).to_have_text("APT75")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(2) > span > div")).to_have_text("APT74")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(3) > span > div")).to_have_text("APT76")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(4) > span > div")).to_have_text("APT77")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(5) > span > div")).to_have_text("APT78")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(6) > span > div")).to_have_text("APT79")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(7) > span > div")).to_have_text("APT80")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div:nth-of-type(8) > span > div")).to_have_text("APT81")
+
+            # attributes
+            expect(page.locator("table > tbody > tr:nth-of-type(1) > td:nth-of-type(1) > div > div > div > div > input")).to_have_value(
+                "test_key"
+            )
+            expect(page.locator("table > tbody > tr:nth-of-type(1) > td:nth-of-type(2) > div > div > div > div > input")).to_have_value(
+                "dangerous"
+            )
+            self.highlight_element(page.get_by_role("button", name="Update", exact=True), scroll=False).click()
 
         def infinite_scroll_all_items():
             self.smooth_scroll(page.locator("div:nth-child(21)").first)
@@ -195,6 +238,7 @@ class TestEndToEndUser(PlaywrightHelpers):
         hotkeys()
         page.screenshot(path="./tests/playwright/screenshots/assess_landing_page.png")
         interact_with_story()
+        assert_edited_story()
 
         assert_stories()
 

--- a/src/worker/worker/http_backend.py
+++ b/src/worker/worker/http_backend.py
@@ -1,15 +1,22 @@
 from celery.backends.base import BaseBackend
 from worker.core_api import CoreApi
-from typing import Optional
 from celery.app.task import Context
+
 
 class HTTPBackend(BaseBackend):
     def __init__(self, app=None, **kwargs):
         super().__init__(app, **kwargs)
         self.core_api = CoreApi()
 
-    def store_result(self, task_id: str, result: Optional[dict | str | Exception], state: str,
-                     traceback: Optional[str]=None, request: Optional[Context]=None, **kwargs):
+    def store_result(
+        self,
+        task_id: str,
+        result: dict | str | Exception | None,
+        state: str,
+        traceback: str | None = None,
+        request: Context | None = None,
+        **kwargs,
+    ):
         data = {
             "task_id": task_id,
             "status": state,

--- a/src/worker/worker/http_backend.py
+++ b/src/worker/worker/http_backend.py
@@ -1,13 +1,15 @@
 from celery.backends.base import BaseBackend
 from worker.core_api import CoreApi
-
+from typing import Optional
+from celery.app.task import Context
 
 class HTTPBackend(BaseBackend):
     def __init__(self, app=None, **kwargs):
         super().__init__(app, **kwargs)
         self.core_api = CoreApi()
 
-    def store_result(self, task_id, result, state, traceback=None, request=None, **kwargs):
+    def store_result(self, task_id: str, result: Optional[dict | str | Exception], state: str,
+                     traceback: Optional[str]=None, request: Optional[Context]=None, **kwargs):
         data = {
             "task_id": task_id,
             "status": state,


### PR DESCRIPTION
- Store all failed Tasks, not only presenter_tasks
- Make post method a little cleaner

## Summary by Sourcery

Store results for all failed tasks, not just presenter tasks.

Bug Fixes:
- Store all failed tasks in the database, rather than only storing failed presenter tasks.

Enhancements:
- Clean up the post method implementation.