### PR TITLE
Bugfix/rt collector

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -357,7 +357,16 @@ class Story(BaseModel):
 
     @classmethod
     def add_or_update(cls, data) -> "tuple[dict, int]":
-        return cls.add(data) if "id" not in data else cls.update(data["id"], data)
+        story_ids = [data.get("id")]
+        if "id" not in data:
+            return cls.add(data)
+        for news_item in data.get("news_items", []):
+            result, _ = cls.add_single_news_item(news_item)
+            story_id = result.get("story_id")
+            if story_id is not None:
+                story_ids.append(story_id)
+        cls.group_stories(story_ids)
+        return cls.update(data["id"], data)
 
     @classmethod
     def add(cls, data) -> "tuple[dict, int]":

--- a/src/core/tests/functional/test_worker.py
+++ b/src/core/tests/functional/test_worker.py
@@ -27,6 +27,65 @@ class TestWorkerApi:
         assert response.get_json()[0].get("title") == update_story_data["title"]
         assert response.get_json()[0].get("id") == stories[0]
 
+    def test_worker_story_update_with_new_news_item(self, client, stories, cleanup_story_update_data, cleanup_news_item, api_header):
+        """
+        This test updates the same story as before (using the story_id from the previous test)
+        by including new news items and adding an extra attribute.
+        It verifies that the total number of news_items in the story increases as expected.
+        """
+        # Get the current state of the story to know the original number of news items.
+        response = client.get(
+            f"{self.base_uri}/stories",
+            headers=api_header,
+            query_string={"story_id": stories[0]},
+        )
+        assert response.status_code == 200
+        original_story = response.get_json()[0]
+        original_news_items = original_story.get("news_items", [])
+        original_news_items_count = len(original_news_items)
+
+        print(f"{original_news_items=}")
+        print(f"{original_news_items_count=}")
+
+        update_data = cleanup_story_update_data.copy()
+        update_data["id"] = stories[0]  # reuse the story id from the previous test
+        update_data["news_items"] = [original_story.get("news_items", [])[0], cleanup_news_item]
+        update_data["attributes"].append({"key": "status", "value": "updated"})
+
+        response = client.post(
+            f"{self.base_uri}/stories",
+            json=update_data,
+            headers=api_header,
+        )
+        assert response.status_code == 200
+        result = response.get_json()
+        assert result.get("message") == "Story updated Successful"
+        assert result.get("id") == stories[0]
+
+        response = client.get(
+            f"{self.base_uri}/stories",
+            headers=api_header,
+            query_string={"story_id": stories[0]},
+        )
+        assert response.status_code == 200
+        updated_story = response.get_json()[0]
+        print(f"{updated_story=}")
+        assert updated_story.get("title") == update_data["title"]
+        assert updated_story.get("id") == stories[0]
+
+        updated_news_items = updated_story.get("news_items", [])
+        assert len(updated_news_items) == 2, f"Expected 2 news items, but got {len(updated_news_items)}"
+
+        for new_item in update_data["news_items"]:
+            assert any(item.get("id") == new_item["id"] for item in updated_news_items), (
+                f"News item {new_item['id']} was not found in the updated story."
+            )
+
+        attributes_in_story = updated_story.get("attributes", [])
+        assert any(attr.get("key") == "status" and attr.get("value") == "updated" for attr in attributes_in_story), (
+            "Updated attribute not found in the story."
+        )
+
 
 class TestWorkerStoryApi:
     base_uri = "/api/worker"

--- a/src/gui/src/components/assess/StoryEdit.vue
+++ b/src/gui/src/components/assess/StoryEdit.vue
@@ -61,11 +61,7 @@
               />
             </template>
           </attributes-table>
-          <story-links
-            v-model="story.links"
-            :news-items="story.news_items"
-            :disabled="hasRtId"
-          />
+          <story-links v-model="story.links" :news-items="story.news_items" />
 
           <v-spacer class="pt-1"></v-spacer>
           <v-btn

--- a/src/gui/src/components/assess/StoryEdit.vue
+++ b/src/gui/src/components/assess/StoryEdit.vue
@@ -24,6 +24,7 @@
             name="title"
             type="text"
             :rules="[rules.required]"
