### PR TITLE
Set frontendupstream port in dev/nginx.conf to default fronted port 5002

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -11,7 +11,7 @@ upstream sseupstream {
 }
 
 upstream frontendupstream {
-  server 127.0.0.1:5001;
+  server 127.0.0.1:5002;
 }
 
 server {


### PR DESCRIPTION
It was still at 5001

## Summary by Sourcery

Chores:
- Update nginx configuration to use the correct frontend port