### PR TITLE
bump python version to 3.13

### DIFF
--- a/docker/Containerfile.core
+++ b/docker/Containerfile.core
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 WORKDIR /app/
@@ -20,7 +20,7 @@ RUN uv venv && \
     export PATH="/app/.venv/bin:$PATH" && \
     uv sync --frozen
 
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 LABEL description="Taranis AI Python Flask JSON RPC API"
 WORKDIR /app/

--- a/docker/Containerfile.frontend
+++ b/docker/Containerfile.frontend
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 WORKDIR /app/
@@ -21,7 +21,7 @@ RUN /app/build_tailwindcss.sh && \
     export PATH="/app/.venv/bin:$PATH" && \
     uv sync --frozen
 
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 LABEL description="Taranis AI Python Flask HTMX Frontend"
 WORKDIR /app/

--- a/docker/Containerfile.worker
+++ b/docker/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 WORKDIR /app/
@@ -24,7 +24,7 @@ RUN uv venv && \
     playwright install chromium --with-deps
 
 
-FROM python:3.12-slim
+FROM python:3.13-slim-bookworm
 
 LABEL description="Taranis AI Python Celery Worker"
 


### PR DESCRIPTION
Switch to Debian trixie on core & frontend
staying with bookworm on worker due to: https://github.com/microsoft/playwright/issues/36916

## Summary by Sourcery

Bump Python to 3.13 by updating the core and frontend Docker containers to Debian trixie while retaining Debian bookworm for the worker due to Playwright compatibility constraints

Enhancements:
- Switch core and frontend Containerfiles to Debian trixie with Python 3.13
- Keep worker Containerfile on Debian bookworm to avoid Playwright installation issue