### PR TITLE
Fix/tlp enum

### DIFF
--- a/src/core/core/model/role.py
+++ b/src/core/core/model/role.py
@@ -18,6 +18,20 @@ class TLPLevel(StrEnum):
     AMBER = "amber"
     RED = "red"
 
+    def __lt__(self, other):
+        if not isinstance(other, TLPLevel):
+            return NotImplemented
+        return self._sort_order_ < other._sort_order_
+
+    def __le__(self, other):
+        return self == other or self < other
+
+    def __gt__(self, other):
+        return not self <= other
+
+    def __ge__(self, other):
+        return not self < other
+
 
 class Role(BaseModel):
     __tablename__ = "role"

--- a/src/core/core/model/role.py
+++ b/src/core/core/model/role.py
@@ -24,13 +24,19 @@ class TLPLevel(StrEnum):
         return self._sort_order_ < other._sort_order_
 
     def __le__(self, other):
-        return self == other or self < other
+        if not isinstance(other, TLPLevel):
+            return NotImplemented
+        return self._sort_order_ <= other._sort_order_
 
     def __gt__(self, other):
-        return not self <= other
+        if not isinstance(other, TLPLevel):
+            return NotImplemented
+        return self._sort_order_ > other._sort_order_
 
     def __ge__(self, other):
-        return not self < other
+        if not isinstance(other, TLPLevel):
+            return NotImplemented
+        return self._sort_order_ >= other._sort_order_
 
 
 class Role(BaseModel):

--- a/src/core/tests/functional/conftest.py
+++ b/src/core/tests/functional/conftest.py
@@ -163,3 +163,111 @@ def cleanup_story_update_data(rt_id_attribute):
             "http://example.com/2",
         ],
     }
+
+
+@pytest.fixture(scope="class")
+def test_user(app):
+    with app.app_context():
+        from core.model.user import User
+
+        user_data = {"id": 222, "name": "Test User", "username": "Test User", "organization": "Test Org", "roles": ["role1", "role2"]}
+        yield User.add(user_data)
+
+        User.delete(user_data["id"])
+
+
+@pytest.fixture(scope="class")
+def report_items(app, test_user):
+    with app.app_context():
+        from core.model.report_item import ReportItem, ReportItemAttribute
+        from core.model.report_item_type import ReportItemType
+        from core.model.report_item import AttributeType
+        from core.model.role import TLPLevel
+
+        report_types = ReportItemType.get_all_for_collector()
+        if not report_types:
+            raise ValueError("No report types found")
+        report_title_ids = {rt.title: rt.id for rt in report_types}
+        osint_repot_id = report_title_ids.get("OSINT Report")
+        cert_repot_id = report_title_ids.get("CERT Report")
+
+        report_item1_data = {
+            "id": "c285fe34-474d-4197-8b1a-564ee46e13f5",
+            "title": "OSINT report Item with TLP:Clear",
+            "completed": False,
+            "report_item_type_id": osint_repot_id,
+        }
+
+        report_item2_data = {
+            "id": "3f98a483-ede6-4614-b329-76f85163d810",
+            "title": "OSINT report Item with TLP:Red",
+            "completed": False,
+            "report_item_type_id": osint_repot_id,
+        }
+
+        report_item3_data = {
+            "id": "4f61e069-bbd0-4fdc-b719-db2a801cb7de",
+            "title": "CERT Report Item without TLP level",
+            "completed": False,
+            "report_item_type_id": cert_repot_id,
+        }
+
+        report_item1, _ = ReportItem.add(report_item1_data, test_user)
+        report_item2, _ = ReportItem.add(report_item2_data, test_user)
+        report_item3, _ = ReportItem.add(report_item3_data, test_user)
+
+        clear_tlp_attr = ReportItemAttribute(attribute_type=AttributeType.TLP, group_title="Summary", value=TLPLevel.CLEAR.value)
+
+        red_tlp_attr = ReportItemAttribute(attribute_type=AttributeType.TLP, group_title="Summary", value=TLPLevel.AMBER.value)
+
+        report_item1.attributes.append(clear_tlp_attr)
+        report_item2.attributes.append(red_tlp_attr)
+
+        yield report_item1, report_item2, report_item3
+
+        ReportItem.delete_all()
+
+
+@pytest.fixture(scope="function")
+def stories_with_tlp(app, fake_source):
+    with app.app_context():
+        from core.model.story import Story, StoryNewsItemAttribute
+        from core.model.news_item import NewsItem
+        from core.model.news_item_attribute import NewsItemAttribute
+        from core.model.role import TLPLevel
+
+        news_items = [
+            {
+                "id": "tlp-news-001",
+                "title": "TLP News Item",
+                "content": "This is TLP-related content.",
+                "source": "https://example.com/news/tlp",
+                "osint_source_id": fake_source,
+                "collected": "2024-01-01T00:00:00",
+                "published": "2024-01-01T00:00:00",
+                "review": "Some review",
+                "hash": "tlp-news-hash",
+                "attributes": [{"key": "TLP", "value": TLPLevel.GREEN.value}],
+            },
+            {
+                "id": "plain-news-002",
+                "title": "Plain News Item",
+                "content": "This is just a regular news item.",
+                "source": "https://example.com/news/plain",
+                "osint_source_id": fake_source,
+                "collected": "2024-01-01T01:00:00",
+                "published": "2024-01-01T01:00:00",
+                "review": "Another review",
+                "hash": "plain-news-hash",
+            },
+        ]
+
+        result, _ = Story.add_news_items(news_items)
+        story_ids = result.get("story_ids")
+
+        yield story_ids
+
+        StoryNewsItemAttribute.delete_all()
+        NewsItem.delete_all()
+        NewsItemAttribute.delete_all()
+        Story.delete_all()

