### PR TITLE
Remove dropdown from tag combobox

### DIFF
--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -149,7 +149,6 @@ class TestEndToEndUser(PlaywrightHelpers):
             page.get_by_label("Tags", exact=True).press("Enter")
             page.get_by_label("Tags", exact=True).fill("APT81")
             page.get_by_label("Tags", exact=True).press("Enter")
-            self.highlight_element(page.get_by_title("Close")).click()
             self.highlight_element(page.get_by_role("button", name="Add New Key-Value"), scroll=False).click()
             self.highlight_element(page.get_by_label("Key"), scroll=False).click()
             self.highlight_element(page.get_by_label("Key"), scroll=False).fill("test_key")

--- a/src/gui/src/components/assess/EditTags.vue
+++ b/src/gui/src/components/assess/EditTags.vue
@@ -13,7 +13,9 @@
     item-value="name"
     item-title="name"
     label="Tags"
+    :menu-props="{ openOnClick: false, openOnFocus: false, modelValue: false }"
     multiple
+    menu-icon=""
   />
 </template>
 


### PR DESCRIPTION
The behaviour of the dropdown in the tag combobox in edit story view is counter-intuitive.

<img width="548" height="204" alt="image" src="https://github.com/user-attachments/assets/025b4305-c575-44e2-834e-a686b424cc23" />

If you click on a tag in the dropdown, it vanishes.

<img width="548" height="204" alt="image" src="https://github.com/user-attachments/assets/f4772af6-463d-4837-8679-b22433f7f23a" />


-> Remove dropdown

## Summary by Sourcery

Remove the dropdown menu from the tag combobox in the edit story view to fix counter-intuitive behavior.

Bug Fixes:
- Disable opening of the dropdown menu on click and focus by setting menu-props
- Hide the dropdown icon by clearing the menu-icon property