### PR TITLE
Fix order lists conflict resolution

### DIFF
--- a/src/core/core/model/news_item_tag.py
+++ b/src/core/core/model/news_item_tag.py
@@ -108,6 +108,29 @@ class NewsItemTag(BaseModel):
         return {tag_name: NewsItemTag(name=tag_name, tag_type=tag_type) for tag_name, tag_type in tags.items()}
 
     @classmethod
+    def _parse_dict_tags(cls, tags: dict) -> dict[str, "NewsItemTag"]:
+        """Parse tags from dict format - handles both old and new formats:
+        - Old: {"APT75": "UNKNOWN"}
+        - New: {"APT75": {"name": "APT75", "tag_type": "UNKNOWN"}}
+        """
+        parsed_tags = {}
+
+        for tag_key, tag_data in tags.items():
+            if isinstance(tag_data, dict):
+                name = tag_data.get("name", tag_key)
+                tag_type = tag_data.get("tag_type", "misc")
+            elif isinstance(tag_data, str):
+                name = tag_key
+                tag_type = tag_data
+            else:
+                name = tag_key
+                tag_type = "misc"
+
+            parsed_tags[name] = NewsItemTag(name=name, tag_type=tag_type)
+
+        return parsed_tags
+
+    @classmethod
     def _parse_list_tags(cls, tags: list) -> dict[str, "NewsItemTag"]:
         new_tags = {}
         for tag in tags:

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1007,13 +1007,13 @@ class Story(BaseModel):
     def to_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = [tag.to_dict() for tag in self.tags[:5]]
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags[:5]], key=lambda x: x["name"])
         return data
 
     def to_detail_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = [tag.to_dict() for tag in self.tags]
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
         data["attributes"] = [attribute.to_small_dict() for attribute in self.attributes]
         data["detail_view"] = True
         return data
@@ -1021,7 +1021,7 @@ class Story(BaseModel):
     def to_worker_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_dict() for news_item in self.news_items]
-        data["tags"] = [{"name": tag.name, "tag_type": tag.tag_type} for tag in self.tags]
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
         if attributes := self.attributes:
             data["attributes"] = [attribute.to_dict() for attribute in attributes]
         return data

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1007,13 +1007,13 @@ class Story(BaseModel):
     def to_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = [tag.to_dict() for tag in self.tags[:5]]
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags[:5]], key=lambda x: x["name"])
         return data
 
     def to_detail_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = [tag.to_dict() for tag in self.tags]
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
         data["attributes"] = [attribute.to_small_dict() for attribute in self.attributes]
         data["detail_view"] = True
         return data
@@ -1021,7 +1021,7 @@ class Story(BaseModel):
     def to_worker_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_dict() for news_item in self.news_items]
-        data["tags"] = {tag.name: tag.tag_type for tag in self.tags}
+        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
         if attributes := self.attributes:
             data["attributes"] = [attribute.to_dict() for attribute in attributes]
         return data

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1007,13 +1007,13 @@ class Story(BaseModel):
     def to_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = sorted([tag.to_dict() for tag in self.tags[:5]], key=lambda x: x["name"])
+        data["tags"] = [tag.to_dict() for tag in self.tags[:5]]
         return data
 
     def to_detail_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_detail_dict() for news_item in self.news_items]
-        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
+        data["tags"] = [tag.to_dict() for tag in self.tags]
         data["attributes"] = [attribute.to_small_dict() for attribute in self.attributes]
         data["detail_view"] = True
         return data
@@ -1021,7 +1021,7 @@ class Story(BaseModel):
     def to_worker_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_dict() for news_item in self.news_items]
-        data["tags"] = sorted([tag.to_dict() for tag in self.tags], key=lambda x: x["name"])
+        data["tags"] = [{"name": tag.name, "tag_type": tag.tag_type} for tag in self.tags]
         if attributes := self.attributes:
             data["attributes"] = [attribute.to_dict() for attribute in attributes]
         return data

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1021,7 +1021,7 @@ class Story(BaseModel):
     def to_worker_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_dict() for news_item in self.news_items]
-        data["tags"] = [{"name": tag.name, "tag_type": tag.tag_type} for tag in self.tags]
+        data["tags"] = {tag.name: tag.tag_type for tag in self.tags}
         if attributes := self.attributes:
             data["attributes"] = [attribute.to_dict() for attribute in attributes]
         return data

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1021,9 +1021,10 @@ class Story(BaseModel):
     def to_worker_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         data["news_items"] = [news_item.to_dict() for news_item in self.news_items]
-        data["tags"] = [{"name": tag.name, "tag_type": tag.tag_type} for tag in self.tags]
+        data["tags"] = {tag.name: tag.to_dict() for tag in self.tags}
         if attributes := self.attributes:
-            data["attributes"] = [attribute.to_dict() for attribute in attributes]
+            data["attributes"] = {attribute.key: attribute.to_small_dict() for attribute in attributes}
+
         return data
 
 