--- a/src/core/tests/functional/conftest.py
+++ b/src/core/tests/functional/conftest.py
@@ -262,9 +262,7 @@ def stories_with_tlp(app, fake_source):
         ]
 
         result, _ = Story.add_news_items(news_items)
-        story_ids = result.get("story_ids")
-
-        yield story_ids
+        yield result.get("story_ids")
 
         StoryNewsItemAttribute.delete_all()
         NewsItem.delete_all()

--- a/src/core/tests/functional/conftest.py
+++ b/src/core/tests/functional/conftest.py
@@ -217,7 +217,6 @@ def report_items(app, test_user):
         report_item3, _ = ReportItem.add(report_item3_data, test_user)
 
         clear_tlp_attr = ReportItemAttribute(attribute_type=AttributeType.TLP, group_title="Summary", value=TLPLevel.CLEAR.value)
-
         red_tlp_attr = ReportItemAttribute(attribute_type=AttributeType.TLP, group_title="Summary", value=TLPLevel.AMBER.value)
 
         report_item1.attributes.append(clear_tlp_attr)

--- a/src/core/tests/functional/test_rbac.py
+++ b/src/core/tests/functional/test_rbac.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+from core.model.role import TLPLevel
+from core.managers.db_manager import db
+
+
+class TestRBAC:
+    def test_filter_report_query_with_tlp(self, report_items):
+        from core.model.report_item import ReportItem
+        from core.service.role_based_access import RoleBasedAccessService
+
+        item1, item2, item3 = report_items
+
+        mock_user = Mock()
+
+        # User has TLP:Green -> Should see only Report Item with TLP:Clear
+        mock_user.get_highest_tlp.return_value = TLPLevel.GREEN
+        query = ReportItem.query
+        results = RoleBasedAccessService.filter_report_query_with_tlp(query, mock_user).all()
+
+        result_ids = {r.id for r in results}
+        assert item1.id in result_ids
+        assert item2.id not in result_ids
+        assert item3.id not in result_ids
+
+        # User has TLP:Amber -> Should see Report Items with TLP:Clear & TLP:Amber
+        mock_user.get_highest_tlp.return_value = TLPLevel.AMBER
+        query = ReportItem.query
+        results = RoleBasedAccessService.filter_report_query_with_tlp(query, mock_user).all()
+        result_ids = {r.id for r in results}
+        assert item1.id in result_ids
+        assert item2.id in result_ids
+        assert item3.id not in result_ids
+
+        # User has TLP:Red -> Should see all Report Items
+        mock_user.get_highest_tlp.return_value = TLPLevel.RED
+        query = ReportItem.query
+        results = RoleBasedAccessService.filter_report_query_with_tlp(query, mock_user).all()
+        result_ids = {r.id for r in results}
+        assert item1.id in result_ids
+        assert item2.id in result_ids
+        assert item3.id in result_ids
+
+        # User has no TLP level set -> Should see all Report Items
+        mock_user.get_highest_tlp.return_value = None
+        query = ReportItem.query
+        results = RoleBasedAccessService.filter_report_query_with_tlp(query, mock_user).all()
+        result_ids = {r.id for r in results}
+        assert item1.id in result_ids
+        assert item2.id in result_ids
+        assert item3.id in result_ids
+        db.session.remove()
+
+    def test_filter_query_with_tlp(self, stories_with_tlp):
+        from core.model.story import Story
+        from core.service.role_based_access import RoleBasedAccessService
+
+        mock_user = Mock()
+
+        # User has only TLP level Clear -> lowest Story TLP level is Green -> empty set
+        mock_user.get_highest_tlp.return_value = TLPLevel.CLEAR
+        results = RoleBasedAccessService.filter_query_with_tlp(Story.query, mock_user).all()
+        assert results == []
+
+        # User has TLP level Green -> should see the TLP Green story
+        mock_user.get_highest_tlp.return_value = TLPLevel.GREEN
+        results = RoleBasedAccessService.filter_query_with_tlp(Story.query, mock_user).all()
+        result_ids = {story.id for story in results}
+        assert stories_with_tlp[0] in result_ids
+        assert stories_with_tlp[1] not in result_ids
+
+        # User has TLP level Red -> should see all stories
+        mock_user.get_highest_tlp.return_value = TLPLevel.RED
+        results = RoleBasedAccessService.filter_query_with_tlp(Story.query, mock_user).all()
+        result_ids = {story.id for story in results}
+        assert stories_with_tlp[0] in result_ids
+        assert stories_with_tlp[1] in result_ids
+
+        # User has no TLP level -> should see all stories
+        mock_user.get_highest_tlp.return_value = TLPLevel.RED
+        results = RoleBasedAccessService.filter_query_with_tlp(Story.query, mock_user).all()
+        result_ids = {story.id for story in results}
+        assert stories_with_tlp[0] in result_ids
+        assert stories_with_tlp[1] in result_ids
+
+        db.session.remove()

