### PR TITLE
feat: Add configurable NLP bot confidence threshold

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -226,6 +226,7 @@ services:
     environment:
       API_KEY: "${BOT_API_KEY}"
       DEBUG: "${DEBUG:-False}"
+      CONFIDENCE_THRESHOLD: "${NLP_CONFIDENCE_THRESHOLD:-0.5}"  # Lowered from 0.7 default
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
- Add CONFIDENCE_THRESHOLD environment variable to nlp_bot service
- Default threshold lowered from 0.7 to 0.5 for better tag extraction
- Enables more aggressive entity extraction from news articles
- Addresses issue where NLP bot was too conservative, extracting 0 tags

This change allows the NLP bot to extract more entities (Person, Location, Organization) from news content, which is essential for story clustering to function properly. The threshold can be overridden via NLP_CONFIDENCE_THRESHOLD environment variable.


🚨Please review the [guidelines for contributing](https://github.com/taranis-ai/.github/blob/master/CONTRIBUTING.md) to this repository.

## Summary by Sourcery

Build:
- Introduce CONFIDENCE_THRESHOLD environment variable for the NLP bot service in docker-compose, defaulting to a lower threshold of 0.5 for more permissive entity extraction.