### PR TITLE
Streamline publishing of misp stories and add osint source status update

### DIFF
--- a/src/core/core/managers/pre_seed_data.py
+++ b/src/core/core/managers/pre_seed_data.py
@@ -68,6 +68,24 @@ workers = [
         "type": "RT_COLLECTOR",
     },
     {
+        "type": "MISP_COLLECTOR",
+        "name": "MISP Collector",
+        "description": "Colletor for MISP",
+        "parameters": [
+            {"parameter": "URL", "rules": "required"},
+            {"parameter": "API_KEY", "rules": "required"},
+            {"parameter": "ORGANISATION_ID", "rules": "required"},
+            {"parameter": "SHARING_GROUP_ID"},
+            {"parameter": "TLP_LEVEL", "rules": "tlp"},
+            {"parameter": "SSL_CHECK", "type": "switch"},
+            {"parameter": "REQUEST_TIMEOUT", "type": "number"},
+            {"parameter": "USER_AGENT"},
+            {"parameter": "PROXY_SERVER"},
+            {"parameter": "ADDITIONAL_HEADERS", "rules": "json"},
+            {"parameter": "REFRESH_INTERVAL", "type": "cron_interval"},
+        ],
+    },
+    {
         "type": "ANALYST_BOT",
         "name": "Analyst Bot",
         "parameters": [
@@ -262,23 +280,6 @@ workers = [
             {"parameter": "REFRESH_INTERVAL", "type": "cron_interval"},
             {"parameter": "SHARING_GROUP_ID"},
             {"parameter": "DISTRIBUTION"},
-        ],
-    },
-    {
-        "type": "MISP_COLLECTOR",
-        "name": "MISP Collector",
-        "description": "Colletor for MISP",
-        "parameters": [
-            {"parameter": "URL", "rules": "required"},
-            {"parameter": "API_KEY", "rules": "required"},
-            {"parameter": "ORGANISATION_ID", "rules": "required"},
-            {"parameter": "SSL_CHECK", "type": "switch"},
-            {"parameter": "REQUEST_TIMEOUT", "type": "number"},
-            {"parameter": "USER_AGENT"},
-            {"parameter": "PROXY_SERVER"},
-            {"parameter": "ADDITIONAL_HEADERS", "rules": "json"},
-            {"parameter": "REFRESH_INTERVAL", "type": "cron_interval"},
-            {"parameter": "SHARING_GROUP_ID"},
         ],
     },
 ]

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -402,7 +402,7 @@ class Story(BaseModel):
             if code != 200 and message.get("error") == "Story already exists":
                 logger.warning(f"Story being added {data['id']} contains existing content. A conflict is raised.")
                 cls.handle_conflicting_news_items(data)
-                return {"error": f"Story being added {data['id']} contains existing content. A conflict is raised."}, code
+                return {"warning": f"Story being added {data['id']} contains existing content. A conflict is raised."}, code
             return message, code
 
         if not conflict:

--- a/src/worker/worker/collectors/base_collector.py
+++ b/src/worker/worker/collectors/base_collector.py
@@ -109,6 +109,17 @@ class BaseCollector:
 
         return news_items
 
+    def process_news_items_in_stories(self, stories: list[dict], source: dict, story_attribute_key: str | None = None) -> list[dict]:
+        processed_stories = []
+        for story in stories:
+            new_story = story.copy()
+            if news_items := new_story.get("news_items"):
+                processed_news_items = self.process_news_items(news_items, source)
+                new_story["news_items"] = [item.to_dict() for item in processed_news_items]
+                logger.debug(f"{new_story['news_items']=}")
+            processed_stories.append(new_story)
+        return processed_stories
+
     def publish(self, news_items: list[NewsItem], source: dict):
         news_items = self.process_news_items(news_items, source)
         logger.info(f"Publishing {len(news_items)} news items to core api")
@@ -129,21 +140,13 @@ class BaseCollector:
             return self.publish(news_items, source)
 
         stories_for_publishing = self.find_existing_stories(story_lists, story_attribute_key, source)
+        processed_stories = self.process_news_items_in_stories(stories_for_publishing, source, story_attribute_key)
 
-        processed_stories = []
-        for story in stories_for_publishing:
-            new_story = story.copy()
-            if news_items := new_story.get("news_items"):
-                processed_news_items = self.process_news_items(news_items, source)
-                new_story["news_items"] = [item.to_dict() for item in processed_news_items]
-                logger.debug(f"{new_story['news_items']=}")
-            processed_stories.append(new_story)
-
-        if processed_stories[0].get("id"):
-            self.publish_misp_stories(processed_stories, story_attribute_key, source)
-
+        if story_attribute_key == "misp_event_uuid":
+            processed_stories = self.prepare_misp_stories(processed_stories, story_attribute_key, source)
         for story in processed_stories:
             self.core_api.add_or_update_story(story)
+        self.core_api.update_osintsource_status(source["id"], None)
 
     def find_existing_stories(self, new_stories: list[dict], story_attribute_key: str, source: dict) -> list[dict]:
         existing_stories = self.core_api.get_stories({"source": source["id"]})
