### PR TITLE
Add SQLAlchemy pool timeout and recycle options to configuration

### DIFF
--- a/src/core/core/config.py
+++ b/src/core/core/config.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse, urlunparse
 
-from pydantic import SecretStr, ValidationInfo, field_validator, model_validator
+from pydantic import Field, SecretStr, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -50,8 +50,8 @@ class Settings(BaseSettings):
     SQLALCHEMY_CONNECT_TIMEOUT: int = 10
     SQLALCHEMY_MAX_OVERFLOW: int = 10
     SQLALCHEMY_POOL_SIZE: int = 20
-    SQLALCHEMY_POOL_TIMEOUT: int | None = None
-    SQLALCHEMY_POOL_RECYCLE: int | None = None
+    SQLALCHEMY_POOL_TIMEOUT: Annotated[int | None, Field(gt=0)] = None
+    SQLALCHEMY_POOL_RECYCLE: Annotated[int | None, Field(ge=-1)] = None
     COLORED_LOGS: bool = True
     BUILD_DATE: datetime = datetime.now()
     GIT_INFO: dict[str, str] | None = None

--- a/src/core/core/config.py
+++ b/src/core/core/config.py
@@ -50,6 +50,8 @@ class Settings(BaseSettings):
     SQLALCHEMY_CONNECT_TIMEOUT: int = 10
     SQLALCHEMY_MAX_OVERFLOW: int = 10
     SQLALCHEMY_POOL_SIZE: int = 20
+    SQLALCHEMY_POOL_TIMEOUT: int | None = None
+    SQLALCHEMY_POOL_RECYCLE: int | None = None
     COLORED_LOGS: bool = True
     BUILD_DATE: datetime = datetime.now()
     GIT_INFO: dict[str, str] | None = None
@@ -72,12 +74,16 @@ class Settings(BaseSettings):
             self.SQLALCHEMY_ENGINE_OPTIONS.update({"connect_args": {"timeout": self.SQLALCHEMY_CONNECT_TIMEOUT}})
         elif self.SQLALCHEMY_DATABASE_URI.startswith("postgresql"):
             self.SQLALCHEMY_ENGINE_OPTIONS.update({"connect_args": {"connect_timeout": self.SQLALCHEMY_CONNECT_TIMEOUT}})
-        self.SQLALCHEMY_ENGINE_OPTIONS.update(
-            {
-                "pool_size": self.SQLALCHEMY_POOL_SIZE,
-                "max_overflow": self.SQLALCHEMY_MAX_OVERFLOW,
-            }
-        )
+
+        update_payload = {
+            "pool_size": self.SQLALCHEMY_POOL_SIZE,
+            "max_overflow": self.SQLALCHEMY_MAX_OVERFLOW,
+        }
+        if self.SQLALCHEMY_POOL_TIMEOUT is not None:
+            update_payload["pool_timeout"] = self.SQLALCHEMY_POOL_TIMEOUT
+        if self.SQLALCHEMY_POOL_RECYCLE is not None:
+            update_payload["pool_recycle"] = self.SQLALCHEMY_POOL_RECYCLE
+        self.SQLALCHEMY_ENGINE_OPTIONS.update(update_payload)
         self.SQLALCHEMY_DATABASE_URI_MASK = mask_db_uri(self.SQLALCHEMY_DATABASE_URI)
         return self
 

--- a/src/core/tests/test_settings.py
+++ b/src/core/tests/test_settings.py
@@ -135,6 +135,9 @@ def test_pool_options_applied_to_actual_engine(app):
 
 def test_pool_options_with_custom_values_applied_to_engine(monkeypatch, clear_pool_env_vars):
     """Integration test: verify custom pool timeout and recycle values are applied to the engine via app context."""
+    import os
+
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", os.getenv("SQLALCHEMY_DATABASE_URI", "sqlite:////tmp/taranis_ai_test.db"))
     monkeypatch.setenv("SQLALCHEMY_POOL_TIMEOUT", "25")
     monkeypatch.setenv("SQLALCHEMY_POOL_RECYCLE", "7200")
 

--- a/src/core/tests/test_settings.py
+++ b/src/core/tests/test_settings.py
@@ -2,6 +2,7 @@ from pydantic import SecretStr
 import pytest
 from core.config import Settings
 
