### PR TITLE
Feature/combine osint source task status

### DIFF
--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -8,6 +8,7 @@ from core.log import logger
 from core.model.word_list import WordList
 from core.model.token_blacklist import TokenBlacklist
 from core.model.product import Product
+from core.model.osint_source import OSINTSource
 from core.config import Config
 
 
@@ -30,15 +31,9 @@ class Task(MethodView):
 
         logger.debug(f"Received task result with id {task_id} and status {status} with result {result}")
 
-        if not result or "error" in result or status == "FAILURE":
-            TaskModel.add_or_update({"id": task_id, "result": serialize_result(result), "status": status})
-            return {"status": status}, 400
-
-        if handle_task_specific_result(task_id, result):
-            return {"status": status}, 201
-
+        handle_task_specific_result(task_id, result, status)
         TaskModel.add_or_update({"id": task_id, "result": serialize_result(result), "status": status})
-        return {"status": status}, 201
+        return {"status": status}, 200
 
 
 def initialize(app: Flask):
@@ -60,12 +55,10 @@ def serialize_result(result: dict | str | None = None):
             return " ".join(map(str, result["exc_message"]))
         return result["exc_message"]
 
-    if "message" in result:
-        return result["message"]
-    return result
+    return result["message"] if "message" in result else result
 
 
-def handle_task_specific_result(task_id: str, result: dict) -> bool:
+def handle_task_specific_result(task_id: str, result: dict, status: str) -> bool:
     if task_id.startswith("gather_word_list"):
         WordList.update_word_list(**result)
     elif task_id.startswith("cleanup_token_blacklist"):
@@ -78,6 +71,12 @@ def handle_task_specific_result(task_id: str, result: dict) -> bool:
             return False
         Product.update_render_for_id(product_id, rendered_product)
     elif task_id.startswith("collect_"):
+        source_id = task_id.split("_")[-1]
+        if source := OSINTSource.get(source_id):
+            if status == "FAILURE":
+                source.update_status(result.get("exc_message", "Error"))
+            else:
+                source.update_status(None)
         logger.debug(f"Collector task {task_id} completed with result: {result}")
     else:
         return False

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -58,7 +58,7 @@ def serialize_result(result: dict | str | None = None):
     return result["message"] if "message" in result else result
 
 
-def handle_task_specific_result(task_id: str, result: dict, status: str) -> bool:
+def handle_task_specific_result(task_id: str, result: dict, status: str):
     if task_id.startswith("gather_word_list"):
         WordList.update_word_list(**result)
     elif task_id.startswith("cleanup_token_blacklist"):
@@ -68,8 +68,8 @@ def handle_task_specific_result(task_id: str, result: dict, status: str) -> bool
         product_id = result.get("product_id")
         if not product_id or not rendered_product:
             logger.error(f"Product {product_id} not found or no render result")
-            return False
-        Product.update_render_for_id(product_id, rendered_product)
+        else:
+            Product.update_render_for_id(product_id, rendered_product)
     elif task_id.startswith("collect_"):
         source_id = task_id.split("_")[-1]
         if source := OSINTSource.get(source_id):
@@ -78,6 +78,3 @@ def handle_task_specific_result(task_id: str, result: dict, status: str) -> bool
             else:
                 source.update_status(None)
         logger.debug(f"Collector task {task_id} completed with result: {result}")
-    else:
-        return False
-    return True

--- a/src/worker/worker/collectors/base_collector.py
+++ b/src/worker/worker/collectors/base_collector.py
@@ -126,7 +126,6 @@ class BaseCollector:
         logger.info(f"Publishing {len(news_items)} news items to core api")
         if news_items_dicts := [item.to_dict() for item in news_items]:
             self.core_api.add_news_items(news_items_dicts)
-        self.core_api.update_osintsource_status(source["id"], None)
 
     def publish_or_update_stories(self, story_lists: list[dict], source: dict, story_attribute_key: str | None = None):
         """

--- a/src/worker/worker/collectors/collector_tasks.py
+++ b/src/worker/worker/collectors/collector_tasks.py
@@ -74,7 +74,6 @@ class CollectorTask(Task):
             except NoChangeError as e:
                 return f"Source '{source.get('name')}' with id {osint_source_id}: {str(e)}"
             except Exception as e:
-                self.core_api.update_osintsource_status(osint_source_id, {"error": str(e)})
                 raise RuntimeError(e) from e
 
         self.core_api.run_post_collection_bots(osint_source_id)

--- a/src/worker/worker/core_api.py
+++ b/src/worker/worker/core_api.py
@@ -165,9 +165,6 @@ class CoreApi:
             logger.exception("Can't run Post Collection Bots")
             return None
 
-    def update_osintsource_status(self, osint_source_id: str, error_msg: dict | None = None) -> dict | None:
-        return self.api_put(url=f"/worker/osint-sources/{osint_source_id}", json_data=error_msg)
-
     def update_osint_source_icon(self, osint_source_id: str, icon) -> dict | None:
         try:
             url = f"{self.api_url}/worker/osint-sources/{osint_source_id}/icon"


### PR DESCRIPTION
Handle updating the OSINT source status in the Task model, instead of in the collectors themselves.

## Summary by Sourcery

Centralize OSINT source status management within the Task API, remove on-collector status updates, standardize task responses, and streamline result serialization

Enhancements:
- Centralize OSINT source status updates in the core Task API by extending handle_task_specific_result to handle collector outcomes and status
- Remove redundant update_osint_source_status helper method and related calls from worker collectors
- Standardize Task API response codes (always return 200) and simplify serialize_result logic