--- a/src/core/core/model/story_conflict.py
+++ b/src/core/core/model/story_conflict.py
@@ -57,46 +57,8 @@ class StoryConflict:
         return obj
 
     @classmethod
-    def _sort_recursively(cls, obj: Any) -> Any:
-        """
-        Recursively sort nested structures for deterministic ordering.
-        Handles dictionaries (sorted by keys), lists of dictionaries (sorted by 'name', 'key', or 'id').
-        Returns a new sorted object without modifying the original.
-        """
-        if isinstance(obj, dict):
-            return {key: cls._sort_recursively(value) for key, value in sorted(obj.items())}
-        elif isinstance(obj, list):
-            if obj and isinstance(obj[0], dict):
-                sort_key = None
-                if "name" in obj[0]:
-                    sort_key = "name"
-                elif "key" in obj[0]:
-                    sort_key = "key"
-                elif "id" in obj[0]:
-                    sort_key = "id"
-
-                if sort_key:
-                    try:
-                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: x.get(sort_key, ""))
-                    except (TypeError, KeyError):
-                        return [cls._sort_recursively(item) for item in obj]
-                else:
-                    try:
-                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: str(x))
-                    except TypeError:
-                        return [cls._sort_recursively(item) for item in obj]
-            else:
-                try:
-                    return sorted([cls._sort_recursively(item) for item in obj])
-                except TypeError:
-                    return [cls._sort_recursively(item) for item in obj]
-        else:
-            return obj
-
-    @classmethod
     def stable_stringify(cls, obj: Any, indent=2) -> str:
-        sorted_obj = cls._sort_recursively(obj)
-        return json.dumps(sorted_obj, sort_keys=True, indent=indent)
+        return json.dumps(obj, sort_keys=True, indent=indent, ensure_ascii=False)
 
     @classmethod
     def normalize_data(cls, current_data: dict[str, Any], new_data: dict[str, Any]) -> tuple[str, str]:

--- a/src/core/core/model/story_conflict.py
+++ b/src/core/core/model/story_conflict.py
@@ -58,8 +58,12 @@ class StoryConflict:
 
     @classmethod
     def _sort_recursively(cls, obj: Any) -> Any:
+        """
+        Recursively sort nested structures for deterministic ordering.
+        Handles dictionaries (sorted by keys), lists of dictionaries (sorted by 'name', 'key', or 'id').
+        Returns a new sorted object without modifying the original.
+        """
         if isinstance(obj, dict):
-            # Sort dictionary keys and recursively sort values
             return {key: cls._sort_recursively(value) for key, value in sorted(obj.items())}
         elif isinstance(obj, list):
             if obj and isinstance(obj[0], dict):
@@ -92,7 +96,7 @@ class StoryConflict:
     @classmethod
     def stable_stringify(cls, obj: Any, indent=2) -> str:
         sorted_obj = cls._sort_recursively(obj)
-        return json.dumps(sorted_obj, sort_keys=True, indent=indent, ensure_ascii=False)
+        return json.dumps(sorted_obj, sort_keys=True, indent=indent)
 
     @classmethod
     def normalize_data(cls, current_data: dict[str, Any], new_data: dict[str, Any]) -> tuple[str, str]:

--- a/src/core/core/model/story_conflict.py
+++ b/src/core/core/model/story_conflict.py
@@ -57,8 +57,45 @@ class StoryConflict:
         return obj
 
     @classmethod
+    def _sort_recursively(cls, obj: Any) -> Any:
+        """
+        Recursively sort all nested structures to ensure deterministic ordering.
+        """
+        if isinstance(obj, dict):
+            return {key: cls._sort_recursively(value) for key, value in sorted(obj.items())}
+        elif isinstance(obj, list):
+            # Sort lists of dictionaries by a consistent key
+            if obj and isinstance(obj[0], dict):
+                sort_key = None
+                if "name" in obj[0]:
+                    sort_key = "name"
+                elif "key" in obj[0]:
+                    sort_key = "key"
+                elif "id" in obj[0]:
+                    sort_key = "id"
+
+                if sort_key:
+                    try:
+                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: x.get(sort_key, ""))
+                    except (TypeError, KeyError):
+                        return [cls._sort_recursively(item) for item in obj]
+                else:
+                    try:
+                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: str(x))
+                    except TypeError:
+                        return [cls._sort_recursively(item) for item in obj]
+            else:
+                try:
+                    return sorted([cls._sort_recursively(item) for item in obj])
+                except TypeError:
+                    return [cls._sort_recursively(item) for item in obj]
+        else:
+            return obj
+
+    @classmethod
     def stable_stringify(cls, obj: Any, indent=2) -> str:
-        return json.dumps(obj, sort_keys=True, indent=indent)
+        sorted_obj = cls._sort_recursively(obj)
+        return json.dumps(sorted_obj, sort_keys=True, indent=indent, ensure_ascii=False)
 
     @classmethod
     def normalize_data(cls, current_data: dict[str, Any], new_data: dict[str, Any]) -> tuple[str, str]:

--- a/src/core/core/model/story_conflict.py
+++ b/src/core/core/model/story_conflict.py
@@ -57,8 +57,42 @@ class StoryConflict:
         return obj
 
     @classmethod
+    def _sort_recursively(cls, obj: Any) -> Any:
+        if isinstance(obj, dict):
+            # Sort dictionary keys and recursively sort values
+            return {key: cls._sort_recursively(value) for key, value in sorted(obj.items())}
+        elif isinstance(obj, list):
+            if obj and isinstance(obj[0], dict):
+                sort_key = None
+                if "name" in obj[0]:
+                    sort_key = "name"
+                elif "key" in obj[0]:
+                    sort_key = "key"
+                elif "id" in obj[0]:
+                    sort_key = "id"
+
+                if sort_key:
+                    try:
+                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: x.get(sort_key, ""))
+                    except (TypeError, KeyError):
+                        return [cls._sort_recursively(item) for item in obj]
+                else:
+                    try:
+                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: str(x))
+                    except TypeError:
+                        return [cls._sort_recursively(item) for item in obj]
+            else:
+                try:
+                    return sorted([cls._sort_recursively(item) for item in obj])
+                except TypeError:
+                    return [cls._sort_recursively(item) for item in obj]
+        else:
+            return obj
+
+    @classmethod
     def stable_stringify(cls, obj: Any, indent=2) -> str:
-        return json.dumps(obj, sort_keys=True, indent=indent, ensure_ascii=False)
+        sorted_obj = cls._sort_recursively(obj)
+        return json.dumps(sorted_obj, sort_keys=True, indent=indent, ensure_ascii=False)
 
     @classmethod
     def normalize_data(cls, current_data: dict[str, Any], new_data: dict[str, Any]) -> tuple[str, str]:

--- a/src/core/core/model/story_conflict.py
+++ b/src/core/core/model/story_conflict.py
@@ -57,45 +57,8 @@ class StoryConflict:
         return obj
 
     @classmethod
-    def _sort_recursively(cls, obj: Any) -> Any:
-        """
-        Recursively sort all nested structures to ensure deterministic ordering.
-        """
-        if isinstance(obj, dict):
-            return {key: cls._sort_recursively(value) for key, value in sorted(obj.items())}
-        elif isinstance(obj, list):
-            # Sort lists of dictionaries by a consistent key
-            if obj and isinstance(obj[0], dict):
-                sort_key = None
-                if "name" in obj[0]:
-                    sort_key = "name"
-                elif "key" in obj[0]:
-                    sort_key = "key"
-                elif "id" in obj[0]:
-                    sort_key = "id"
-
-                if sort_key:
-                    try:
-                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: x.get(sort_key, ""))
-                    except (TypeError, KeyError):
-                        return [cls._sort_recursively(item) for item in obj]
-                else:
-                    try:
-                        return sorted([cls._sort_recursively(item) for item in obj], key=lambda x: str(x))
-                    except TypeError:
-                        return [cls._sort_recursively(item) for item in obj]
-            else:
-                try:
-                    return sorted([cls._sort_recursively(item) for item in obj])
-                except TypeError:
-                    return [cls._sort_recursively(item) for item in obj]
-        else:
-            return obj
-
-    @classmethod
     def stable_stringify(cls, obj: Any, indent=2) -> str:
-        sorted_obj = cls._sort_recursively(obj)
-        return json.dumps(sorted_obj, sort_keys=True, indent=indent, ensure_ascii=False)
+        return json.dumps(obj, sort_keys=True, indent=indent, ensure_ascii=False)
 
     @classmethod
     def normalize_data(cls, current_data: dict[str, Any], new_data: dict[str, Any]) -> tuple[str, str]:

--- a/src/core/tests/functional/test_worker.py
+++ b/src/core/tests/functional/test_worker.py
@@ -81,9 +81,10 @@ class TestWorkerApi:
                 f"News item {new_item['id']} was not found in the updated story."
             )
 
-        attributes_in_story = updated_story.get("attributes", [])
-        assert any(attr.get("key") == "status" and attr.get("value") == "updated" for attr in attributes_in_story), (
-            "Updated attribute not found in the story."
+        attributes_in_story = updated_story.get("attributes", {})
+        assert "status" in attributes_in_story, "Updated attribute key 'status' not found in the story."
+        assert attributes_in_story["status"].get("value") == "updated", (
+            f"Expected 'updated' but got '{attributes_in_story['status'].get('value')}'"
         )
 
     def test_worker_create_full_story(self, client, full_story: list[dict], api_header):

--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -307,8 +307,8 @@ class TestEndToEndUser(PlaywrightHelpers):
             expect(page.locator("div[name='comment']").get_by_role("textbox")).to_have_text("I like this story, it needs to be reviewed.")
 
             # Tag chips
-            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(0)).to_have_text("APT74")
-            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(1)).to_have_text("APT75")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(0)).to_have_text("APT75")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(1)).to_have_text("APT74")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(2)).to_have_text("APT76")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(3)).to_have_text("APT77")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(4)).to_have_text("APT78")