+
 @pytest.mark.parametrize(
     "raw_uri",
     [
@@ -26,9 +27,8 @@ def test_psycopg_multi_host_uri(monkeypatch, raw_uri):
     assert "db-1" in settings.SQLALCHEMY_DATABASE_URI
     assert "db-2" in settings.SQLALCHEMY_DATABASE_URI
     assert "db-3" in settings.SQLALCHEMY_DATABASE_URI
-    assert settings.SQLALCHEMY_ENGINE_OPTIONS["connect_args"] == {
-        "connect_timeout": settings.SQLALCHEMY_CONNECT_TIMEOUT
-    }
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["connect_args"] == {"connect_timeout": settings.SQLALCHEMY_CONNECT_TIMEOUT}
+
 
 def test_api_key(app):
     from core.config import Config
@@ -42,3 +42,108 @@ def test_flask_secret_key(app):
     with app.app_context():
         secret_key = app.config.get("JWT_SECRET_KEY", None)
         assert secret_key == "test_key"
+
+
+def test_sqlalchemy_pool_timeout_env_var(monkeypatch):
+    """Test that SQLALCHEMY_POOL_TIMEOUT is correctly read from environment and added to engine options."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_TIMEOUT", raising=False)
+
+    settings = Settings(SQLALCHEMY_POOL_TIMEOUT=666)
+
+    assert settings.SQLALCHEMY_POOL_TIMEOUT == 666
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_timeout"] == 666
+
+
+def test_sqlalchemy_pool_timeout_not_set(monkeypatch):
+    """Test that SQLALCHEMY_POOL_TIMEOUT is optional and not added to engine options when None."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_TIMEOUT", raising=False)
+
+    settings = Settings()
+
+    assert settings.SQLALCHEMY_POOL_TIMEOUT is None
+    assert "pool_timeout" not in settings.SQLALCHEMY_ENGINE_OPTIONS
+
+
+def test_sqlalchemy_pool_recycle_env_var(monkeypatch):
+    """Test that SQLALCHEMY_POOL_RECYCLE is correctly read from environment and added to engine options."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_RECYCLE", raising=False)
+
+    settings = Settings(SQLALCHEMY_POOL_RECYCLE=3600)
+
+    assert settings.SQLALCHEMY_POOL_RECYCLE == 3600
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_recycle"] == 3600
+
+
+def test_sqlalchemy_pool_recycle_not_set(monkeypatch):
+    """Test that SQLALCHEMY_POOL_RECYCLE is optional and not added to engine options when None."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_RECYCLE", raising=False)
+
+    settings = Settings()
+
+    assert settings.SQLALCHEMY_POOL_RECYCLE is None
+    assert "pool_recycle" not in settings.SQLALCHEMY_ENGINE_OPTIONS
+
+
+def test_sqlalchemy_pool_timeout_and_recycle_both_set(monkeypatch):
+    """Test that both SQLALCHEMY_POOL_TIMEOUT and SQLALCHEMY_POOL_RECYCLE are added to engine options."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_TIMEOUT", raising=False)
+    monkeypatch.delenv("SQLALCHEMY_POOL_RECYCLE", raising=False)
+
+    settings = Settings(SQLALCHEMY_POOL_TIMEOUT=666, SQLALCHEMY_POOL_RECYCLE=3600)
+
+    assert settings.SQLALCHEMY_POOL_TIMEOUT == 666
+    assert settings.SQLALCHEMY_POOL_RECYCLE == 3600
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_timeout"] == 666
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_recycle"] == 3600
+
+
+def test_sqlalchemy_engine_options_includes_pool_size_and_max_overflow(monkeypatch):
+    """Test that basic pool size and max overflow are always included in engine options."""
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+
+    settings = Settings()
+
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_size"] == settings.SQLALCHEMY_POOL_SIZE
+    assert settings.SQLALCHEMY_ENGINE_OPTIONS["max_overflow"] == settings.SQLALCHEMY_MAX_OVERFLOW
+
+
+def test_pool_options_applied_to_actual_engine(app):
+    """Integration test: verify default pool options are applied to the actual Flask app's database engine."""
+    from core.managers.db_manager import db
+
+    with app.app_context():
+        pool = db.engine.pool
+
+        # Verify pool size is configured
+        assert pool.size() == 20
+
+        # Verify pool timeout - default is 30 seconds when SQLALCHEMY_POOL_TIMEOUT is None
+        assert pool._timeout == 30
+
+        # Verify pool recycle - default is -1 (disabled) when SQLALCHEMY_POOL_RECYCLE is None
+        assert pool._recycle == -1
+
+
+def test_pool_options_with_custom_values_applied_to_engine(monkeypatch):
+    """Integration test: verify custom pool timeout and recycle values are applied to SQLAlchemy engine."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import QueuePool
+
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+
+    settings = Settings(SQLALCHEMY_POOL_TIMEOUT=25, SQLALCHEMY_POOL_RECYCLE=7200)
+
+    # Create engine with custom options using QueuePool (which supports timeout/recycle)
+    engine = create_engine("sqlite:///:memory:", poolclass=QueuePool, **settings.SQLALCHEMY_ENGINE_OPTIONS)
+
+    # Verify custom values are applied to the pool
+    assert engine.pool._timeout == 25
+    assert engine.pool._recycle == 7200
+    assert engine.pool.size() == settings.SQLALCHEMY_POOL_SIZE
+
+    engine.dispose()


### PR DESCRIPTION
Add SQLALCHEMY_POOL_TIMEOUT and SQLALCHEMY_POOL_RECYCLE as sqlalchemy options.

Can be set via ENV variables.

## Summary by Sourcery

Add configurable SQLAlchemy connection pool timeout and recycle options and ensure they are propagated into engine options and the actual engine pool.

New Features:
- Introduce SQLALCHEMY_POOL_TIMEOUT and SQLALCHEMY_POOL_RECYCLE settings that can be configured via environment and passed to SQLAlchemy engine options.

Tests:
- Add unit and integration tests verifying pool timeout and recycle defaults, optional behavior, and application to engine pools, alongside existing pool size and max overflow options.