### PR TITLE
Change report type preseed to not contain report IDs

### DIFF
--- a/src/core/core/managers/pre_seed_data.py
+++ b/src/core/core/managers/pre_seed_data.py
@@ -328,7 +328,6 @@ bots = [
 
 report_types = [
     {
-        "id": 1,
         "title": "OSINT Report",
         "description": "Example OSINT Report provided by Taranis AI",
         "attribute_groups": [
@@ -360,7 +359,6 @@ report_types = [
         ],
     },
     {
-        "id": 2,
         "title": "Disinformation",
         "description": "Example Disinformation Report provided by Taranis AI",
         "attribute_groups": [
@@ -390,7 +388,6 @@ report_types = [
         ],
     },
     {
-        "id": 3,
         "title": "Vulnerability Report",
         "description": "Example Vulnerability Report provided by Taranis AI",
         "attribute_groups": [
@@ -483,7 +480,6 @@ report_types = [
         ],
     },
     {
-        "id": 4,
         "title": "CERT Report",
         "description": "Example CERT Report provided by Taranis AI",
         "attribute_groups": [


### PR DESCRIPTION
At the moment, we preseed the ReportTypes with fixed IDs, this seems to confuse the database and when a new ReportType is created manually from GUI, it starts incrementing from `id=1` and fails n-times until he hits a free ID. 
- Preseeding without a fixed ID fixes the issue

## Summary by Sourcery

Bug Fixes:
- Resolve issue with database ID incrementing by removing predefined IDs from report type preseeding