### PR TITLE
Story bot issues

### DIFF
--- a/src/core/core/api/bots.py
+++ b/src/core/core/api/bots.py
@@ -15,7 +15,7 @@ class BotGroupAction(MethodView):
     def put(self):
         story_ids = request.json
         if not story_ids:
-            return {"No story ids provided"}, 400
+            return {"error": "No story ids provided"}, 400
         response, code = story.Story.group_stories(story_ids)
         sse_manager.news_items_updated()
         return response, code
@@ -26,7 +26,7 @@ class BotGroupMultipleAction(MethodView):
     def put(self):
         story_ids = request.json
         if not story_ids:
-            return {"No stories provided"}, 400
+            return {"error": "No stories provided"}, 400
         response, code = story.Story.group_multiple_stories(story_ids)
         sse_manager.news_items_updated()
         return response, code
@@ -37,7 +37,7 @@ class BotUnGroupAction(MethodView):
     def put(self):
         newsitem_ids = request.json
         if not newsitem_ids:
-            return {"No news items provided"}, 400
+            return {"error": "No news items provided"}, 400
         response, code = story.Story.remove_news_items_from_story(newsitem_ids)
         sse_manager.news_items_updated()
         return response, code


### PR DESCRIPTION
The Group-related MethodViews in bots.py returned sets, which are not JSON serializable and caused Flask errors -> Switch to dict

Distinguish between a failed run of the story clustering bot and the case where no clusters were found.

## Summary by Sourcery

Enhance story clustering bot error handling and standardize JSON responses for grouping endpoints

Bug Fixes:
- Replace non-JSON-serializable return values with dicts in BotGroupAction, BotGroupMultipleAction, and BotUnGroupAction
- Use a consistent {"error": "..."} format for missing-input HTTP 400 error responses

Enhancements:
- Distinguish between a failed clustering run, no clusters found, and successful clustering in the StoryBot execute method
- Propagate the bot’s original message on success and raise an exception if no response is received