### PR TITLE
Bugfix/misp collector task result

### DIFF
--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -29,6 +29,7 @@ class Task(MethodView):
         status = data.get("status")
 
         logger.debug(f"Received task result with id {task_id} and status {status}")
+        logger.debug(f"{data=}")
 
         if not result or "error" in result or status == "FAILURE":
             TaskModel.add_or_update({"id": task_id, "result": serialize_result(result), "status": status})
@@ -55,11 +56,10 @@ def serialize_result(result: dict | str | None = None):
 
     if isinstance(result, str):
         return result
-
     if "exc_message" in result:
         if isinstance(result["exc_message"], (list, tuple)):
             logger.debug(f"{result["exc_message"]=}")
-            return " ".join(result["exc_message"])
+            return " ".join(map(str, result["exc_message"]))
         return result["exc_message"]
 
     if "message" in result:

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -58,6 +58,7 @@ def serialize_result(result: dict | str | None = None):
 
     if "exc_message" in result:
         if isinstance(result["exc_message"], (list, tuple)):
+            logger.debug(f"{result["exc_message"]=}")
             return " ".join(result["exc_message"])
         return result["exc_message"]
 

--- a/src/worker/worker/collectors/misp_collector.py
+++ b/src/worker/worker/collectors/misp_collector.py
@@ -58,6 +58,7 @@ class MISPCollector(BaseCollector):
 
         events: list[dict] = [misp.get_event(event_id) for event_id in event_ids]  # type: ignore
         logger.debug(f"{events=}")
+        logger.debug(f"{len(events)=}")
         story_dicts = [
             self.get_story(event, source)
             for event in events


### PR DESCRIPTION
Task result is not parsed correctly in the case the TimeLimitExceeded is returned.
```
result={'exc_type': 'TimeLimitExceeded', 'exc_message': [300], 'exc_module': 'billiard.exceptions'}
```
- fixed its serialization
- added a debug line to see result in debug mode