### PR TITLE
Fix summary not updatable with a falsy value

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -559,8 +559,8 @@ class Story(BaseModel):
             cls.reset_tags(story_id)
             cls.update_tags(story_id, data["tags"])
 
-        if summary := data.get("summary"):
-            story.summary = summary
+        if "summary" in data:
+            story.summary = data["summary"]
 
         if "attributes" in data:
             story.set_attributes(data["attributes"])


### PR DESCRIPTION
Summary should be updatable with an empty string. Current `if data.get("summary")` prevents that.

## Summary by Sourcery

Bug Fixes:
- Enable setting the summary to an empty string by replacing a truthiness check with a key existence check in the update method