### PR TITLE
Reorder tmux panes without gap

### DIFF
--- a/dev/start_tmux.sh
+++ b/dev/start_tmux.sh
@@ -9,13 +9,13 @@ tmux new-session -s taranis -n core -c src/core -d
 tmux send-keys -t taranis:core "./install_and_run_dev.sh" C-m
 
 # Create Frontend tabs
-tmux new-window -t taranis:2 -n tailwind -c src/frontend
+tmux new-window -t taranis:1 -n tailwind -c src/frontend
 tmux send-keys -t taranis:tailwind "./install_and_run_tailwind.sh" C-m
-tmux new-window -t taranis:3 -n frontend -c src/frontend
+tmux new-window -t taranis:2 -n frontend -c src/frontend
 tmux send-keys -t taranis:frontend "./install_and_run_dev.sh" C-m
 
 # Create Worker tab
-tmux new-window -t taranis:4 -n worker -c src/worker
+tmux new-window -t taranis:3 -n worker -c src/worker
 tmux send-keys -t taranis:worker "./install_and_run_dev.sh" C-m
 
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Reassign tmux window indices for tailwind, frontend, and worker tabs to use consecutive indices starting from 1