### PR TITLE
Fix vanishing stories in pagination view

### DIFF
--- a/src/core/core/config.py
+++ b/src/core/core/config.py
@@ -117,8 +117,9 @@ class Settings(BaseSettings):
         return self
 
     @field_validator("JWT_SECRET_KEY", "API_KEY", mode="before")
-    def check_non_empty_string(cls, v: str, info: ValidationInfo) -> str:
-        if not isinstance(v, str) or not v.strip():
+    def check_non_empty_string_or_secret(cls, v, info: ValidationInfo) -> str | SecretStr:
+        value = v.get_secret_value() if isinstance(v, SecretStr) else v
+        if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{info.field_name} must be a non-empty string")
         return v
 

--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -382,7 +382,6 @@ export const useAssessStore = defineStore(
       updateStories()
     }
 
-
     function reset() {
       osint_sources.value = { total_count: 0, items: [] }
       osint_source_groups.value = { total_count: 0, items: [] }

--- a/src/gui/src/views/users/AssessView.vue
+++ b/src/gui/src/views/users/AssessView.vue
@@ -22,7 +22,7 @@
       </template>
       <template #loading />
     </v-infinite-scroll>
-    <div v-if="storySelection.length > 0" class="mb-16"></div>
+    <div v-if="infiniteScroll && storySelection.length > 0" class="mb-16"></div>
     <v-container v-else-if="stories.items.length > 0 && !infiniteScroll" fluid>
       <template v-for="item in stories.items" :key="item.id">
         <card-story :story="item" @refresh="refresh(item.id)" />
@@ -87,7 +87,7 @@ export default defineComponent({
     const { stories, loading, storyCounts, storySelection } =
       storeToRefs(assessStore)
     const { storyFilter, storyPage, infiniteScroll } = storeToRefs(filterStore)
-
+    console.log(storySelection)
     let doneCallback = null
 
     assessHotkeys()


### PR DESCRIPTION
The conditional div, that keeps the StorySelectionToolbar away from the Load More button  should only appear if infinite scroll is activated

## Summary by Sourcery

Fix story pagination spacing issue and enhance configuration validation

Bug Fixes:
- Only render the spacing div between stories and the Load More button when infinite scroll is active to prevent content disappearance

Enhancements:
- Allow SecretStr values in JWT_SECRET_KEY and API_KEY validation by unwrapping and checking their secret values
- Add console logging for story selection state for debugging

Chores:
- Remove extraneous blank lines in store and view components