### PR TITLE
Show bot result icons in Stoy Meta Info

### DIFF
--- a/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
+++ b/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
@@ -50,19 +50,21 @@ export default {
       if (isNaN(props.cybersecurityScore)) {
         return `Cybersecurity: ${props.cybersecurityStatus}`
       }
-      return `Cybersecurity: ${props.cybersecurityStatus}, Score: ${props.cybersecurityScore.toFixed(4)}`
+      return `Cybersecurity: ${props.cybersecurityStatus}, Score: ${props.cybersecurityScore.toFixed(3)}`
     })
 
     const statusIcon = computed(() => {
       switch (props.cybersecurityStatus?.toLowerCase()) {
         case 'yes':
-          return 'mdi-shield-half-full'
+          return 'mdi-shield'
         case 'no':
           return 'mdi-shield-off'
         case 'mixed':
-          return 'mdi-shield-half'
+          return 'mdi-shield-half-full'
+        case 'incomplete':
+          return 'mdi-shield-remove-outline'
         default:
-          return 'mdi-shield-outline'
+          return 'mdi-shield-off-outline'
       }
     })
 

--- a/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
+++ b/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
@@ -1,13 +1,13 @@
 <template>
-  <!--reduced view => render a single <td>, show only emoji + tooltip -->
-  <td v-if="reducedView && cybersecurityStatus" class="py-0">
+  <!-- reduced view => inline span (no table cell) -->
+  <span v-if="reducedView && cybersecurityStatus" class="inline-icon">
     <v-tooltip activator="parent" location="bottom">
       <template #activator="{ props }">
-        <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
+        <v-icon v-bind="props" size="x-small" class="mr-1" :icon="statusIcon" />
       </template>
       <span>{{ `Cybersecurity: ${cybersecurityStatus}` }}</span>
     </v-tooltip>
-  </td>
+  </span>
 
   <!-- full view -->
   <tr v-else-if="!reducedView && cybersecurityStatus">
@@ -45,7 +45,6 @@ export default {
     reducedView: { type: Boolean, default: false }
   },
   setup(props) {
-    // tooltip for full mode
     const fullTooltip = computed(() => {
       if (!props.cybersecurityStatus) return ''
       if (isNaN(props.cybersecurityScore)) {
@@ -61,16 +60,20 @@ export default {
         case 'no':
           return 'mdi-shield-off'
         case 'mixed':
-          return 'mdi-shield-half-full'
+          return 'mdi-shield-half'
         default:
           return 'mdi-shield-outline'
       }
     })
 
-    return {
-      fullTooltip,
-      statusIcon
-    }
+    return { fullTooltip, statusIcon }
   }
 }
 </script>
