### PR TITLE
Remove sync enums with db

### DIFF
--- a/src/core/core/managers/db_seed_manager.py
+++ b/src/core/core/managers/db_seed_manager.py
@@ -39,7 +39,7 @@ def pre_seed():
 
 
 def sync_enums(db_engine: Engine):
-    from core.model.worker import WORKER_CATEGORY, WORKER_TYPES, BOT_TYPES, COLLECTOR_TYPES, PRESENTER_TYPES, PUBLISHER_TYPES, CONNECTOR_TYPES
+    from core.model.worker import WORKER_CATEGORY, WORKER_TYPES, BOT_TYPES, COLLECTOR_TYPES, PRESENTER_TYPES, PUBLISHER_TYPES
     from core.model.parameter_value import PARAMETER_TYPES
 
     with db_engine.connect() as connection:
@@ -52,7 +52,6 @@ def sync_enums(db_engine: Engine):
         sync_enum_with_db(enum_type=PRESENTER_TYPES, connection=connection, table_column="product_type.type")
         sync_enum_with_db(enum_type=PUBLISHER_TYPES, connection=connection, table_column="publisher_preset.type")
         sync_enum_with_db(enum_type=PARAMETER_TYPES, connection=connection, table_column="parameter_value.type")
-        sync_enum_with_db(enum_type=CONNECTOR_TYPES, connection=connection, table_column="connector.type")
 
 
 def pre_seed_update(db_engine: Engine):


### PR DESCRIPTION
Remove the synchronisation of enums with DB temporarily.

## Summary by Sourcery

Enhancements:
- Remove the synchronization of CONNECTOR_TYPES enum from the database sync process