### PR TITLE
Fix test_e2e_publish rendering 

### DIFF
--- a/src/core/tests/playwright/conftest.py
+++ b/src/core/tests/playwright/conftest.py
@@ -1012,8 +1012,11 @@ def create_html_render(app):
                 product_id = "test"
 
             # test html for product rendering
-            test_html = "Thanks to Cybersecurity experts, the world of IT is now safe."
+            test_html_b64 = "VGhhbmtzIHRvIEN5YmVyc2VjdXJpdHkgZXhwZXJ0cywgdGhlIHdvcmxkIG9mIElUIGlzIG5vdyBzYWZlLg=="
 
-            Product.update_render_for_id(product_id, test_html)
+            _, status_code = Product.update_render_for_id(product_id, test_html_b64)
+
+            if status_code != 200:
+                raise RuntimeError(f"Failed to render product with id {product_id}")
 
     return get_product_to_render

--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -577,6 +577,7 @@ class TestEndToEndUser(PlaywrightHelpers):
         create_html_render()
 
         self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product")).click()
-        self.short_sleep(duration=6)
-        expect(page.get_by_test_id("text-render")).to_contain_text("Thanks to Cybersecurity experts, the world of IT is now safe.")
+        expect(page.get_by_test_id("text-render")).to_contain_text(
+            "Thanks to Cybersecurity experts, the world of IT is now safe.", timeout=10_000
+        )
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/core/tests/playwright/test_e2e_user.py
+++ b/src/core/tests/playwright/test_e2e_user.py
@@ -4,6 +4,7 @@ import pytest
 import time
 from playwright.sync_api import expect, Page, Locator
 from playwright_helpers import PlaywrightHelpers
+from typing import Callable
 
 
 @pytest.mark.e2e_user
@@ -556,13 +557,13 @@ class TestEndToEndUser(PlaywrightHelpers):
         page.screenshot(path=f"./tests/playwright/screenshots/{pic_prefix}analyze_view.png")
 
     @pytest.mark.e2e_publish
-    def test_e2e_publish(self, taranis_frontend: Page):
+    def test_e2e_publish(self, taranis_frontend: Page, create_html_render: Callable):
         page = taranis_frontend
-        self.add_keystroke_overlay(page)
 
         self.highlight_element(page.get_by_role("link", name="Publish").first).click()
         page.wait_for_url("**/publish", wait_until="domcontentloaded")
         expect(page).to_have_title("Taranis AI | Publish")
+
         self.highlight_element(page.get_by_role("button", name="New Product").first).click()
         self.highlight_element(page.get_by_role("combobox").locator("div").filter(has_text="Product Type").locator("div")).click()
         self.highlight_element(page.get_by_role("option", name="Default TEXT Presenter")).click()
@@ -571,6 +572,11 @@ class TestEndToEndUser(PlaywrightHelpers):
         self.highlight_element(page.get_by_label("Description")).click()
         self.highlight_element(page.get_by_label("Description")).fill("Test Description")
         self.highlight_element(page.get_by_role("button", name="Save")).click()
-        page.get_by_text("Product created").click()
-        self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product"))
+
+        self.short_sleep(duration=1)
+        create_html_render()
+
+        self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product")).click()
+        self.short_sleep(duration=6)
+        expect(page.get_by_test_id("text-render")).to_contain_text("Thanks to Cybersecurity experts, the world of IT is now safe.")
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/core/tests/playwright/test_e2e_workflow.py
+++ b/src/core/tests/playwright/test_e2e_workflow.py
@@ -154,6 +154,8 @@ class TestUserWorkflow(PlaywrightHelpers):
             self.highlight_element(
                 page.locator("div").filter(has_text="Patient Data Harvesting by APT60").nth(5).get_by_role("link").nth(2)
             ).click()
+            self.short_sleep(0.5)
+
             # Mark as read
             self.highlight_element(page.get_by_test_id("mark as read")).click()
             # Remove mark as important
@@ -305,6 +307,7 @@ class TestUserWorkflow(PlaywrightHelpers):
             self.highlight_element(page.get_by_role("button", name="reset filter")).click()
             self.highlight_element(page.get_by_label("Tags", exact=True)).click()
             self.highlight_element(page.get_by_label("Tags", exact=True)).fill("test")
+            self.short_sleep(0.5)
             self.highlight_element(page.get_by_text("Test Report").last).click()
             page.get_by_test_id("all-stories-div").click()
             page.keyboard.press("Control+A")

--- a/src/core/tests/playwright/test_e2e_workflow.py
+++ b/src/core/tests/playwright/test_e2e_workflow.py
@@ -358,6 +358,7 @@ class TestUserWorkflow(PlaywrightHelpers):
         create_html_render()
 
         self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product")).click()
-        self.short_sleep(duration=6)
-        expect(page.get_by_test_id("text-render")).to_contain_text("Thanks to Cybersecurity experts, the world of IT is now safe.")
+        expect(page.get_by_test_id("text-render")).to_contain_text(
+            "Thanks to Cybersecurity experts, the world of IT is now safe.", timeout=10_000
+        )
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/core/tests/playwright/test_e2e_workflow.py
+++ b/src/core/tests/playwright/test_e2e_workflow.py
@@ -359,4 +359,5 @@ class TestUserWorkflow(PlaywrightHelpers):
 
         self.highlight_element(page.get_by_role("main").locator("header").get_by_role("button", name="Render Product")).click()
         self.short_sleep(duration=6)
+        expect(page.get_by_test_id("text-render")).to_contain_text("Thanks to Cybersecurity experts, the world of IT is now safe.")
         page.screenshot(path="./tests/playwright/screenshots/screenshot_publish.png")

--- a/src/gui/src/components/publish/ProductItem.vue
+++ b/src/gui/src/components/publish/ProductItem.vue
@@ -125,9 +125,13 @@
               :data="'data:application/pdf;base64,' + renderedProduct"
               type="application/pdf"
               width="100%"
+              data-testid="pdf-render"
             />
 
-            <pre v-if="renderedProductMimeType === 'text/plain'">
+            <pre
+              v-if="renderedProductMimeType === 'text/plain'"
+              data-testid="text-render"
+            >
               {{ renderedProduct }}
             </pre>
           </div>


### PR DESCRIPTION
- Fixes the rendering error in test_e2e_publish method in test_e2e_workflow.py
- Adds rendering to test_e2e_publish in test_e2e_user.py

## Summary by Sourcery

Fix rendering assertion failures in end-to-end publish tests by integrating an HTML render fixture, base64-encoding and validating test HTML in the fixture, adding data-testid markers in the Vue component, and stabilizing e2e workflows with short_sleep delays.

Bug Fixes:
- Fix test_e2e_publish in user and workflow tests to correctly trigger and verify HTML rendering

Enhancements:
- Base64-encode the test HTML in get_product_to_render fixture and validate the HTTP response code
- Add data-testid attributes to the PDF and text render elements in ProductItem.vue

Tests:
- Introduce create_html_render fixture in test_e2e_publish and add assertions on rendered text
- Insert short_sleep calls in various e2e workflow tests to improve timing stability