### PR TITLE
improve source preview

### DIFF
--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -544,7 +544,7 @@ class OSINTSourcePreview(MethodView):
 
         if result := task.Task.get(task_id):
             return result.to_dict(), 200
-        return {"error": "Task not found"}, 404
+        return queue_manager.queue_manager.preview_osint_source(source_id)
 
     @auth_required("CONFIG_OSINT_SOURCE_UPDATE")
     def post(self, source_id):

--- a/src/core/core/api/task.py
+++ b/src/core/core/api/task.py
@@ -29,7 +29,7 @@ class Task(MethodView):
         result = data.get("result")
         status = data.get("status")
 
-        logger.debug(f"Received task result with id {task_id} and status {status} with result {result}")
+        logger.debug(f"Received task result with id {task_id} and status {status}")
 
         handle_task_specific_result(task_id, result, status)
         TaskModel.add_or_update({"id": task_id, "result": serialize_result(result), "status": status})

--- a/src/frontend/frontend/core_api.py
+++ b/src/frontend/frontend/core_api.py
@@ -123,6 +123,13 @@ class CoreApi:
             logger.error(f"Collect OSINT source preview failed: {e}")
             return None
 
+    def get_osint_source_preview(self, osint_source_id: str):
+        try:
+            return self.api_get(f"/config/osint-sources/{osint_source_id}/preview")
+        except Exception as e:
+            logger.error(f"Retrieving OSINT source preview failed: {e}")
+            return None
+
     def collect_osint_source(self, osint_source_id: str):
         try:
             return self.api_post(f"/config/osint-sources/{osint_source_id}/collect")

--- a/src/frontend/frontend/core_api.py
+++ b/src/frontend/frontend/core_api.py
@@ -116,13 +116,6 @@ class CoreApi:
             logger.error(f"Load default OSINT sources failed: {e}")
             return None
 
-    def collect_osint_source_preview(self, osint_source_id: str):
-        try:
-            return self.api_post(f"/config/osint-sources/{osint_source_id}/preview")
-        except Exception as e:
-            logger.error(f"Collect OSINT source preview failed: {e}")
-            return None
-
     def get_osint_source_preview(self, osint_source_id: str):
         try:
             return self.api_get(f"/config/osint-sources/{osint_source_id}/preview")

--- a/src/frontend/frontend/router/admin.py
+++ b/src/frontend/frontend/router/admin.py
@@ -90,16 +90,6 @@ class LoadDefaultOSINTSources(MethodView):
         return SourceView.load_default_osint_sources()
 
 
-class OSINTSourcePreview(MethodView):
-    @auth_required()
-    def post(self, osint_source_id: str):
-        return SourceView.collect_osint_source_preview(osint_source_id)
-
-    @auth_required()
-    def get(self, osint_source_id: str):
-        return SourceView.get_osint_source_preview_view(osint_source_id)
-
-
 class OSINTSourceCollect(MethodView):
     @auth_required()
     def post(self, osint_source_id: str | None = None):
@@ -198,7 +188,12 @@ def init(app: Flask):
     admin_bp.add_url_rule("/export/osint_sources", view_func=ExportOSINTSources.as_view("export_osint_sources"))
     admin_bp.add_url_rule("/import/osint_sources", view_func=ImportOSINTSources.as_view("import_osint_sources"))
     admin_bp.add_url_rule("/load_default_osint_sources", view_func=LoadDefaultOSINTSources.as_view("load_default_osint_sources"))
-    admin_bp.add_url_rule("/source_preview/<string:osint_source_id>", view_func=OSINTSourcePreview.as_view("osint_source_preview"))
+    admin_bp.add_url_rule(
+        "/source_preview/<string:osint_source_id>",
+        view_func=SourceView.get_osint_source_preview_view,
+        methods=["GET"],
+        endpoint="osint_source_preview",
+    )
     admin_bp.add_url_rule("/source_collect", view_func=OSINTSourceCollect.as_view("collect_osint_source_all"))
     admin_bp.add_url_rule("/source_collect/<string:osint_source_id>", view_func=OSINTSourceCollect.as_view("collect_osint_source"))
 

--- a/src/frontend/frontend/templates/osint_source/osint_source_preview.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_preview.html
@@ -9,7 +9,13 @@
     <p>OSINT source preview is currently being processed. Please wait...</p>
   </div>
   {% elif task_result.status == 'SUCCESS' %}