@@ -173,7 +176,8 @@ class BaseCollector:
 
         return new_stories
 
-    def publish_misp_stories(self, story_lists: list[dict], story_attribute_key: str, source: dict):
+    def prepare_misp_stories(self, story_lists: list[dict], story_attribute_key: str, source: dict) -> list[dict]:
+        stories = []
         for story in story_lists:
             if existing_story := self.core_api.get_stories({"story_id": story.get("id")}):
                 if len(existing_story) > 1:
@@ -186,7 +190,8 @@ class BaseCollector:
                 if news_items_to_delete := self.get_news_items_to_delete(story, existing_story[0]):
                     story["news_items_to_delete"] = news_items_to_delete
 
-                self.core_api.add_or_update_story(story)
+            stories.append(story)
+        return stories
 
     def check_internal_changes(self, existing_story) -> bool:
         if existing_story.get("last_change") == "internal":

--- a/src/worker/worker/collectors/misp_collector.py
+++ b/src/worker/worker/collectors/misp_collector.py
@@ -43,33 +43,7 @@ class MISPCollector(BaseCollector):
 
     def collect(self, source: dict, manual: bool = False) -> None:
         self.parse_parameters(source.get("parameters", ""))
-
-        misp = PyMISP(url=self.url, key=self.api_key, ssl=self.ssl, proxies=self.proxies, http_headers=self.headers)
-
-        # Note: searching here directly for objects that belong to a sharing group by id using the sharinggroup parameter does not work in 2.5.2.
-        # It seems to completely ingnore the sharinggroup parameter and return all objects. The objects controller is poorly documented.
-        taranis_objects: list[MISPObject] = misp.search(controller="objects", object_name="taranis-news-item", pythonify=True)  # type: ignore
-
-        logger.debug(f"{taranis_objects=}")
-        event_ids = set()
-        for obj in taranis_objects:
-            event_ids.add(obj.event_id)  # type: ignore
-            print(f"Object ID: {obj.id}, Event ID: {obj.event_id}, Object Name: {obj.name}")  # type: ignore
-
-        events: list[dict] = [misp.get_event(event_id) for event_id in event_ids]  # type: ignore
-        logger.debug(f"{events=}")
-        story_dicts = [
-            self.get_story(event, source)
-            for event in events
-            if (not self.sharing_group_id or str(event.get("Event", {}).get("sharing_group_id")) == str(self.sharing_group_id))
-        ]
-        story_dicts: list[dict] = [s for s in story_dicts if s is not None]
-
-        for story in story_dicts:
-            if self.check_for_proposal_existence(misp, story.get("id", "")):
-                story["has_proposals"] = f"{self.url}/events/view/{story.get('id')}"
-        logger.debug(f"{story_dicts=}")
-        self.publish_or_update_stories(story_dicts, source, story_attribute_key="misp_event_uuid")
+        return self.misp_collector(source)
 
     def check_for_proposal_existence(self, misp, event_uuid) -> bool:
         resp = misp._prepare_request("GET", f"shadow_attributes/index/{event_uuid}")
@@ -233,6 +207,35 @@ class MISPCollector(BaseCollector):
             logger.error(f"The Taranis event is malformed and does not contain the required properties: {story_properties=}")
             raise RuntimeError("The Taranis event is malformed and does not contain the required properties")
         return self.to_story_dict(story_properties, story_news_items, event.get("Event", {}).get("uuid"))
+
+    def misp_collector(self, source: dict) -> None:
+        misp = PyMISP(url=self.url, key=self.api_key, ssl=self.ssl, proxies=self.proxies, http_headers=self.headers)
+
+        # Note: searching here directly for objects that belong to a sharing group by id using the sharinggroup parameter does not work in 2.5.2.
+        # It seems to completely ingnore the sharinggroup parameter and return all objects. The objects controller is poorly documented.
+        taranis_objects: list[MISPObject] = misp.search(controller="objects", object_name="taranis-news-item", pythonify=True)  # type: ignore
+
+        logger.debug(f"{taranis_objects=}")
+        event_ids = set()
+        for obj in taranis_objects:
+            event_ids.add(obj.event_id)  # type: ignore
+            print(f"Object ID: {obj.id}, Event ID: {obj.event_id}, Object Name: {obj.name}")  # type: ignore
+
+        events: list[dict] = [misp.get_event(event_id) for event_id in event_ids]  # type: ignore
+        logger.debug(f"{events=}")
+        story_dicts = [
+            self.get_story(event, source)
+            for event in events
+            if (not self.sharing_group_id or str(event.get("Event", {}).get("sharing_group_id")) == str(self.sharing_group_id))
+        ]
+        story_dicts: list[dict] = [s for s in story_dicts if s is not None]
+
+        for story in story_dicts:
+            if self.check_for_proposal_existence(misp, story.get("id", "")):
+                story["has_proposals"] = f"{self.url}/events/view/{story.get('id')}"
+        logger.debug(f"{story_dicts=}")
+        self.publish_or_update_stories(story_dicts, source, story_attribute_key="misp_event_uuid")
+        return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean `publish_or_update_stories` method and prevent double submission to core.