### PR TITLE
Story Selection updates

### DIFF
--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -248,6 +248,7 @@ export const useAssessStore = defineStore(
           return
         }
         await unGroupAction(stories)
+        clearSelection()
         await updateStories()
       } catch (error) {
         notifyFailure(error)

--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -67,7 +67,6 @@ export const useAssessStore = defineStore(
         console.debug('Updating Stories with Filter', filterQuery)
         const response = await getStories(filterQuery)
         stories.value.items = response.data.items
-        clearSelection()
         if (response.data.counts) {
           storyCounts.value = response.data.counts
           weekChartOptions.value.scales.y2.max =

--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -248,7 +248,6 @@ export const useAssessStore = defineStore(
           return
         }
         await unGroupAction(stories)
-        clearSelection()
         await updateStories()
       } catch (error) {
         notifyFailure(error)

--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -67,6 +67,7 @@ export const useAssessStore = defineStore(
         console.debug('Updating Stories with Filter', filterQuery)
         const response = await getStories(filterQuery)
         stories.value.items = response.data.items
+        clearSelection()
         if (response.data.counts) {
           storyCounts.value = response.data.counts
           weekChartOptions.value.scales.y2.max =
@@ -142,6 +143,7 @@ export const useAssessStore = defineStore(
     }
 
     function removeStoryByID(id) {
+      clearSelection()
       deleteStory(id)
       stories.value.items = stories.value.items.filter(
         (item) => item?.id !== id

--- a/src/gui/src/stores/FilterStore.js
+++ b/src/gui/src/stores/FilterStore.js
@@ -78,6 +78,7 @@ export const useFilterStore = defineStore(
         storyFilterQuery.value = newFilterQuery
         router.push({ query: filter })
         const assessStore = useAssessStore()
+        assessStore.clearSelection()
         assessStore.updateStories()
       },
       { deep: true }


### PR DESCRIPTION
Regarding #577 

Currently, the story selection was cleared only when:
- Stories were ungrouped
- Filters were reset

Add a call to assessStore.clearSelection in filter watcher in FilterStore.js, so that the selection is cleared when a filter is adapted
The only drawback here is that, when the same story is still shown after applying the new filter, the selection is gone as well. But I think we can live with that.

Add a call to clearSelection to removeStoryByID, so that the selection is cleared when a story is deleted.
