### PR TITLE
Fix validation of collapsed required report attributes

### DIFF
--- a/src/gui/src/components/analyze/ReportItem.vue
+++ b/src/gui/src/components/analyze/ReportItem.vue
@@ -92,6 +92,7 @@
                   v-model="expand_panel_groups"
                   class="mb-1"
                   multiple
+                  eager
                 >
                   <v-expansion-panel
                     :title="attribute_group"


### PR DESCRIPTION
Issue https://github.com/taranis-ai/taranis-ai/issues/464
When collapsing a v-expansion-panel with a v-text-field that has the required rule, it gets removed from the DOM and therefore validation is no longer done.

Adding vuetify "eager" prop to v-expansion-panel forces the children to be added to the DOM and therefore validation works as expected.

## Summary by Sourcery

Bug Fixes:
- Resolve validation problem for required form fields in collapsed expansion panels by ensuring child components remain in the DOM