### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Analysts then refine these AI-augmented articles into structured reports that se
 
 ## Getting Started
 
-For production deployments see our [Deployment Guide using docker compose](https://taranis.ai/docs/getting-started/01_deployment/)
+For production deployments, see our [Deployment Guide using docker compose](https://taranis.ai/docs/getting-started/01_deployment/)
 
 ## Contributions
 


### PR DESCRIPTION
Files in the getting-started dir in taranis.ai are now numbered.
Change deployment -> 01_deployment in README.md

## Summary by Sourcery

Documentation:
- Update the Getting Started section in README to link to the new numbered deployment guide path.