### PR TITLE
Add typecheck to group_stories

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -827,6 +827,9 @@ class Story(BaseModel):
     @classmethod
     def group_stories(cls, story_ids: list[str], user: User | None = None):
         try:
+            if not isinstance(story_ids, list):
+                return {"error": "story_ids must be a list"}, 400
+
             if len(story_ids) < 2 or any(not isinstance(a_id, str) or len(a_id) == 0 for a_id in story_ids):
                 return {"error": "at least two valid Story ids needed"}, 404
 


### PR DESCRIPTION
Why not to add a type check...

```python
[Core] [DEBUG] - Grouping Stories Failed - 'str' object has no attribute 'pop'
[Core] [DEBUG] - Traceback (most recent call last):
  File "/home/<username>/git/taranis-ai/src/core/core/model/story.py", line 668, in group_stories
    first_story = Story.get(story_ids.pop(0))
                            ^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'pop'
```

## Summary by Sourcery

Bug Fixes:
- Add validation in group_stories to return a 400 error if story_ids is not a list