-  {% for story in task_result.result %}{{ story_card(story) }}{% endfor %}
+    {% if task_result.result %}
+      {% for story in task_result.result %}{{ story_card(story) }}{% endfor %}
+    {% else %}
+      <div class="alert alert-info my-5 mx-5">
+        <p>No results found for this OSINT source.</p>
+      </div>
+    {% endif %}
   {% endif %}
   {% else %}
   <div class="alert alert-info my-5 mx-5">

--- a/src/frontend/frontend/templates/osint_source/osint_source_preview.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_preview.html
@@ -2,5 +2,19 @@
 {% from 'assess/story/story_card.html' import story_card %}
 
 {% block content %}
+<div id="source_preview">
+  {% if task_result %}
+  {% if task_result.status == 'STARTED' %}
+  <div class="alert alert-info my-5 mx-5" hx-get hx-trigger="every 20s" hx-target="#source_preview" hx-swap="outerHTML" hx-select="#source_preview">
+    <p>OSINT source preview is currently being processed. Please wait...</p>
+  </div>
+  {% elif task_result.status == 'SUCCESS' %}
   {% for story in task_result.result %}{{ story_card(story) }}{% endfor %}
+  {% endif %}
+  {% else %}
+  <div class="alert alert-info my-5 mx-5">
+    <p>No results found for this OSINT source.</p>
+  </div>
+  {% endif %}
+</div>
 {% endblock content %}

--- a/src/frontend/frontend/views/source_views.py
+++ b/src/frontend/frontend/views/source_views.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Literal
-from flask import render_template, request, Response, redirect, url_for
+from flask import render_template, request, Response, url_for
 
 from models.admin import OSINTSource, WorkerParameter, WorkerParameterValue, TaskResult
 from models.types import COLLECTOR_TYPES
@@ -192,18 +192,7 @@ class SourceView(BaseView):
         ), 200
 
     @classmethod
-    def collect_osint_source_preview(cls, osint_source_id: str):
-        response = CoreApi().collect_osint_source_preview(osint_source_id)
-        logger.debug(f"Collect OSINT source preview response: {response}")
-        if not response:
-            logger.error("Failed to load OSINT source preview")
-            return render_template(
-                "notification/index.html", notification={"message": "Failed to load OSINT source preview", "error": True}
-            ), 500
-        DataPersistenceLayer().invalidate_cache_by_object(TaskResult)
-        return redirect(url_for("admin.osint_source_preview", osint_source_id=osint_source_id))
-
-    @classmethod
+    @auth_required()
     def get_osint_source_preview_view(cls, osint_source_id: str):
         task_result = None
         if response := CoreApi().get_osint_source_preview(osint_source_id):

--- a/src/frontend/frontend/views/source_views.py
+++ b/src/frontend/frontend/views/source_views.py
@@ -56,10 +56,7 @@ class SourceView(BaseView):
                 "icon": "eye",
                 "method": "post",
                 "url": url_for("admin.osint_source_preview", osint_source_id=""),
-                "hx_target_error": "#notification-bar",
-                "hx_target": None,
-                "hx_swap": None,
-                "confirm": None,
+                "type": "link",
             },
             {
                 "label": "Collect",
@@ -208,11 +205,11 @@ class SourceView(BaseView):
 
     @classmethod
     def get_osint_source_preview_view(cls, osint_source_id: str):
-        dpl = DataPersistenceLayer()
-        if task_result := dpl.get_object(TaskResult, f"source_preview_{osint_source_id}"):
-            return render_template("osint_source/osint_source_preview.html", task_result=task_result)
-
-        return render_template("notification/index.html", notification={"message": "OSINT source preview not found", "error": True}), 404
+        task_result = None
+        if response := CoreApi().get_osint_source_preview(osint_source_id):
+            task_result = TaskResult(**response)
+        logger.debug(f"Task result for OSINT source preview: {task_result}")
+        return render_template("osint_source/osint_source_preview.html", task_result=task_result)
 
     @classmethod
     def delete_view(cls, object_id: str | int) -> tuple[str, int]:


### PR DESCRIPTION
## Summary by Sourcery

Enhance the OSINT source preview workflow by migrating data retrieval to CoreApi, enriching backend task endpoints to return status and trigger previews on demand, and adding dynamic UI polling in the preview template.

Enhancements:
- Replace direct DataPersistenceLayer access with CoreApi in get_osint_source_preview_view
- Introduce get_osint_source_preview in frontend CoreApi and simplify preview action to a link
- Add htmx-based polling in the osint_source_preview template for processing, success, and empty states
- Modify preview_osint_source API to return id, status, and 201 Created when scheduling a preview
- Include explicit task_id in queue_manager send_task and signature calls for consistent task tracking