### PR TITLE
Fix missing rules prop in AttributeStory.vue

### DIFF
--- a/src/gui/src/components/analyze/AttributeItem.vue
+++ b/src/gui/src/components/analyze/AttributeItem.vue
@@ -128,6 +128,7 @@
       :readonly="readOnly"
       :title="attributeItem.title"
       :report-item-id="reportItemId"
+      :required="attributeItem.required"
     />
     <AttributeAttachment
       v-if="attributeItem.type === 'ATTACHMENT'"

--- a/src/gui/src/components/analyze/AttributeStory.vue
+++ b/src/gui/src/components/analyze/AttributeStory.vue
@@ -5,6 +5,7 @@
     :label="title"
     :items="report_item_stories[reportItemId]"
     :multiple="multiple"
+    :rules="rules"
     closable-chips
     chips
     center-affix
@@ -49,10 +50,12 @@ export default {
       required: true
     },
     readOnly: { type: Boolean, default: false },
-    multiple: { type: Boolean, default: true }
+    multiple: { type: Boolean, default: true },
+    required: { type: Boolean, default: false }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
+    const rules = [(v) => v.length > 0 || 'Required']
     const store = useAnalyzeStore()
 
     const { report_item_stories } = storeToRefs(store)
@@ -74,7 +77,8 @@ export default {
         get: () => selected.value,
         set: updateSelected
       }),
-      report_item_stories
+      report_item_stories,
+      rules
     }
   }
 }


### PR DESCRIPTION
Fix missing prop in AttributeStory.vue leading to not enforcing required fields in of `attributes: Story` in preseed.