### PR TITLE
`NewsItem.updated` timestamp freeze

### DIFF
--- a/src/core/core/model/news_item.py
+++ b/src/core/core/model/news_item.py
@@ -64,8 +64,6 @@ class NewsItem(BaseModel):
         title: str,
         source: str,
         content: str,
-        published: datetime | str,
-        collected: datetime | str,
         osint_source_id: str = "manual",
         review: str = "",
         author: str = "",
@@ -75,6 +73,8 @@ class NewsItem(BaseModel):
         attributes=None,
         id=None,
         last_change="external",
+        published: datetime | str | None = None,
+        collected: datetime | str | None = None,
         story_id: str = "",
     ):
         self.id = id or str(uuid.uuid4())


### PR DESCRIPTION
- `NewsItem.update` timestamp was only initialised once.
- Usage of a callable makes this behave correctly for each row in the database.
- `Column.onupdate` assures that if no value is passed to `NewsItem.updated` it will set a proper default.

## Summary by Sourcery

Ensure NewsItem timestamps are initialized and updated using callables for per-row defaults.

Bug Fixes:
- Fix NewsItem.updated so it is refreshed on each update instead of being set only once at model definition time.

Enhancements:
- Use callable defaults for collected and published timestamps to create per-instance values instead of sharing a single datetime across all rows.
- Require published and collected timestamps as constructor arguments instead of defaulting them at instantiation time.