### PR TITLE
Fix use configured credentials in postgres healthcheck

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -89,7 +89,7 @@ services:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-taranis}"
     command: ["postgres", "-c", "shared_buffers=${DB_SHARED_BUFFERS:-64MB}", "-c", "max_connections=${DB_MAX_CONNECTIONS:-1000}"]
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-taranis} -d ${DB_DATABASE:-taranis}"]
       interval: 10s
       start_period: 10s
       timeout: 3s


### PR DESCRIPTION
## Summary
Fix PostgreSQL healthcheck in `docker/compose.yml` to use the configured DB user and database instead of implicit defaults.

## Problem
The DB container logs repeatedly showed:

`FATAL: role "root" does not exist`

Root cause: `pg_isready` was executed without explicit `-U`/`-d`, so the check attempted a connection with the container OS user (`root`), which is not a PostgreSQL role.

## Change
Updated healthcheck in `docker/compose.yml`:

- from: `["CMD", "pg_isready"]`
- to: `["CMD-SHELL", "pg_isready -U ${DB_USER:-taranis} -d ${DB_DATABASE:-taranis}"]`

This makes the healthcheck authenticate against the intended PostgreSQL role/database and aligns behavior with `dev/compose.yml`.

## Impact
- Removes noisy/failing `role "root" does not exist` log entries caused by healthchecks.

## Verification
- Start stack: `docker compose -f docker/compose.yml up -d`
- Check DB logs: `docker compose -f docker/compose.yml logs database`
- Expected: no new `FATAL: role "root" does not exist` entries from healthchecks.

## Summary by Sourcery

Bug Fixes:
- Correct PostgreSQL healthcheck to authenticate with the configured database user and database, avoiding failures due to using the OS root user.