### PR TITLE
Add autofocus to frontend login mask username field

### DIFF
--- a/src/frontend/frontend/templates/login/login.html
+++ b/src/frontend/frontend/templates/login/login.html
@@ -8,7 +8,7 @@
     <div class="card-body items-center text-center space-y-4">
       <label class="floating-label input w-full mb-5 form-control">
         <span>Username</span>
-        <input id="username" type="text" placeholder="Username" name="username" required />
+        <input id="username" type="text" placeholder="Username" name="username" required autofocus />
       </label>
 
       <div x-data="{ showPassword: false }" class="w-full">


### PR DESCRIPTION
So often i am surfing locally in the frontend,
so often i ask myself "why does the login mask don't have focus" when i need to login again.

With this "autofocus" attribute the username is focused.

## Summary by Sourcery

Enhancements:
- Add autofocus attribute to the username input on the login page