### PR TITLE
Add SBOM generation

### DIFF
--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
-          retention-days: 30
+          retention-days: 90
           overwrite: true
           name: taranis_core_sbom.json
           path: ${{ runner.temp }}/taranis_core_sbom.json

--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -57,12 +57,20 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: src/gui/pnpm-lock.yaml
 
-      - name: Set Artifact Name
-        run: echo "TRACES_ARTIFACT_NAME=playwright-traces-build-core" >> ${GITHUB_ENV}
-
       - name: e2e tests
         id: e2e_tests
         run: uv run pytest --e2e-ci
+
+      - name: Create SBOM
+        run: uvx --from cyclonedx-bom cyclonedx-py environment '.venv' -o ${{ runner.temp }}/taranis_core_sbom.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          overwrite: true
+          name: taranis_core_sbom.json
+          path: ${{ runner.temp }}/taranis_core_sbom.json
 
       - name: Upload a e2e-test trace
         uses: actions/upload-artifact@v4
@@ -70,7 +78,7 @@ jobs:
         with:
           retention-days: 7
           overwrite: true
-          name: ${{ env.TRACES_ARTIFACT_NAME }}
+          name: playwright-traces-build-core
           path: src/core/trace.zip
 
 

--- a/.github/workflows/build_worker.yaml
+++ b/.github/workflows/build_worker.yaml
@@ -40,17 +40,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: src/gui/pnpm-lock.yaml
-
       - name: Install Playwright dependencies
         run: uv run playwright install --with-deps chromium
 

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -28,17 +28,6 @@ jobs:
       - name: Lint with ruff
         run: uv run ruff check --output-format=github .
 
-      - name: TEST TEST TEST Create SBOM
-        run: uvx cyclonedx-py environment '.venv' -o ${{ runner.temp }}/sbom.json
-
-      - name: TEST TEST TEST Upload SBOM
-        uses: actions/upload-artifact@v4
-        with:
-          retention-days: 1
-          overwrite: true
-          name: taranis_core_sbom_test.json
-          path: ${{ runner.temp }}/sbom.json
-
       - name: Run tests and capture output
         run: |
           {

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -28,6 +28,17 @@ jobs:
       - name: Lint with ruff
         run: uv run ruff check --output-format=github .
 
+      - name: TEST TEST TEST Create SBOM
+        run: uvx cyclonedx-py environment '.venv' -o ${{ runner.temp }}/sbom.json
+
+      - name: TEST TEST TEST Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 1
+          overwrite: true
+          name: taranis_core_sbom_test.json
+          path: ${{ runner.temp }}/sbom.json
+
       - name: Run tests and capture output
         run: |
           {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,13 @@ jobs:
             docker buildx imagetools create --tag ghcr.io/${REPOSITORY_OWNER}/${image}:${TAG} ghcr.io/${REPOSITORY_OWNER}/${image}:latest
           done
 
+      - name: Download latest SBOM artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=$(gh run list --workflow "build core" --status success --commit "${{ github.sha }}" --limit 1 --json databaseId --jq '.[0].databaseId')
+          gh run download $run_id -n taranis_core_sbom -D ${{ runner.temp }}
+
       - name: Release
         uses: softprops/action-gh-release@v2.0.6
         with:
@@ -63,3 +70,4 @@ jobs:
           files: |
             docker/compose.yml
             ${{ runner.temp }}/env.sample
+            ${{ runner.temp }}/taranis_core_sbom.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           run_id=$(gh run list --workflow "build core" --status success --commit "${{ github.sha }}" --limit 1 --json databaseId --jq '.[0].databaseId')
-          gh run download $run_id -n taranis_core_sbom -D ${{ runner.temp }}
+          gh run download $run_id -n taranis_core_sbom.json -D ${{ runner.temp }}
 
       - name: Release
         uses: softprops/action-gh-release@v2.0.6

--- a/src/core/core/managers/api_manager.py
+++ b/src/core/core/managers/api_manager.py
@@ -1,7 +1,6 @@
 from swagger_ui import api_doc
 from flask import jsonify
 from pathlib import Path
-from flask_caching import Cache
 from flask_cors import CORS
 
 from core.config import Config
@@ -9,7 +8,6 @@ import core.api as core_api
 
 
 def initialize(app):
-    Cache(app)
     CORS(app)
 
     app.url_map.strict_slashes = False

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "Flask-JWT-Extended",
     "yoyo-migrations",
     "Flask-SQLAlchemy",
-    "flask_caching",
     "click",
     "celery",
     "SQLAlchemy",


### PR DESCRIPTION
Add SBOM to Github Actions

## Summary by Sourcery

Add Software Bill of Materials (SBOM) generation to the project's GitHub Actions workflows and remove unused dependencies

New Features:
- Implement SBOM generation and artifact upload in GitHub Actions workflows

Bug Fixes:
- Remove redundant Cache initialization in API manager

CI:
- Modify build_core.yaml to generate and upload SBOM artifact
- Update release.yaml to download and include SBOM in release assets

Chores:
- Remove unused Flask-Caching dependency from core project
- Simplify build_worker.yaml by removing unnecessary Node.js and pnpm setup steps