### PR TITLE
Refactor install_and_run_dev.sh scripts 

### DIFF
--- a/src/core/install_and_run_dev.sh
+++ b/src/core/install_and_run_dev.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Deactivate any active virtual environment to avoid conflicts
-if [ -n "${VIRTUAL_ENV:-}" ]; then
-    unset VIRTUAL_ENV
-    unset PYTHONHOME
-    PATH=$(echo "$PATH" | sed -e "s|${VIRTUAL_ENV}/bin:||")
-fi
-
 set -eu
 
 uv sync --all-extras --frozen --python 3.13 --no-install-package taranis-models

--- a/src/frontend/install_and_run_dev.sh
+++ b/src/frontend/install_and_run_dev.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Deactivate any active virtual environment to avoid conflicts
-if [ -n "${VIRTUAL_ENV:-}" ]; then
-    unset VIRTUAL_ENV
-    unset PYTHONHOME
-    PATH=$(echo "$PATH" | sed -e "s|${VIRTUAL_ENV}/bin:||")
-fi
-
 set -eu
 
 uv sync --all-extras --frozen --python 3.13 --no-install-package taranis-models

--- a/src/worker/install_and_run_dev.sh
+++ b/src/worker/install_and_run_dev.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Deactivate any active virtual environment to avoid conflicts
-if [ -n "${VIRTUAL_ENV:-}" ]; then
-    unset VIRTUAL_ENV
-    unset PYTHONHOME
-    PATH=$(echo "$PATH" | sed -e "s|${VIRTUAL_ENV}/bin:||")
-fi
-
 set -eu
 
 uv sync --all-extras --frozen --python 3.13 --no-install-package taranis-models


### PR DESCRIPTION
My frontend did not start because it used a wrong venv, 
so i propose these changes to deactivate venvs and start python prefixed with uv.

## Summary by Sourcery

Refactor development start-up scripts to ensure a clean Python environment by deactivating any existing virtual environment and running services with uv run instead of manual venv activation

Enhancements:
- Add automatic deactivation of any active Python virtual environment to avoid conflicts before dependency installation
- Replace sourcing of .venv/bin/activate with uv run python for running Flask and worker scripts across frontend, worker, and core directories