### PR TITLE
Bugfix/Collector Error

### DIFF
--- a/src/core/core/__init__.py
+++ b/src/core/core/__init__.py
@@ -31,3 +31,4 @@ def initialize_managers(app: Flask, initial_setup: bool = True):
     api_manager.initialize(app)
     data_manager.initialize(initial_setup)
     schedule_manager.initialize()
+    queue_manager.queue_manager.post_init()

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -185,7 +185,6 @@ def initialize(app: Flask, initial_setup: bool = True):
             queue_manager.error = ""
         if initial_setup:
             logger.info(f"QueueManager initialized: {queue_manager._celery.broker_connection().as_uri()}")
-            queue_manager.post_init()
     except OperationalError:
         logger.error("Could not reach rabbitmq")
         queue_manager.error = "Could not reach rabbitmq"


### PR DESCRIPTION
Run queue_manager.post_init after instantiating schedule_manager, since it relies on an existing schedule_manager object

## Summary by Sourcery

Bug Fixes:
- Fixes an error caused by the queue manager relying on the schedule manager by initialising the queue manager after the schedule manager.