--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -307,8 +307,8 @@ class TestEndToEndUser(PlaywrightHelpers):
             expect(page.locator("div[name='comment']").get_by_role("textbox")).to_have_text("I like this story, it needs to be reviewed.")
 
             # Tag chips
-            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(0)).to_have_text("APT75")
-            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(1)).to_have_text("APT74")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(0)).to_have_text("APT74")
+            expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(1)).to_have_text("APT75")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(2)).to_have_text("APT76")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(3)).to_have_text("APT77")
             expect(page.get_by_label("Tags", exact=True).locator("xpath=..").locator("div.v-chip__content").nth(4)).to_have_text("APT78")

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -1,0 +1,78 @@
+import pytest
+from core.model.story_conflict import StoryConflict
+
+
+class TestStoryConflictSorting:
+    def test_stable_stringify_produces_consistent_results(self):
+        """Test that the same data produces the same string regardless of input order."""
+        # Test data with nested structures
+        story_data_1 = {
+            "title": "Test Story",
+            "description": "A test story",
+            "tags": [
+                {"name": "zebra_tag", "tag_type": "PERSON"},
+                {"name": "alpha_tag", "tag_type": "LOCATION"},
+                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+            ],
+            "attributes": [
+                {"key": "source", "value": "news_site_2"},
+                {"key": "author", "value": "john_doe"},
+                {"key": "category", "value": "politics"},
+            ],
+        }
+
+        # Same data but different order
+        story_data_2 = {
+            "title": "Test Story",
+            "description": "A test story",
+            "tags": [
+                {"name": "alpha_tag", "tag_type": "LOCATION"},
+                {"name": "zebra_tag", "tag_type": "PERSON"},
+                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+            ],
+            "attributes": [
+                {"key": "category", "value": "fun"},
+                {"key": "source", "value": "new_news"},
+                {"key": "author", "value": "cute_dog"},
+            ],
+        }
+
+        result_1 = StoryConflict.stable_stringify(story_data_1)
+        result_2 = StoryConflict.stable_stringify(story_data_2)
+
+        assert result_1 == result_2, "Same data with different order should produce identical strings"
+
+    def test_fix_addresses_original_issue_521(self):
+        """Integration test that verifies the fix addresses the original issue #521."""
+        # Simulate the exact scenario described in issue #521
+        original_story = {
+            "title": "Breaking News Story",
+            "description": "Important news",
+            "tags": [
+                {"name": "Politics", "tag_type": "CATEGORY"},
+                {"name": "Europe", "tag_type": "LOCATION"},
+                {"name": "John Smith", "tag_type": "PERSON"},
+            ],
+            "attributes": [{"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}, {"key": "verified", "value": "true"}],
+        }
+
+        updated_story = {
+            "title": "Breaking News Story",
+            "description": "Important news",
+            "tags": [
+                {"name": "John Smith", "tag_type": "PERSON"},
+                {"name": "Politics", "tag_type": "CATEGORY"},
+                {"name": "Europe", "tag_type": "LOCATION"},
+            ],
+            "attributes": [{"key": "verified", "value": "true"}, {"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}],
+        }
+
+        normalized_original, normalized_updated = StoryConflict.normalize_data(original_story, updated_story)
+
+        assert (
+            normalized_original == normalized_updated
+        ), "Stories with same content but different order should normalize to identical strings"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -9,32 +9,16 @@ class TestStoryConflictSorting:
         story_data_1 = {
             "title": "Test Story",
             "description": "A test story",
-            "tags": [
-                {"name": "zebra_tag", "tag_type": "PERSON"},
-                {"name": "alpha_tag", "tag_type": "LOCATION"},
-                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-            ],
-            "attributes": [
-                {"key": "source", "value": "news_site_2"},
-                {"key": "author", "value": "john_doe"},
-                {"key": "category", "value": "politics"},
-            ],
+            "tags": {"zebra_tag": "PERSON", "alpha_tag": "LOCATION", "beta_tag": "ORGANIZATION"},
+            "attributes": {"source": "news_site_2", "author": "john_doe", "category": "politics"},
         }
 
-        # Same data but different order
+        # Same data but keys in different order
         story_data_2 = {
             "title": "Test Story",
             "description": "A test story",
-            "tags": [
-                {"name": "alpha_tag", "tag_type": "LOCATION"},
-                {"name": "zebra_tag", "tag_type": "PERSON"},
-                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-            ],
-            "attributes": [
-                {"key": "category", "value": "fun"},
-                {"key": "source", "value": "new_news"},
-                {"key": "author", "value": "cute_dog"},
-            ],
+            "tags": {"alpha_tag": "LOCATION", "zebra_tag": "PERSON", "beta_tag": "ORGANIZATION"},
+            "attributes": {"category": "politics", "source": "news_site_2", "author": "john_doe"},
         }
 
         result_1 = StoryConflict.stable_stringify(story_data_1)
@@ -44,27 +28,18 @@ class TestStoryConflictSorting:
 
     def test_fix_addresses_original_issue_521(self):
         """Integration test that verifies the fix addresses the original issue #521."""
-        # Simulate the exact scenario described in issue #521
         original_story = {
             "title": "Breaking News Story",
             "description": "Important news",
-            "tags": [
-                {"name": "Politics", "tag_type": "CATEGORY"},
-                {"name": "Europe", "tag_type": "LOCATION"},
-                {"name": "John Smith", "tag_type": "PERSON"},
-            ],
-            "attributes": [{"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}, {"key": "verified", "value": "true"}],
+            "tags": {"Politics": "CATEGORY", "Europe": "LOCATION", "John Smith": "PERSON"},
+            "attributes": {"source": "Reuters", "urgency": "high", "verified": "true"},
         }
 
         updated_story = {
             "title": "Breaking News Story",
             "description": "Important news",
-            "tags": [
-                {"name": "John Smith", "tag_type": "PERSON"},
-                {"name": "Politics", "tag_type": "CATEGORY"},
-                {"name": "Europe", "tag_type": "LOCATION"},
-            ],
-            "attributes": [{"key": "verified", "value": "true"}, {"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}],
+            "tags": {"John Smith": "PERSON", "Politics": "CATEGORY", "Europe": "LOCATION"},
+            "attributes": {"verified": "true", "source": "Reuters", "urgency": "high"},
         }
 
         normalized_original, normalized_updated = StoryConflict.normalize_data(original_story, updated_story)

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -75,7 +75,7 @@ def updated_story():
 
 
 class TestStoryConflictSorting:
-    def test_stable_stringify_handles_different_tag_order(self, sample_story_data_1, sample_story_data_2):
+    def test_stable_stringify_handles_different_tag_order(self, story_data_1, story_data_2):
         result_1 = StoryConflict.stable_stringify(story_data_1)
         result_2 = StoryConflict.stable_stringify(story_data_2)
 

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -7,16 +7,16 @@ def story_data_1():
     return {
         "title": "Test Story",
         "description": "A test story",
-        "tags": [
-            {"name": "zebra_tag", "tag_type": "PERSON"},
-            {"name": "alpha_tag", "tag_type": "LOCATION"},
-            {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-        ],
-        "attributes": [
-            {"key": "source", "value": "news_site_2"},
-            {"key": "author", "value": "john_doe"},
-            {"key": "category", "value": "politics"},
-        ],
+        "tags": {
+            "zebra_tag": {"name": "zebra_tag", "tag_type": "PERSON"},
+            "alpha_tag": {"name": "alpha_tag", "tag_type": "LOCATION"},
+            "beta_tag": {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+        },
+        "attributes": {
+            "source": {"key": "source", "value": "news_site_2"},
+            "author": {"key": "author", "value": "john_doe"},
+            "category": {"key": "category", "value": "politics"},
+        },
     }
 
 
@@ -25,16 +25,16 @@ def story_data_2():
     return {
         "title": "Test Story",
         "description": "A test story",
-        "tags": [
-            {"name": "alpha_tag", "tag_type": "LOCATION"},
-            {"name": "zebra_tag", "tag_type": "PERSON"},
-            {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-        ],
-        "attributes": [
-            {"key": "category", "value": "politics"},
-            {"key": "source", "value": "news_site_2"},
-            {"key": "author", "value": "john_doe"},
-        ],
+        "tags": {
+            "alpha_tag": {"name": "alpha_tag", "tag_type": "LOCATION"},
+            "zebra_tag": {"name": "zebra_tag", "tag_type": "PERSON"},
+            "beta_tag": {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+        },
+        "attributes": {
+            "category": {"key": "category", "value": "politics"},
+            "source": {"key": "source", "value": "news_site_2"},
+            "author": {"key": "author", "value": "john_doe"},
+        },
     }
 
 
@@ -43,16 +43,16 @@ def original_story():
     return {
         "title": "Breaking News Story",
         "description": "Important news",
-        "tags": [
-            {"name": "Politics", "tag_type": "CATEGORY"},
-            {"name": "Europe", "tag_type": "LOCATION"},
-            {"name": "John Smith", "tag_type": "PERSON"},
-        ],
-        "attributes": [
-            {"key": "source", "value": "Reuters"},
-            {"key": "urgency", "value": "high"},
-            {"key": "verified", "value": "true"},
-        ],
+        "tags": {
+            "Politics": {"name": "Politics", "tag_type": "CATEGORY"},
+            "Europe": {"name": "Europe", "tag_type": "LOCATION"},
+            "John Smith": {"name": "John Smith", "tag_type": "PERSON"},
+        },
+        "attributes": {
+            "source": {"key": "source", "value": "Reuters"},
+            "urgency": {"key": "urgency", "value": "high"},
+            "verified": {"key": "verified", "value": "true"},
+        },
     }
 
 
@@ -61,16 +61,16 @@ def updated_story():
     return {
         "title": "Breaking News Story",
         "description": "Important news",
-        "tags": [
-            {"name": "John Smith", "tag_type": "PERSON"},
-            {"name": "Politics", "tag_type": "CATEGORY"},
-            {"name": "Europe", "tag_type": "LOCATION"},
-        ],
-        "attributes": [
-            {"key": "verified", "value": "true"},
-            {"key": "source", "value": "Reuters"},
-            {"key": "urgency", "value": "high"},
-        ],
+        "tags": {
+            "John Smith": {"name": "John Smith", "tag_type": "PERSON"},
+            "Politics": {"name": "Politics", "tag_type": "CATEGORY"},
+            "Europe": {"name": "Europe", "tag_type": "LOCATION"},
+        },
+        "attributes": {
+            "verified": {"key": "verified", "value": "true"},
+            "source": {"key": "source", "value": "Reuters"},
+            "urgency": {"key": "urgency", "value": "high"},
+        },
     }
 
 

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -1,4 +1,3 @@
-import pytest
 from core.model.story_conflict import StoryConflict
 
 
@@ -71,7 +70,3 @@ class TestStoryConflictSorting:
         assert (
             normalized_original == normalized_updated
         ), "Stories with same content but different order should normalize to identical strings"
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -3,22 +3,38 @@ from core.model.story_conflict import StoryConflict
 
 
 class TestStoryConflictSorting:
-    def test_stable_stringify_produces_consistent_results(self):
-        """Test that the same data produces the same string regardless of input order."""
-        # Test data with nested structures
+    def test_stable_stringify_handles_different_tag_order(self):
+        """Test that tags in different order produce the same string representation."""
+        # Test data with nested structures - same content, different order
         story_data_1 = {
             "title": "Test Story",
             "description": "A test story",
-            "tags": {"zebra_tag": "PERSON", "alpha_tag": "LOCATION", "beta_tag": "ORGANIZATION"},
-            "attributes": {"source": "news_site_2", "author": "john_doe", "category": "politics"},
+            "tags": [
+                {"name": "zebra_tag", "tag_type": "PERSON"},
+                {"name": "alpha_tag", "tag_type": "LOCATION"},
+                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+            ],
+            "attributes": [
+                {"key": "source", "value": "news_site_2"},
+                {"key": "author", "value": "john_doe"},
+                {"key": "category", "value": "politics"},
+            ],
         }
 
-        # Same data but keys in different order
+        # Same data but tags and attributes in different order
         story_data_2 = {
             "title": "Test Story",
             "description": "A test story",
-            "tags": {"alpha_tag": "LOCATION", "zebra_tag": "PERSON", "beta_tag": "ORGANIZATION"},
-            "attributes": {"category": "politics", "source": "news_site_2", "author": "john_doe"},
+            "tags": [
+                {"name": "alpha_tag", "tag_type": "LOCATION"},
+                {"name": "zebra_tag", "tag_type": "PERSON"},
+                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+            ],
+            "attributes": [
+                {"key": "category", "value": "politics"},
+                {"key": "source", "value": "news_site_2"},
+                {"key": "author", "value": "john_doe"},
+            ],
         }
 
         result_1 = StoryConflict.stable_stringify(story_data_1)
@@ -26,20 +42,28 @@ class TestStoryConflictSorting:
 
         assert result_1 == result_2, "Same data with different order should produce identical strings"
 
-    def test_fix_addresses_original_issue_521(self):
-        """Integration test that verifies the fix addresses the original issue #521."""
+    def test_normalize_data_handles_different_ordering(self):
+        """Test that normalize_data produces consistent results regardless of input order."""
         original_story = {
             "title": "Breaking News Story",
             "description": "Important news",
-            "tags": {"Politics": "CATEGORY", "Europe": "LOCATION", "John Smith": "PERSON"},
-            "attributes": {"source": "Reuters", "urgency": "high", "verified": "true"},
+            "tags": [
+                {"name": "Politics", "tag_type": "CATEGORY"},
+                {"name": "Europe", "tag_type": "LOCATION"},
+                {"name": "John Smith", "tag_type": "PERSON"},
+            ],
+            "attributes": [{"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}, {"key": "verified", "value": "true"}],
         }
 
         updated_story = {
             "title": "Breaking News Story",
             "description": "Important news",
-            "tags": {"John Smith": "PERSON", "Politics": "CATEGORY", "Europe": "LOCATION"},
-            "attributes": {"verified": "true", "source": "Reuters", "urgency": "high"},
+            "tags": [
+                {"name": "John Smith", "tag_type": "PERSON"},
+                {"name": "Politics", "tag_type": "CATEGORY"},
+                {"name": "Europe", "tag_type": "LOCATION"},
+            ],
+            "attributes": [{"key": "verified", "value": "true"}, {"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}],
         }
 
         normalized_original, normalized_updated = StoryConflict.normalize_data(original_story, updated_story)

--- a/src/core/tests/test_story_conflict.py
+++ b/src/core/tests/test_story_conflict.py
@@ -1,70 +1,87 @@
+import pytest
 from core.model.story_conflict import StoryConflict
 
 
+@pytest.fixture
+def story_data_1():
+    return {
+        "title": "Test Story",
+        "description": "A test story",
+        "tags": [
+            {"name": "zebra_tag", "tag_type": "PERSON"},
+            {"name": "alpha_tag", "tag_type": "LOCATION"},
+            {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+        ],
+        "attributes": [
+            {"key": "source", "value": "news_site_2"},
+            {"key": "author", "value": "john_doe"},
+            {"key": "category", "value": "politics"},
+        ],
+    }
+
+
+@pytest.fixture
+def story_data_2():
+    return {
+        "title": "Test Story",
+        "description": "A test story",
+        "tags": [
+            {"name": "alpha_tag", "tag_type": "LOCATION"},
+            {"name": "zebra_tag", "tag_type": "PERSON"},
+            {"name": "beta_tag", "tag_type": "ORGANIZATION"},
+        ],
+        "attributes": [
+            {"key": "category", "value": "politics"},
+            {"key": "source", "value": "news_site_2"},
+            {"key": "author", "value": "john_doe"},
+        ],
+    }
+
+
+@pytest.fixture
+def original_story():
+    return {
+        "title": "Breaking News Story",
+        "description": "Important news",
+        "tags": [
+            {"name": "Politics", "tag_type": "CATEGORY"},
+            {"name": "Europe", "tag_type": "LOCATION"},
+            {"name": "John Smith", "tag_type": "PERSON"},
+        ],
+        "attributes": [
+            {"key": "source", "value": "Reuters"},
+            {"key": "urgency", "value": "high"},
+            {"key": "verified", "value": "true"},
+        ],
+    }
+
+
+@pytest.fixture
+def updated_story():
+    return {
+        "title": "Breaking News Story",
+        "description": "Important news",
+        "tags": [
+            {"name": "John Smith", "tag_type": "PERSON"},
+            {"name": "Politics", "tag_type": "CATEGORY"},
+            {"name": "Europe", "tag_type": "LOCATION"},
+        ],
+        "attributes": [
+            {"key": "verified", "value": "true"},
+            {"key": "source", "value": "Reuters"},
+            {"key": "urgency", "value": "high"},
+        ],
+    }
+
+
 class TestStoryConflictSorting:
-    def test_stable_stringify_handles_different_tag_order(self):
-        """Test that tags in different order produce the same string representation."""
-        # Test data with nested structures - same content, different order
-        story_data_1 = {
-            "title": "Test Story",
-            "description": "A test story",
-            "tags": [
-                {"name": "zebra_tag", "tag_type": "PERSON"},
-                {"name": "alpha_tag", "tag_type": "LOCATION"},
-                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-            ],
-            "attributes": [
-                {"key": "source", "value": "news_site_2"},
-                {"key": "author", "value": "john_doe"},
-                {"key": "category", "value": "politics"},
-            ],
-        }
-
-        # Same data but tags and attributes in different order
-        story_data_2 = {
-            "title": "Test Story",
-            "description": "A test story",
-            "tags": [
-                {"name": "alpha_tag", "tag_type": "LOCATION"},
-                {"name": "zebra_tag", "tag_type": "PERSON"},
-                {"name": "beta_tag", "tag_type": "ORGANIZATION"},
-            ],
-            "attributes": [
-                {"key": "category", "value": "politics"},
-                {"key": "source", "value": "news_site_2"},
-                {"key": "author", "value": "john_doe"},
-            ],
-        }
-
+    def test_stable_stringify_handles_different_tag_order(self, sample_story_data_1, sample_story_data_2):
         result_1 = StoryConflict.stable_stringify(story_data_1)
         result_2 = StoryConflict.stable_stringify(story_data_2)
 
         assert result_1 == result_2, "Same data with different order should produce identical strings"
 
-    def test_normalize_data_handles_different_ordering(self):
-        """Test that normalize_data produces consistent results regardless of input order."""
-        original_story = {
-            "title": "Breaking News Story",
-            "description": "Important news",
-            "tags": [
-                {"name": "Politics", "tag_type": "CATEGORY"},
-                {"name": "Europe", "tag_type": "LOCATION"},
-                {"name": "John Smith", "tag_type": "PERSON"},
-            ],
-            "attributes": [{"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}, {"key": "verified", "value": "true"}],
-        }
-
-        updated_story = {
-            "title": "Breaking News Story",
-            "description": "Important news",
-            "tags": [
-                {"name": "John Smith", "tag_type": "PERSON"},
-                {"name": "Politics", "tag_type": "CATEGORY"},
-                {"name": "Europe", "tag_type": "LOCATION"},
-            ],
-            "attributes": [{"key": "verified", "value": "true"}, {"key": "source", "value": "Reuters"}, {"key": "urgency", "value": "high"}],
-        }
-
+    def test_normalize_data_handles_different_ordering(self, original_story, updated_story):
         normalized_original, normalized_updated = StoryConflict.normalize_data(original_story, updated_story)
 
         assert (

--- a/src/gui/src/components/assess/EditTags.vue
+++ b/src/gui/src/components/assess/EditTags.vue
@@ -1,7 +1,7 @@
 <template>
   <v-combobox
     v-model="tags"
-    :items="modelValue"
+    :items="tagsArray"
     chips
     density="compact"
     closable-chips
@@ -24,20 +24,40 @@ export default {
   name: 'EditTags',
   props: {
     modelValue: {
-      type: Array,
-      default: () => []
+      type: Object,
+      default: () => ({})
     }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
-    const updatedTags = ref(props.modelValue)
+    const tagsArray = computed(() => {
+      return Object.values(props.modelValue || {})
+    })
+
+    const updatedTags = ref(tagsArray.value)
 
     const updateTags = (val) => {
       updatedTags.value = val
-      emit('update:modelValue', val)
+      
+      // Convert Array back to Object format for parent component
+      const tagsObject = {}
+      if (Array.isArray(val)) {
+        val.forEach(tag => {
+          if (typeof tag === 'string') {
+            // Handle new tags entered as strings
+            tagsObject[tag] = { name: tag, tag_type: 'UNKNOWN' }
+          } else if (tag && tag.name) {
+            // Handle existing tag objects
+            tagsObject[tag.name] = tag
+          }
+        })
+      }
+      
+      emit('update:modelValue', tagsObject)
     }
 
     return {
+      tagsArray,
       tags: computed({
         get: () => updatedTags.value,
         set: updateTags

--- a/src/gui/src/components/assess/card/TagList.vue
+++ b/src/gui/src/components/assess/card/TagList.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="tags" class="story-tag-list">
     <v-chip
-      v-for="(tag, i) in tags"
-      :key="i"
+      v-for="(tag, tagName) in tags"
+      :key="tagName"
       class="py-3 mr-1 mt-1"
       :color="labelcolor(tag.tag_type)"
       link
@@ -52,8 +52,8 @@ export default defineComponent({
   name: 'TagList',
   props: {
     tags: {
-      type: Array,
-      required: true
+      type: Object,
+      default: () => ({})
     },
     truncate: {
       type: Boolean,
@@ -79,7 +79,6 @@ export default defineComponent({
     const router = useRouter()
 
     const max_width = computed(() => (props.truncate ? '60px' : '120px'))
-
     const flex_wrap = computed(() => (props.wrap ? 'wrap' : 'nowrap'))
 
     const updateTags = (tag) => {

--- a/src/gui/src/components/popups/PopupEditTags.vue
+++ b/src/gui/src/components/popups/PopupEditTags.vue
@@ -49,8 +49,8 @@ export default {
       required: true
     },
     tags: {
-      type: Array,
-      default: () => []
+      type: Object,
+      default: () => ({})
     },
     dialog: Boolean
   },
@@ -61,7 +61,8 @@ export default {
     const close = () => {
       emit('close')
     }
-    const updatedTags = ref(props.tags)
+    
+    const updatedTags = ref(props.tags || {})
 
     async function editTags() {
       await assessStore.updateTags(props.storyId, updatedTags.value)


### PR DESCRIPTION
Story conflict resolution was showing misleading diffs where the same tags appeared in different orders, causing false conflicts and breaking story clustering functionality.

- Added _sort_recursively() method in story_conflict.py, which recursively sorts all dicts and lists to ensure consistent ordering

- It sorts lists of dicts by appropriate keys: "name", "key", or "id" and falls back to string representation for sorting when no standard key exists

- Added tag sorting in to_dict(), to_detail_dict(), and to_worker_dict() methods to ensure consistent ordering across API responses


## Summary by Sourcery

Normalize tag representation and JSON serialization to ensure consistent ordering in conflict resolution and prevent false conflicts

Bug Fixes:
- Prevent false story conflicts caused by tag order variations

Enhancements:
- Change `to_worker_dict` to represent tags as a dict for stable ordering
- Enable `ensure_ascii=False` in `stable_stringify` for proper JSON output

Tests:
- Add tests for `stable_stringify` consistency across key orders
- Add integration test for `normalize_data` to verify original issue #521 is resolved