### PR TITLE
Fix name of sentiment_analysis_bot in compose.yml

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -227,7 +227,7 @@ services:
         max-file: "10"
 
 
-  sentiment_bot:
+  sentiment_analysis_bot:
     depends_on:
       workers:
         condition: service_healthy


### PR DESCRIPTION
The hostname of the sentiment analysis bot is by default **sentiment_analysis_bot** (in pre_seed_data.py)
In the compose.yml, the hostname was **sentiment_bot**

Rename hostname in compose.yml

## Summary by Sourcery

Bug Fixes:
- Fix the hostname of the sentiment analysis bot in compose.yml