### PR TITLE
Use key instead of code in Shift + R handling

### DIFF
--- a/src/frontend/frontend/templates/assess/assess_top_bar.html
+++ b/src/frontend/frontend/templates/assess/assess_top_bar.html
@@ -29,7 +29,7 @@
 
         <button type="button"
                 class="btn btn-outline"
-                hx-trigger="click, keyup[shiftKey && code == 'R'] from:body"
+                hx-trigger="click, keyup[shiftKey && key == 'R'] from:body"
                 hx-get="{{ url_for('assess.report_story') }}"
                 hx-target="body"
                 hx-swap="beforeend"


### PR DESCRIPTION
Shift + R (Add to report) was not working
Switch from 'code' to 'key' in hx-trigger

## Summary by Sourcery

Bug Fixes:
- Restore functionality of the Shift + R keyboard shortcut for adding a story to a report by using the key property instead of code in the trigger condition.