### PR TITLE
Add note about MISP in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See [taranis.ai](https://taranis.ai/docs/) for documentation of user stories and
 * Analyst-Friendly Workflow: Offers a streamlined process where analysts can easily convert unstructured news into structured report items, optimizing the data transformation journey.
 * Multi-Format Output: Generates a variety of end products, including structured reports and PDF files, tailored to specific informational needs.
 * Seamless Publishing: Facilitates the effortless publication of finalized intelligence products, ensuring timely dissemination of critical information.
+* Collaborative Threat Intelligence (Experimental): Supports Story-level sharing between Taranis AI instances via [MISP](https://www.misp-project.org/), or directly between Taranis AI and MISP for flexible collaboration and information dissemination.
 
 ### OpenAPI
 


### PR DESCRIPTION
- Can we do it?
- Yes we can!

## Summary by Sourcery

Documentation:
- Add a note about experimental support for collaborative threat intelligence sharing via MISP.