### PR TITLE
Force submission of falsy form_switches in frontend

### DIFF
--- a/src/frontend/frontend/templates/macros/forms.html
+++ b/src/frontend/frontend/templates/macros/forms.html
@@ -69,12 +69,17 @@
 {% endmacro %}
 
 {% macro form_switch_content(name, value, yes_val='Yes', no_val='No', required=True, preserve=True, input_class='') %}
-  <input id="{{ name }}"
-         name="{{ name }}"
-         type="checkbox"
-         class="toggle toggle-primary {{ input_class }}"
-         {% if required %}required{% endif %}
-         {% if value %}checked{% endif %}
-         onchange="document.getElementById('{{ name }}_status').textContent = this.checked ? '{{ yes_val }}' : '{{ no_val }}';" />
-  <span class="text-base-content {{ input_class }}" id="{{ name }}_status">{{ yes_val if value else no_val }}</span>
+  <!--checkbox does not emit falsy states - this makes sure it is included in form submission if unchecked-->
+  <input type="hidden" name="{{ name }}" value="{{ no_val }}" />
+  <input
+    id="{{ name }}"
+    name="{{ name }}"
+    type="checkbox"
+    value="{{ yes_val }}"
+    class="toggle toggle-primary {{ input_class }}"
+    {% if required %}required{% endif %}
+    {% if value == yes_val %}checked{% endif %}
+    onchange="document.getElementById('{{ name }}_status').textContent = this.checked ? '{{ yes_val }}' : '{{ no_val }}';"
+  />
+  <span class="text-base-content {{ input_class }}" id="{{ name }}_status">{{ yes_val if value == yes_val else no_val }}</span>
 {% endmacro %}

--- a/src/frontend/frontend/templates/osint_source/osint_source_form.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_form.html
@@ -41,14 +41,3 @@
   <input type="submit" class="btn btn-primary w-full" value="{{ submit_text }}" />
 </form>
 </div>
-
-<script>
-  document.body.addEventListener('htmx:beforeSend', evt => {
-    const fd = evt.detail.requestConfig.parameters; // this is a FormData
-    console.group('🔍 HTMX Payload');
-    for (const [key, value] of fd.entries()) {
-      console.log(`${key} =`, value);
-    }
-    console.groupEnd();
-  });
-</script>

--- a/src/frontend/frontend/templates/osint_source/osint_source_form.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_form.html
@@ -41,3 +41,14 @@
   <input type="submit" class="btn btn-primary w-full" value="{{ submit_text }}" />
 </form>
 </div>
+
+<script>
+  document.body.addEventListener('htmx:beforeSend', evt => {
+    const fd = evt.detail.requestConfig.parameters; // this is a FormData
+    console.group('🔍 HTMX Payload');
+    for (const [key, value] of fd.entries()) {
+      console.log(`${key} =`, value);
+    }
+    console.groupEnd();
+  });
+</script>

--- a/src/frontend/frontend/templates/partials/worker_parameters.html
+++ b/src/frontend/frontend/templates/partials/worker_parameters.html
@@ -12,7 +12,7 @@
   {% elif field.type == 'textarea' %}
     {{ form_textarea(label=field.label, name='parameters[' + field.name + ']', value=field_value, required=required) }}
   {% elif field.type == 'switch' %}
-    {{ form_switch(label=field.label, name='parameters[' + field.name + ']', value=field_value, required=required) }}
+    {{ form_switch(label=field.label, name='parameters[' + field.name + ']', value=field_value, yes_val='true', no_val='false', required=required) }}
   {% elif field.type == 'cron_interval' %}
     {{ form_cron(label=field.label, name='parameters[' + field.name + ']', value=field_value, error=field.error, required=required) }}
   {% endif %}


### PR DESCRIPTION
At least, when you edit a collector, and you want to disable for example `BROWSER_MODE` or a different property using the `switch` component, it [does not emmit on false](https://stackoverflow.com/questions/1809494/post-unchecked-html-checkboxes).

It results in the inability to disable these settings that are switches.
The value of those sliders has changed for OSINTSources - from `"true"` and `"false"` to `"Yes"` and `"No"`, which the collectors are not adjusted to either.

## Summary by Sourcery

Ensure switch components in the frontend always submit a value by adding a hidden input for falsy states and standardize switch values to 'true'/'false'.

Bug Fixes:
- Fix form switches not emitting false states, restoring the ability to disable settings

Enhancements:
- Add a hidden input in form_switch macro to force submission of unchecked switch values
- Update worker_parameters partial to use 'true' and 'false' as switch labels and values