+
+<style scoped>
+.inline-icon {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
+++ b/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
@@ -1,0 +1,88 @@
+<template>
+  <tr v-if="!compactView && cybersecurityStatus">
+    <!-- reduced view, show only emoji + tooltip -->
+    <template v-if="reducedView">
+      <td class="py-0">
+        <v-tooltip activator="parent" location="bottom">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
+          </template>
+          <span>{{ reducedTooltip }}</span>
+        </v-tooltip>
+      </td>
+    </template>
+
+    <!-- full view -->
+    <template v-else>
+      <td class="py-0 news-item-title">
+        <strong>Cyberesecurity</strong>
+      </td>
+      <td class="py-0">
+        {{ cybersecurityStatus }}
+        <v-tooltip activator="parent" location="bottom">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
+          </template>
+          <span>{{ fullTooltip }}</span>
+        </v-tooltip>
+      </td>
+    </template>
+  </tr>
+</template>
+
+<script>
+import { computed } from 'vue'
+
+export default {
+  name: 'CybersecurityStatusInfo',
+  props: {
+    cybersecurityStatus: {
+      type: String,
+      required: false,
+      default: null
+    },
+    cybersecurityScore: {
+      type: Number,
+      required: false,
+      default: undefined
+    },
+    compactView: { type: Boolean, default: false },
+    reducedView: { type: Boolean, default: false }
+  },
+  setup(props) {
+    // tooltip for full mode
+    const fullTooltip = computed(() => {
+      if (!props.cybersecurityStatus) return ''
+      if (isNaN(props.cybersecurityScore)) {
+        return `Cybersecurity: ${props.cybersecurityStatus}`
+      }
+      return `Cybersecurity: ${props.cybersecurityStatus}, Score: ${(props.cybersecurityScore * 100).toFixed(2)}%`
+    })
+
+    // tooltip for reduced mode
+    const reducedTooltip = computed(() => {
+      if (!props.cybersecurityStatus) return ''
+      return `Cybersecurity: ${props.cybersecurityStatus}`
+    })
+
+    const statusIcon = computed(() => {
+      switch (props.cybersecurityStatus?.toLowerCase()) {
+        case 'yes':
+          return 'mdi-shield-half-full'
+        case 'no':
+          return 'mdi-shield-off'
+        case 'mixed':
+          return 'mdi-shield-half-full'
+        default:
+          return 'mdi-shield-outline'
+      }
+    })
+
+    return {
+      fullTooltip,
+      reducedTooltip,
+      statusIcon
+    }
+  }
+}
+</script>

--- a/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
+++ b/src/gui/src/components/assess/card/CybersecurityStatusInfo.vue
@@ -1,32 +1,28 @@
 <template>
-  <tr v-if="!compactView && cybersecurityStatus">
-    <!-- reduced view, show only emoji + tooltip -->
-    <template v-if="reducedView">
-      <td class="py-0">
-        <v-tooltip activator="parent" location="bottom">
-          <template #activator="{ props }">
-            <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
-          </template>
-          <span>{{ reducedTooltip }}</span>
-        </v-tooltip>
-      </td>
-    </template>
+  <!--reduced view => render a single <td>, show only emoji + tooltip -->
+  <td v-if="reducedView && cybersecurityStatus" class="py-0">
+    <v-tooltip activator="parent" location="bottom">
+      <template #activator="{ props }">
+        <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
+      </template>
+      <span>{{ `Cybersecurity: ${cybersecurityStatus}` }}</span>
+    </v-tooltip>
+  </td>
 
-    <!-- full view -->
-    <template v-else>
-      <td class="py-0 news-item-title">
-        <strong>Cyberesecurity</strong>
-      </td>
-      <td class="py-0">
-        {{ cybersecurityStatus }}
-        <v-tooltip activator="parent" location="bottom">
-          <template #activator="{ props }">
-            <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
-          </template>
-          <span>{{ fullTooltip }}</span>
-        </v-tooltip>
-      </td>
-    </template>
+  <!-- full view -->
+  <tr v-else-if="!reducedView && cybersecurityStatus">
+    <td class="py-0 news-item-title">
+      <strong>Cyberesecurity</strong>
+    </td>
+    <td class="py-0">
+      {{ cybersecurityStatus }}
+      <v-tooltip activator="parent" location="bottom">
+        <template #activator="{ props }">
+          <v-icon v-bind="props" size="x-small" :icon="statusIcon" />
+        </template>
+        <span>{{ fullTooltip }}</span>
+      </v-tooltip>
+    </td>
   </tr>
 </template>
 
@@ -46,7 +42,6 @@ export default {
       required: false,
       default: undefined
     },
-    compactView: { type: Boolean, default: false },
     reducedView: { type: Boolean, default: false }
   },
   setup(props) {
@@ -56,13 +51,7 @@ export default {
       if (isNaN(props.cybersecurityScore)) {
         return `Cybersecurity: ${props.cybersecurityStatus}`
       }
-      return `Cybersecurity: ${props.cybersecurityStatus}, Score: ${(props.cybersecurityScore * 100).toFixed(2)}%`
-    })
-
-    // tooltip for reduced mode
-    const reducedTooltip = computed(() => {
-      if (!props.cybersecurityStatus) return ''
-      return `Cybersecurity: ${props.cybersecurityStatus}`
+      return `Cybersecurity: ${props.cybersecurityStatus}, Score: ${props.cybersecurityScore.toFixed(4)}`
     })
 
     const statusIcon = computed(() => {
@@ -80,7 +69,6 @@ export default {
 
     return {
       fullTooltip,
-      reducedTooltip,
       statusIcon
     }
   }

--- a/src/gui/src/components/assess/card/NewsMetaInfo.vue
+++ b/src/gui/src/components/assess/card/NewsMetaInfo.vue
@@ -18,12 +18,10 @@
       <sentiment-info
         :sentiment-category="sentiment_category"
         :sentiment-score="sentiment_score"
-        :compact-view="compactView"
       />
       <cybersecurity-status-info
         :cybersecurity-status="cybersecurity_status"
         :cybersecurity-score="cybersecurity_score"
-        :compact-view="compactView"
       />
     </tbody>
   </table>

--- a/src/gui/src/components/assess/card/NewsMetaInfo.vue
+++ b/src/gui/src/components/assess/card/NewsMetaInfo.vue
@@ -15,7 +15,11 @@
       </tr>
       <article-info :news-item="newsItem" />
       <author-info :news-item="newsItem" />
-      <sentiment-info :news-item="newsItem" />
+      <sentiment-info
+        :sentiment-category="sentiment_category"
+        :sentiment-score="sentiment_score"
+        :compact-view="compactView"
+      />
     </tbody>
   </table>
 </template>
@@ -44,17 +48,12 @@ export default {
   },
   setup(props) {
     const { d } = useI18n()
+    const { compactView } = storeToRefs(useFilterStore())
 
     const published_date = computed(() => {
       return props.newsItem?.published
         ? d(new Date(props.newsItem.published), 'long')
         : null
-    })
-
-    const { compactView } = storeToRefs(useFilterStore())
-
-    const author = computed(() => {
-      return props.newsItem?.author
     })
 
     const collected_date = computed(() => {
@@ -63,11 +62,25 @@ export default {
         : null
     })
 
+    const sentiment_category = computed(() => {
+      return props.newsItem?.attributes?.find(
+        (attr) => attr.key === 'sentiment_category'
+      )?.value
+    })
+
+    const sentiment_score = computed(() => {
+      const score = props.newsItem?.attributes?.find(
+        (attr) => attr.key === 'sentiment_score'
+      )?.value
+      return score !== undefined ? parseFloat(score) : NaN
+    })
+
     return {
       published_date,
-      author,
       collected_date,
-      compactView
+      compactView,
+      sentiment_category,
+      sentiment_score
     }
   }
 }
@@ -78,7 +91,6 @@ export default {
   word-wrap: anywhere;
   width: 100%;
 }
-
 .newsitem-meta-info tr td {
   vertical-align: top;
 }

--- a/src/gui/src/components/assess/card/SentimentInfo.vue
+++ b/src/gui/src/components/assess/card/SentimentInfo.vue
@@ -1,13 +1,18 @@
 <template>
   <!-- reduced view => render a single <td>, show only emoji + tooltip -->
-  <td v-if="reducedView && sentimentCategory" class="py-0">
+  <span v-if="reducedView && sentimentCategory" class="inline-icon">
     <v-tooltip activator="parent" location="bottom">
       <template #activator="{ props }">
-        <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
+        <v-icon
+          v-bind="props"
+          size="x-small"
+          class="mr-1"
+          :icon="sentimentEmoji"
+        />
       </template>
       <span>{{ `Sentiment: ${sentimentCategory}` }}</span>
     </v-tooltip>
-  </td>
+  </span>
 
   <!-- full view -->
   <tr v-else-if="!reducedView && sentimentCategory">
@@ -72,3 +77,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.inline-icon {
+  display: inline-flex;
+  align-items: center;
+}
+</style>

--- a/src/gui/src/components/assess/card/SentimentInfo.vue
+++ b/src/gui/src/components/assess/card/SentimentInfo.vue
@@ -1,10 +1,10 @@
 <template>
-  <tr v-if="sentiment_category">
+  <tr v-if="sentimentCategory">
     <td v-if="!compactView" class="py-0 news-item-title">
       <strong>{{ $t('assess.sentiment') }}:</strong>
     </td>
     <td class="py-0">
-      {{ sentiment_category }}
+      {{ sentimentCategory }}
       <v-tooltip activator="parent" location="bottom">
         <template v-slot:activator="{ props }">
           <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
@@ -17,13 +17,18 @@
 
 <script>
 import { computed } from 'vue'
-
 export default {
   name: 'SentimentInfo',
   props: {
-    newsItem: {
-      type: Object,
-      required: true
+    sentimentCategory: {
+      type: String,
+      required: false,
+      default: null
+    },
+    sentimentScore: {
+      type: Number,
+      required: false,
+      default: undefined
     },
     compactView: {
       type: Boolean,
@@ -31,28 +36,15 @@ export default {
     }
   },
   setup(props) {
-    const sentiment_category = computed(() => {
-      return props.newsItem?.attributes?.find(
-        (attr) => attr.key === 'sentiment_category'
-      )?.value
-    })
-
-    const sentiment_score = computed(() => {
-      const score = props.newsItem?.attributes?.find(
-        (attr) => attr.key === 'sentiment_score'
-      )?.value
-      return score !== undefined ? parseFloat(score) : NaN
-    })
-
     const sentimentTooltip = computed(() => {
-      if (isNaN(sentiment_score.value)) {
-        return `Sentiment is ${sentiment_category.value} with no score available`
+      if (isNaN(props.sentimentScore)) {
+        return `Sentiment is ${props.sentimentCategory} with no score available`
       }
-      return `Sentiment is ${sentiment_category.value} with a score of ${(sentiment_score.value * 100).toFixed(2)}%`
+      return `Sentiment is ${props.sentimentCategory} with a score of ${(props.sentimentScore * 100).toFixed(2)}%`
     })
 
     const sentimentEmoji = computed(() => {
-      switch (sentiment_category.value?.toLowerCase()) {
+      switch (props.sentimentCategory.toLowerCase()) {
         case 'positive':
           return 'mdi-emoticon-happy-outline'
         case 'negative':
@@ -65,8 +57,6 @@ export default {
     })
 
     return {
-      sentiment_category,
-      sentiment_score,
       sentimentTooltip,
       sentimentEmoji
     }

--- a/src/gui/src/components/assess/card/SentimentInfo.vue
+++ b/src/gui/src/components/assess/card/SentimentInfo.vue
@@ -1,17 +1,32 @@
 <template>
-  <tr v-if="sentimentCategory">
-    <td v-if="!compactView" class="py-0 news-item-title">
-      <strong>{{ $t('assess.sentiment') }}:</strong>
-    </td>
-    <td class="py-0">
-      {{ sentimentCategory }}
-      <v-tooltip activator="parent" location="bottom">
-        <template v-slot:activator="{ props }">
-          <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
-        </template>
-        <span>{{ sentimentTooltip }}</span>
-      </v-tooltip>
-    </td>
+  <tr v-if="!compactView && sentimentCategory">
+    <!-- reduced view, show only emoji + tooltip -->
+    <template v-if="reduced">
+      <td class="py-0">
+        <v-tooltip activator="parent" location="bottom">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
+          </template>
+          <span>{{ reducedTooltip }}</span>
+        </v-tooltip>
+      </td>
+    </template>
+
+    <!-- full view -->
+    <template v-else>
+      <td class="py-0 news-item-title">
+        <strong>{{ $t('assess.sentiment') }}:</strong>
+      </td>
+      <td class="py-0">
+        {{ sentimentCategory }}
+        <v-tooltip activator="parent" location="bottom">
+          <template #activator="{ props }">
+            <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
+          </template>
+          <span>{{ fullTooltip }}</span>
+        </v-tooltip>
+      </td>
+    </template>
   </tr>
 </template>
 
@@ -33,14 +48,21 @@ export default {
     compactView: {
       type: Boolean,
       default: false
-    }
+    },
+    reduced: { type: Boolean, default: false }
   },
   setup(props) {
-    const sentimentTooltip = computed(() => {
+    const fullTooltip = computed(() => {
+      if (!props.sentimentCategory) return ''
       if (isNaN(props.sentimentScore)) {
         return `Sentiment is ${props.sentimentCategory} with no score available`
       }
       return `Sentiment is ${props.sentimentCategory} with a score of ${(props.sentimentScore * 100).toFixed(2)}%`
+    })
+
+    const reducedTooltip = computed(() => {
+      if (!props.sentimentCategory) return ''
+      return `Sentiment is ${props.sentimentCategory}`
     })
 
     const sentimentEmoji = computed(() => {
@@ -57,7 +79,8 @@ export default {
     })
 
     return {
-      sentimentTooltip,
+      fullTooltip,
+      reducedTooltip,
       sentimentEmoji
     }
   }

--- a/src/gui/src/components/assess/card/SentimentInfo.vue
+++ b/src/gui/src/components/assess/card/SentimentInfo.vue
@@ -65,6 +65,8 @@ export default {
           return 'mdi-emoticon-sad-outline'
         case 'neutral':
           return 'mdi-emoticon-neutral-outline'
+        case 'mixed':
+          return 'mdi-emoticon-confused-outline'
         default:
           return 'mdi-emoticon-outline'
       }

--- a/src/gui/src/components/assess/card/SentimentInfo.vue
+++ b/src/gui/src/components/assess/card/SentimentInfo.vue
@@ -1,32 +1,28 @@
 <template>
-  <tr v-if="!compactView && sentimentCategory">
-    <!-- reduced view, show only emoji + tooltip -->
-    <template v-if="reduced">
-      <td class="py-0">
-        <v-tooltip activator="parent" location="bottom">
-          <template #activator="{ props }">
-            <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
-          </template>
-          <span>{{ reducedTooltip }}</span>
-        </v-tooltip>
-      </td>
-    </template>
+  <!-- reduced view => render a single <td>, show only emoji + tooltip -->
+  <td v-if="reducedView && sentimentCategory" class="py-0">
+    <v-tooltip activator="parent" location="bottom">
+      <template #activator="{ props }">
+        <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
+      </template>
+      <span>{{ `Sentiment: ${sentimentCategory}` }}</span>
+    </v-tooltip>
+  </td>
 
-    <!-- full view -->
-    <template v-else>
-      <td class="py-0 news-item-title">
-        <strong>{{ $t('assess.sentiment') }}:</strong>
-      </td>
-      <td class="py-0">
-        {{ sentimentCategory }}
-        <v-tooltip activator="parent" location="bottom">
-          <template #activator="{ props }">
-            <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
-          </template>
-          <span>{{ fullTooltip }}</span>
-        </v-tooltip>
-      </td>
-    </template>
+  <!-- full view -->
+  <tr v-else-if="!reducedView && sentimentCategory">
+    <td class="py-0 news-item-title">
+      <strong>{{ $t('assess.sentiment') }}:</strong>
+    </td>
+    <td class="py-0">
+      {{ sentimentCategory }}
+      <v-tooltip activator="parent" location="bottom">
+        <template #activator="{ props }">
+          <v-icon v-bind="props" size="x-small" :icon="sentimentEmoji" />
+        </template>
+        <span>{{ fullTooltip }}</span>
+      </v-tooltip>
+    </td>
   </tr>
 </template>
 
@@ -45,11 +41,7 @@ export default {
       required: false,
       default: undefined
     },
-    compactView: {
-      type: Boolean,
-      default: false
-    },
-    reduced: { type: Boolean, default: false }
+    reducedView: { type: Boolean, default: false }
   },
   setup(props) {
     const fullTooltip = computed(() => {
@@ -58,11 +50,6 @@ export default {
         return `Sentiment is ${props.sentimentCategory} with no score available`
       }
       return `Sentiment is ${props.sentimentCategory} with a score of ${(props.sentimentScore * 100).toFixed(2)}%`
-    })
-
-    const reducedTooltip = computed(() => {
-      if (!props.sentimentCategory) return ''
-      return `Sentiment is ${props.sentimentCategory}`
     })
 
     const sentimentEmoji = computed(() => {
@@ -80,7 +67,6 @@ export default {
 
     return {
       fullTooltip,
-      reducedTooltip,
       sentimentEmoji
     }
   }

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -69,6 +69,16 @@
         v-if="detailView && story.news_items.length === 1"
         :news-item="story.news_items[0]"
       />
+      <sentiment-info
+        v-if="
+          detailView &&
+          story_sentiment_category &&
+          story_sentiment_category !== 'none'
+        "
+        :sentiment-category="story_sentiment_category"
+        :compact-view="compactView"
+        :reduced="true"
+      />
       <v-dialog v-model="showTagDialog" width="auto">
         <popup-edit-tags
           :tags="story.tags"
@@ -94,6 +104,7 @@ import AuthorInfo from '@/components/assess/card/AuthorInfo.vue'
 import PopupEditTags from '@/components/popups/PopupEditTags.vue'
 import StoryVotes from '@/components/assess/card/StoryVotes.vue'
 import RelevanceIndicator from '@/components/assess/card/RelevanceIndicator.vue'
+import SentimentInfo from '@/components/assess/card/SentimentInfo.vue'
 
 export default {
   name: 'StoryMetaInfo',
@@ -103,7 +114,8 @@ export default {
     AuthorInfo,
     StoryVotes,
     TagList,
-    RelevanceIndicator
+    RelevanceIndicator,
+    SentimentInfo
   },
   props: {
     story: {
@@ -192,6 +204,43 @@ export default {
       return ['']
     })
 
+    const story_sentiment_category = computed(() => {
+      const items = props.story?.news_items ?? []
+      if (!Array.isArray(items) || items.length === 0) return 'none'
+
+      let pos = 0,
+        neg = 0,
+        neu = 0
+
+      for (const item of items) {
+        const cat = item?.attributes?.find(
+          (a) => a.key === 'sentiment_category'
+        )?.value
+        switch ((cat || '').toString().toLowerCase()) {
+          case 'positive':
+            pos++
+            break
+          case 'negative':
+            neg++
+            break
+          case 'neutral':
+            neu++
+            break
+          default:
+            break
+        }
+      }
+
+      if (pos === 0 && neg === 0 && neu === 0) return 'none'
+
+      const maxCount = Math.max(pos, neg, neu)
+      const leaders = []
+      if (pos === maxCount) leaders.push('positive')
+      if (neg === maxCount) leaders.push('negative')
+      if (neu === maxCount) leaders.push('neutral')
+      return leaders.length === 1 ? leaders[0] : 'mixed'
+    })
+
     function editTags() {
       console.log('edit tags')
       showTagDialog.value = true
@@ -209,6 +258,7 @@ export default {
       published_date_outdated,
       story_in_reports,
       getPublishedDate,
+      story_sentiment_category,
       filteredTags,
       editTags,
       getSharingIcon,

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -69,26 +69,21 @@
         v-if="detailView && story.news_items.length === 1"
         :news-item="story.news_items[0]"
       />
-      <sentiment-info
-        v-if="
-          detailView &&
-          story_sentiment_category &&
-          story_sentiment_category !== 'none'
-        "
-        :sentiment-category="story_sentiment_category"
-        :compact-view="compactView"
-        :reduced="true"
-      />
-      <cybersecurity-status-info
-        v-if="
-          detailView &&
-          story_cybersecurity_status &&
-          story_cybersecurity_status !== 'none'
-        "
-        :cybersecurity-status="story_cybersecurity_status"
-        :compact-view="compactView"
-        :reducedView="true"
-      />
+      <tr v-if="detailView">
+        <sentiment-info
+          v-if="story_sentiment_category && story_sentiment_category !== 'none'"
+          :sentiment-category="story_sentiment_category"
+          :reduced-view="true"
+        />
+        <cybersecurity-status-info
+          v-if="
+            story_cybersecurity_status &&
+            ['yes', 'no', 'mixed'].includes(story_cybersecurity_status)
+          "
+          :cybersecurity-status="story_cybersecurity_status"
+          :reduced-view="true"
+        />
+      </tr>
       <v-dialog v-model="showTagDialog" width="auto">
         <popup-edit-tags
           :tags="story.tags"

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -70,19 +70,23 @@
         :news-item="story.news_items[0]"
       />
       <tr v-if="detailView">
-        <sentiment-info
-          v-if="story_sentiment_category && story_sentiment_category !== 'none'"
-          :sentiment-category="story_sentiment_category"
-          :reduced-view="true"
-        />
-        <cybersecurity-status-info
-          v-if="
-            story_cybersecurity_status &&
-            ['yes', 'no', 'mixed'].includes(story_cybersecurity_status)
-          "
-          :cybersecurity-status="story_cybersecurity_status"
-          :reduced-view="true"
-        />
+        <td class="py-0">
+          <sentiment-info
+            v-if="
+              story_sentiment_category && story_sentiment_category !== 'none'
+            "
+            :sentiment-category="story_sentiment_category"
+            :reduced-view="true"
+          />
+          <cybersecurity-status-info
+            v-if="
+              story_cybersecurity_status &&
+              ['yes', 'no', 'mixed'].includes(story_cybersecurity_status)
+            "
+            :cybersecurity-status="story_cybersecurity_status"
+            :reduced-view="true"
+          />
+        </td>
       </tr>
       <v-dialog v-model="showTagDialog" width="auto">
         <popup-edit-tags

--- a/src/gui/src/components/assess/card/StoryMetaInfo.vue
+++ b/src/gui/src/components/assess/card/StoryMetaInfo.vue
@@ -257,35 +257,26 @@ export default {
       const human = attrs.find((a) => a.key === 'cybersecurity_human')?.value
       const bot = attrs.find((a) => a.key === 'cybersecurity_bot')?.value
       const chosen = human ?? bot
-      if (chosen === undefined || chosen === null || chosen === '')
-        return 'none'
-      const v = String(chosen).trim().toLowerCase()
+      const v = (chosen ?? '').toString().trim().toLowerCase()
+
       if (v === 'yes' || v === 'true' || v === '1') return 'yes'
       if (v === 'no' || v === 'false' || v === '0') return 'no'
-      if (v === 'mixed') return 'mixed'
+
       return 'none'
     }
 
     const story_cybersecurity_status = computed(() => {
       const items = props.story?.news_items ?? []
-      const statusList = items.map(getItemCybersecurityStatus)
-      const statusSet = new Set(statusList)
+      const set = new Set(items.map(getItemCybersecurityStatus))
 
-      if (statusSet.has('none') && statusSet.size > 1) return 'incomplete'
-
-      const key = [...statusSet].sort().join('|')
-      switch (key) {
-        case 'no':
-          return 'no'
-        case 'yes':
-          return 'yes'
-        case 'yes|no':
-          return 'mixed'
-        case 'none':
-          return 'none'
-        default:
-          return 'none'
+      if (set.has('none') && set.size > 1) return 'incomplete'
+      if (set.has('yes') && set.has('no') && set.size === 2) return 'mixed'
+      if (set.size === 1) {
+        if (set.has('yes')) return 'yes'
+        if (set.has('no')) return 'no'
+        if (set.has('none')) return 'none'
       }
+      return 'none'
     })
 
     function editTags() {


### PR DESCRIPTION
The results of bot runs (currently: sentiment and cybersec classifier) should be visible not only in the NewsItem MetaInfo, but also in the MetaInfo of the Story
Show an icon together with a short tooltip, if the StoryCard is expanded (detailView)

## Detailed changes

- Create CybersecurityStatusInfo.vue component - analogue to SentimentInfo.vue, display The Cybersecurity status, the score and a corresponding icon
- Add reducedView to SentimentInfo.vue and CybersecurityStatusInfo.vue - display only the icon + tooltip (for StoryMetaInfo.vue)
- Calculate the story sentiment and cybersecurity status as a composition of the individual news item statuses (similar to what is done in story.py)