### PR TITLE
Add report tag to a story when it is created from dict

### DIFF
--- a/src/core/core/api/analyze.py
+++ b/src/core/core/api/analyze.py
@@ -53,6 +53,9 @@ class ReportItem(MethodView):
     @auth_required("ANALYZE_CREATE")
     def post(self):
         try:
+            if not request.json:
+                logger.debug("No data in request")
+                return "No data in request", 400
             new_report_item, status = report_item.ReportItem.add(request.json, current_user)
         except Exception as ex:
             logger.exception()

--- a/src/core/core/model/report_item.py
+++ b/src/core/core/model/report_item.py
@@ -152,7 +152,7 @@ class ReportItem(BaseModel):
         return [cls.from_dict(report_item) for report_item in data]
 
     @classmethod
-    def add(cls, report_item_data, user):
+    def add(cls, report_item_data: dict, user: User | None = None) -> tuple["ReportItem", int]:
         report_item = cls.from_dict(report_item_data)
 
         if not report_item.allowed_with_acl(user, True):
@@ -161,6 +161,10 @@ class ReportItem(BaseModel):
         if user:
             report_item.user_id = user.id
         report_item.add_attributes()
+
+        if stories := report_item.stories:
+            for story in stories:
+                NewsItemTagService.add_report_tag(story, report_item)
 
         db.session.add(report_item)
         db.session.commit()


### PR DESCRIPTION
A report tag was not being added when a report was created "on the fly" with stories included.