### PR TITLE
hotfix fts

### DIFF
--- a/src/core/core/sql/fulltext_search.sql
+++ b/src/core/core/sql/fulltext_search.sql
@@ -2,7 +2,8 @@ CREATE EXTENSION IF NOT EXISTS unaccent;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- Ensure Story has a tsvector column for full-text search
-ALTER TABLE story ADD COLUMN IF NOT EXISTS search_vector tsvector NOT NULL DEFAULT ''::tsvector;
+ALTER TABLE story ADD COLUMN IF NOT EXISTS search_vector tsvector DEFAULT ''::tsvector;
+ALTER TABLE story ALTER COLUMN search_vector DROP NOT NULL;
 
 -- Build a weighted tsvector for a Story (IDs are TEXT)
 CREATE OR REPLACE FUNCTION fts_build_story_search_vector(story_row_id text)


### PR DESCRIPTION
## Summary by Sourcery

Relax the NOT NULL constraint on the story full-text search vector column to allow existing and new rows without an initialized search vector.

Bug Fixes:
- Allow stories to exist without a populated search_vector to prevent failures when the column cannot be immediately computed.

Enhancements:
- Set a default empty tsvector for the story search_vector column while no longer enforcing NOT NULL.