### PR TITLE
Adding new OSINT Source is not possible due to an undefined variable

### DIFF
--- a/src/gui/src/components/assess/card/StoryActions.vue
+++ b/src/gui/src/components/assess/card/StoryActions.vue
@@ -1,5 +1,10 @@
 <template>
-  <div v-if="active" class="ml-auto mr-auto" style="width: fit-content" :data-testid="`story-actions-div-${story.id}`">
+  <div
+    v-if="active"
+    class="ml-auto mr-auto"
+    style="width: fit-content"
+    :data-testid="`story-actions-div-${story.id}`"
+  >
     <v-btn
       v-if="!reportView && !detailView"
       v-ripple="false"

--- a/src/gui/src/components/config/EditConfig.vue
+++ b/src/gui/src/components/config/EditConfig.vue
@@ -190,20 +190,18 @@ export default {
 
     const rulesDict = {
       required: (v) => Boolean(v) || 'Required',
-      email: (v) => /.+@.+\..+/.test(v) || 'E-mail must be valid',
-      filesize: (v) =>
-        Boolean(v.length == 0) ||
-        Boolean(v[0].size < 2 * 1024 * 1024) ||
-        'Filesize must be less than 2MB',
+      email: (v) => (v && /.+@.+\..+/.test(v)) || 'E-mail must be valid',
+      filesize: (v) => {
+        if (!v || !Array.isArray(v) || v.length === 0) return true
+        return v[0].size < 2 * 1024 * 1024 || 'Filesize must be less than 2MB'
+      },
       tlp: (v) =>
         ['red', 'amber', 'amber+strict', 'green', 'clear', undefined].includes(
           v
         ) ||
         'Invalid TLP allowed values: red, amber, amber+strict, green, clear',
       json: (v) => {
-        if (!v || v.length === 0) {
-          return true
-        }
+        if (!v || v.length === 0) return true
         try {
           JSON.parse(v)
           return true


### PR DESCRIPTION
Issue: when you expand an OSINT source `v` is undefined.

- add formatting fix

## Summary by Sourcery

Fixes a bug where the 'v' variable was undefined when expanding an OSINT source, and includes some formatting fixes.

Bug Fixes:
- Fixes an issue where the variable 'v' was undefined when expanding an OSINT source.

Enhancements:
- Improves the filesize validation rule to handle undefined or non-array values.