### PR TITLE
add validation to ci

### DIFF
--- a/.github/workflows/linting_openapi.yaml
+++ b/.github/workflows/linting_openapi.yaml
@@ -4,7 +4,12 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".github/workflows/linting_openapi.yaml"
       - "src/core/core/static/openapi3_1.yaml"
+
+env:
+  UV_NO_SYNC: true
+  UV_FROZEN: true
 
 jobs:
   open_api_lint:
@@ -12,6 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Validate OpenAPI spec
+        run: uvx --from openapi-spec-validator openapi-spec-validator src/core/core/static/openapi3_1.yaml
 
       - name: Running OpenAPI Spec diff action
         uses: oasdiff/oasdiff-action/breaking@main


### PR DESCRIPTION
Fixes: #210

## Summary by Sourcery

Add validation of the OpenAPI specification to the OpenAPI linting CI workflow and ensure the workflow runs when its own configuration file changes.

CI:
- Run OpenAPI specification validation in the linting workflow using openapi-spec-validator via uv.
- Configure the linting workflow environment and Python setup using uv, and trigger it on changes to the workflow file itself.