### PR TITLE
Remove ignore_result from BotTask & CollectorTask

### DIFF
--- a/src/worker/worker/bots/bot_tasks.py
+++ b/src/worker/worker/bots/bot_tasks.py
@@ -11,7 +11,6 @@ class BotTask(Task):
     priority = 2
     default_retry_delay = 60
     time_limit = 18000
-    ignore_result = True
 
     def __init__(self):
         self.core_api = CoreApi()

--- a/src/worker/worker/collectors/collector_tasks.py
+++ b/src/worker/worker/collectors/collector_tasks.py
@@ -65,7 +65,6 @@ class CollectorTask(Task):
     priority = 5
     default_retry_delay = 60
     time_limit = 300
-    ignore_result = True
 
     def __init__(self):
         self.core_api = CoreApi()


### PR DESCRIPTION
Remove ignore_result = True class variables from BotTask and CollectorTask, to allow them to send the results to the HTTPBackend

## Summary by Sourcery

Enhancements:
- Remove the `ignore_result` attribute from `BotTask` and `CollectorTask`.