+            :disabled="hasRtId"
           />
           <code-editor
             v-model:content="story.summary"
@@ -47,7 +48,10 @@
 
           <edit-tags v-model="story.tags" />
 
-          <attributes-table v-model="filteredStoryAttributes">
+          <attributes-table
+            v-model="filteredStoryAttributes"
+            :disabled="hasRtId"
+          >
             <template #top>
               <v-btn
                 class="mt-4"
@@ -57,7 +61,11 @@
               />
             </template>
           </attributes-table>
-          <story-links v-model="story.links" :news-items="story.news_items" />
+          <story-links
+            v-model="story.links"
+            :news-items="story.news_items"
+            :disabled="hasRtId"
+          />
 
           <v-spacer class="pt-1"></v-spacer>
           <v-btn
@@ -65,7 +73,6 @@
             class="mt-5"
             type="submit"
             :color="hasRtId ? 'error' : 'success'"
-            :disabled="hasRtId"
           >
             {{ $t('button.update') }}
           </v-btn>

--- a/src/gui/src/components/assess/StoryLinks.vue
+++ b/src/gui/src/components/assess/StoryLinks.vue
@@ -14,7 +14,6 @@
     item-title="link"
     label="Links"
     multiple
-    :disabled="disabled"
   />
   <v-btn class="mt-5" color="primary" @click="updateLinksFromNewsItems">
     {{ $t('enter.updatelinks') }}
@@ -35,10 +34,6 @@ export default {
     newsItems: {
       type: Array,
       default: () => []
-    },
-    disabled: {
-      type: Boolean,
-      default: false
     }
   },
   emits: ['update:modelValue'],

--- a/src/gui/src/components/assess/StoryLinks.vue
+++ b/src/gui/src/components/assess/StoryLinks.vue
@@ -14,6 +14,7 @@
     item-title="link"
     label="Links"
     multiple
+    :disabled="disabled"
   />
   <v-btn class="mt-5" color="primary" @click="updateLinksFromNewsItems">
     {{ $t('enter.updatelinks') }}
@@ -34,6 +35,10 @@ export default {
     newsItems: {
       type: Array,
       default: () => []
+    },
+    disabled: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue'],

--- a/src/gui/src/components/common/AttributesTable.vue
+++ b/src/gui/src/components/common/AttributesTable.vue
@@ -18,6 +18,7 @@
             max-width="50%"
             class=""
             @click="showDialog = true"
+            :disabled="disabled"
           />
         </v-row>
         <slot name="top"></slot>
@@ -32,6 +33,7 @@
               flat
               hide-details
               @change="updateValue()"
+              :disabled="disabled"
             ></v-text-field>
           </td>
           <td>
@@ -92,7 +94,8 @@ import { computed, ref } from 'vue'
 const props = defineProps({
   modelValue: { type: Array, required: true, default: () => [] },
   headerFilter: { type: Array, default: () => ['key', 'value'] },
-  order: { type: Boolean, default: false }
+  order: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false }
 })
 
 const emit = defineEmits(['update:modelValue'])

--- a/src/worker/worker/collectors/rt_collector.py
+++ b/src/worker/worker/collectors/rt_collector.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 from urllib.parse import urlparse, urljoin
 import requests
+from datetime import datetime
 
 from worker.log import logger
 from worker.collectors.base_web_collector import BaseWebCollector, NoChangeError
@@ -146,7 +147,7 @@ class RTCollector(BaseWebCollector):
             hash=hashlib.sha256(for_hash.encode()).hexdigest(),
             title="attachment",
             content=decoded_content or "attachment without content",
-            published_date=attachment.get("Created", ""),
+            published_date=datetime.fromisoformat(created),
             author=author,
             review=source.get("review", ""),
             source=self.base_url,
@@ -208,9 +209,7 @@ class RTCollector(BaseWebCollector):
         self.last_attempted = self.get_last_attempted(source)
 
         logger.info(f"Searching for tickets with query: {self.search_query}")
