### PR TITLE
`mark-as-read` and `mark-as-important` has incorrect function call order

### DIFF
--- a/src/gui/src/stores/AssessStore.js
+++ b/src/gui/src/stores/AssessStore.js
@@ -324,22 +324,22 @@ export const useAssessStore = defineStore(
       console.debug('Triggerd News items update')
       new_stories.value = true
     }
-    function markStoryAsRead(id, filter = true) {
+    async function markStoryAsRead(id, filter = true) {
       const item = stories.value.items.find((item) => item.id === id)
       item.read = !item.read
+      await readStory(id, item.read)
       if (filter) {
         filterStories()
       }
-      readStory(id, item.read)
     }
 
-    function markStoryAsImportant(id, filter = true) {
+    async function markStoryAsImportant(id, filter = true) {
       const item = stories.value.items.find((item) => item.id === id)
       item.important = !item.important
+      await importantStory(id, item.important)
       if (filter) {
         filterStories()
       }
-      importantStory(id, item.important)
     }
 
     function filterStories() {


### PR DESCRIPTION
Fix incorrect function call order in the `mark as read` and `mark as important` story action update.

The problem manifests when the last story of a page is marked as read or important. Then the `updateStories` in `filterStories()` is called and that is wrong (or at least too soon), because the backend hasn't even received that the story should have been changed (with the function `readStory`).

The same problem has `mark as important`.