### PR TITLE
Sort filter keys before retrieving from filterStore

### DIFF
--- a/src/gui/src/utils/query.js
+++ b/src/gui/src/utils/query.js
@@ -14,6 +14,7 @@ export function getQueryStringFromNestedObject(filterObject) {
     return ''
   }
   return Object.entries(filterObject)
+    .sort(([a], [b]) => a.localeCompare(b))
     .filter(([, val]) => val != null)
     .map(([key, val]) => {
       if (Array.isArray(val)) {


### PR DESCRIPTION
Relates to Issue https://github.com/taranis-ai/taranis-ai/issues/564
Sorting the keys before retrieving them from the filterStore and creating a filter query out of it should resolve the strange Filter -> Refresh -> Filter -> Refresh error

Maybe someone can check if this really does something. My hypothesis on this one rests on shaky ground.

## Summary by Sourcery

Bug Fixes:
- Sort filter keys before generating query string to prevent inconsistent ordering and resolve filter-refresh loops.