### PR TITLE
Bugfix: 438 - sentimen_analysis_bot key error

### DIFF
--- a/src/worker/worker/bots/sentiment_analysis_bot.py
+++ b/src/worker/worker/bots/sentiment_analysis_bot.py
@@ -37,13 +37,17 @@ class SentimentAnalysisBot(BaseBot):
             news_items = story.get("news_items", [])
             for news_item in news_items:
                 text_content = news_item.get("content", "")
-                if sentiment := self.bot_api.api_post("/", {"text": text_content}):
-                    logger.debug(f"Received sentiment label: {sentiment['label']} with score: {sentiment['score']}")
-                    news_item_id = news_item["id"]
-                    results[news_item_id] = {
-                        "sentiment": sentiment["score"],
-                        "category": sentiment["label"],
-                    }
+                if response := self.bot_api.api_post("/", {"text": text_content}):
+                    if "error" in response:
+                        logger.error(response.get("error"))
+                    else:
+                        sentiment = response.get("sentiment")
+                        logger.debug(f"Received sentiment label: {sentiment['label']} with score: {sentiment['score']}")
+                        news_item_id = news_item["id"]
+                        results[news_item_id] = {
+                            "sentiment": sentiment["score"],
+                            "category": sentiment["label"],
+                        }
 
         return results
 

--- a/src/worker/worker/bots/sentiment_analysis_bot.py
+++ b/src/worker/worker/bots/sentiment_analysis_bot.py
@@ -34,20 +34,27 @@ class SentimentAnalysisBot(BaseBot):
     def analyze_news_items(self, stories: list) -> dict:
         results = {}
         for story in stories:
-            news_items = story.get("news_items", [])
-            for news_item in news_items:
+            for news_item in story.get("news_items", []):
                 text_content = news_item.get("content", "")
-                if response := self.bot_api.api_post("/", {"text": text_content}):
-                    if "error" in response:
-                        logger.error(response.get("error"))
-                    else:
-                        sentiment = response.get("sentiment")
-                        logger.debug(f"Received sentiment label: {sentiment['label']} with score: {sentiment['score']}")
-                        news_item_id = news_item["id"]
-                        results[news_item_id] = {
-                            "sentiment": sentiment["score"],
-                            "category": sentiment["label"],
-                        }
+                response = self.bot_api.api_post("/", {"text": text_content})
+
+                if not response:
+                    continue
+                if "error" in response:
+                    logger.error(response["error"])
+                    continue
+
+                sentiment = response.get("sentiment")
+                if not sentiment:
+                    continue
+
+                label = sentiment.get("label")
+                score = sentiment.get("score")
+                logger.debug(f"Received sentiment label: {label} with score: {score}")
+
+                news_item_id = news_item.get("id")
+                if news_item_id is not None:
+                    results[news_item_id] = {"sentiment": score, "category": label}
 
         return results
 


### PR DESCRIPTION
The sentiment_analysis_bot returns a response in the format:

- {"sentiment": {"label": <label>, "score": <score}} (nested dict) when successful
- {"error": <error_msg>} when not

analyze_news_items in worker/bots/sentiment_analysis_bot.py did not unpack the dict correctly
Fixed that and also added logging of unsuccessful sentiment_analysis_bot

## Summary by Sourcery

Fixes a bug in the sentiment_analysis_bot that caused a key error when the bot returned an error response. Adds logging for unsuccessful sentiment analysis bot responses.

Bug Fixes:
- Fixes a key error in the sentiment_analysis_bot when the bot returns an error response.

Enhancements:
- Adds logging for unsuccessful sentiment analysis bot responses.