--- a/src/core/tests/functional/test_rbac.py
+++ b/src/core/tests/functional/test_rbac.py
@@ -76,7 +76,7 @@ class TestRBAC:
         assert stories_with_tlp[1] in result_ids
 
         # User has no TLP level -> should see all stories
-        mock_user.get_highest_tlp.return_value = TLPLevel.RED
+        mock_user.get_highest_tlp.return_value = None
         results = RoleBasedAccessService.filter_query_with_tlp(Story.query, mock_user).all()
         result_ids = {story.id for story in results}
         assert stories_with_tlp[0] in result_ids


### PR DESCRIPTION
-  Fixes the incorrect comparison of TLP levels in https://github.com/taranis-ai/taranis-ai/blob/master/src/core/core/service/role_based_access.py filter_query_with_tlp & filter_report_query_with_tlp methods

-  Adds test cases for TLP level access

## Summary by Sourcery

Improve TLP (Traffic Light Protocol) level comparison and access control in the application

Bug Fixes:
- Fix incorrect TLP level comparison in role-based access filtering methods

Enhancements:
- Add comparison methods to TLPLevel enum to enable proper ordering of TLP levels

Tests:
- Add comprehensive test cases for TLP-based access control in report items and stories
- Implement test fixtures to validate TLP level filtering across different user access levels