### PR TITLE
Make NLP bot do tag updates in batches

### DIFF
--- a/src/worker/worker/bots/nlp_bot.py
+++ b/src/worker/worker/bots/nlp_bot.py
@@ -4,6 +4,11 @@ from worker.bot_api import BotApi
 from worker.log import logger
 
 
+def batched(stories: list, batch_size=10):
+    for i in range(0, len(stories), batch_size):
+        yield stories[i : i + batch_size]
+
+
 class NLPBot(BaseBot):
     def __init__(self, language="en"):
         super().__init__()
@@ -12,12 +17,15 @@ class NLPBot(BaseBot):
         self.bot_api = BotApi(Config.NLP_API_ENDPOINT)
 
     def execute(self, parameters: dict | None = None) -> dict:
+        update_result = {}
+
         if not parameters:
             parameters = {}
         if stories := self.get_stories(parameters):
             self.bot_api.update_parameters(parameters=parameters)
-            return self.process_stories(stories)
-
+            for story_batch in batched(stories):
+                update_result |= self.process_stories(story_batch)
+            return update_result
         return {"message": "No new stories found"}
 
     def collect_keywords(self, stories: list) -> dict:

--- a/src/worker/worker/tests/bots/test_bots.py
+++ b/src/worker/worker/tests/bots/test_bots.py
@@ -38,7 +38,7 @@ def test_nlp_bot(story_get_mock, tags_update_mock, ner_bot_mock):
     ner_bot_result = nlp_bot.execute()
 
     assert story_get_mock.call_count == 1
-    assert tags_update_mock.call_count == 1
+    assert tags_update_mock.call_count == 2
     assert ner_bot_mock.call_count > 1
 
     assert ner_bot_result


### PR DESCRIPTION
Since NLP can take a significant amount of time, it is better to regularly update the tags of a batch of stories.

## Summary by Sourcery

Process stories in batches in NLPBot.execute to update tags incrementally and aggregate results

Enhancements:
- Add batched helper to split story list into fixed-size chunks
- Modify NLPBot.execute to iterate over story batches, invoke processing per batch, and merge the update results

Tests:
- Adjust NLPBot tests to expect multiple tag update calls per batch