-        response = self.send_get_request(
-            f"{self.api_url}tickets?query={self.search_query}", self.last_attempted
-        )
+        response = self.send_get_request(f"{self.api_url}tickets?query={self.search_query}", self.last_attempted)
 
         try:
             tickets_ids_list = [ticket.get("id") for ticket in response.json().get("items", [])]

--- a/src/worker/worker/tests/collectors/conftest.py
+++ b/src/worker/worker/tests/collectors/conftest.py
@@ -77,7 +77,6 @@ def base_web_collector_mock(requests_mock):
     requests_mock.get("https://test.org/429", status_code=429)
 
 
-
 @pytest.fixture
 def rss_collector_mock(requests_mock, collectors_mock):
     from worker.tests.testdata import rss_collector_url, rss_collector_fav_icon_url, rss_collector_targets
@@ -88,8 +87,7 @@ def rss_collector_mock(requests_mock, collectors_mock):
     requests_mock.get(rss_collector_targets[2], json={})
     requests_mock.get(rss_collector_fav_icon_url, json={})
     requests_mock.get(rss_collector_url, text=file_loader("test_rss_feed.xml"))
-    requests_mock.get(rss_collector_url_not_modified, text="", status_code=304,
-                      headers={"Last-Modified": "Sat, 01 Jan 2022 00:00:00 GMT"})
+    requests_mock.get(rss_collector_url_not_modified, text="", status_code=304, headers={"Last-Modified": "Sat, 01 Jan 2022 00:00:00 GMT"})
     requests_mock.get(rss_collector_url_no_content, text="", status_code=200)
 
 

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -174,7 +174,6 @@ def test_rt_collector_collect(rt_mock, rt_collector):
     import worker.tests.collectors.rt_testdata as rt_testdata
 
     result = rt_collector.collect(rt_testdata.rt_collector_source_data)
-
     assert result is None
 
 


### PR DESCRIPTION
#### RT Collector fixes:
- NewsItem objects conversion to dictionaries,
- Published date attribute converted to type Datetime,
- looping over the NewsItem attributes for matches fixed
#### Improvements
- Allowing to edit manually in an RT story: Summary, Comment, Tags, Links
#### Sidenotes
- Now it is not possible to handle case, when news items are removed - this is not relevant for RT, but could be for other usecases (MISP)

##### StoryEdit.vue for RT tickets
![image](https://github.com/user-attachments/assets/c6533531-1e98-43a5-9f7e-610b8a6db26d)


## Summary by Sourcery

Fixes a bug in the RT collector that prevented NewsItem objects from being correctly converted to dictionaries and ensures the published date is correctly converted to the Datetime type. It also fixes an issue with looping over NewsItem attributes for matches. Additionally, it allows manual editing of the Summary, Comment, Tags, and Links fields in an RT story.

Bug Fixes:
- Fixes a bug in the RT collector that prevented NewsItem objects from being correctly converted to dictionaries.
- Fixes an issue with looping over NewsItem attributes for matches.
- Ensures the published date is correctly converted to the Datetime type.

Enhancements:
- Allows manual editing of the Summary, Comment, Tags, and Links fields in an RT story.

## Summary by Sourcery

Fixes bugs in the RT collector related to NewsItem conversion, published date handling, and attribute matching. Also, it enhances the GUI to allow manual editing of specific fields in an RT story and disables editing of certain fields when a RT id is present.

Bug Fixes:
- Fixes a bug in the RT collector that prevented NewsItem objects from being correctly converted to dictionaries.
- Fixes an issue with looping over NewsItem attributes for matches.
- Ensures the published date is correctly converted to the Datetime type.
- Fixes an issue where existing stories were not being found due to incorrect attribute comparison logic.
- Fixes an issue where news_items were not converted to dictionaries before being passed to the core_api

Enhancements:
- Allows manual editing of the Summary, Comment, Tags, and Links fields in an RT story in the GUI.
- Disables editing of the title and attributes table in the GUI when an RT id is present.
- Adds a test case to verify story updates with new news items and attributes.
- Improves the logic for finding existing stories by iterating through attributes and comparing key-value pairs.
- Adds a post_init call to the queue manager to ensure it is initialized correctly.