### PR TITLE
Bugfix/Wordlist cannot be updated

### DIFF
--- a/src/gui/src/components/config/WordListForm.vue
+++ b/src/gui/src/components/config/WordListForm.vue
@@ -167,6 +167,7 @@ export default {
       }
 
       const wordlistData = {
+        id: props.wordlistId,
         name: wordlist.value.name,
         description: wordlist.value.description,
         link: wordlist.value.link,


### PR DESCRIPTION
- Add missing ID in the wordlist object

Issue: The update was not possible as the PUT request was sent to `/word-list/undefined` endpoint

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where wordlists could not be updated because the ID was missing from the wordlist object.