### PR TITLE
Introduce object referencing for story-news_item

### DIFF
--- a/src/worker/worker/collectors/misp_collector.py
+++ b/src/worker/worker/collectors/misp_collector.py
@@ -264,6 +264,24 @@ class MispCollector(BaseCollector):
 
         return cleaned
 
+    def _get_referenced_news_item_uuids(self, story_object: dict | None, news_item_objects: list[dict]) -> set[str]:
+        news_item_uuids = {uuid for obj in news_item_objects if isinstance((uuid := obj.get("uuid")), str)}
+        if not news_item_uuids:
+            return set()
+
+        referenced_news_item_uuids: set[str] = set()
+
+        if story_object:
+            for reference in story_object.get("ObjectReference", []):
+                relationship_type = reference.get("relationship_type")
+                referenced_uuid = reference.get(
+                    "referenced_uuid",
+                )
+                if relationship_type and isinstance(referenced_uuid, str) and referenced_uuid in news_item_uuids:
+                    referenced_news_item_uuids.add(referenced_uuid)
+
+        return referenced_news_item_uuids
+
     def get_extended_event_news_items(self, event: dict, misp, source) -> list:
         all_news_items = []
         if extending_events := event.get("Event", {}).get("extensionEvents", {}):
@@ -294,17 +312,24 @@ class MispCollector(BaseCollector):
             return None
         return self.to_story_dict(story_properties, story_news_items)
 
-    def extract_story_data_from_event_objects(self, event_object_dicts: list[dict], source) -> tuple[dict, list]:  # TODO: check this
-        story_news_items = []
+    def extract_story_data_from_event_objects(self, event_object_dicts: list[dict], source) -> tuple[dict, list]:
         story_properties = {}
-        for object in event_object_dicts:
-            if object.get("name") == "taranis-story":
-                story_properties = self.get_story_properties_from_story_object(object)
-            elif object.get("name") == "taranis-news-item":
-                news_item = self.create_news_item(object, source)
-                story_news_items.append(news_item)
+        story_object = None
+        news_item_objects = []
+
+        for event_object in event_object_dicts:
+            if event_object.get("name") == "taranis-story":
+                story_object = event_object
+                story_properties = self.get_story_properties_from_story_object(event_object)
+            elif event_object.get("name") == "taranis-news-item":
+                news_item_objects.append(event_object)
             else:
-                logger.warning(f"Unknown object type in MISP event: {object.get('name')}")
+                logger.warning(f"Unknown object type in MISP event: {event_object.get('name')}")
+
+        referenced_news_item_uuids = self._get_referenced_news_item_uuids(story_object, news_item_objects)
+        selected_news_item_objects = [item for item in news_item_objects if item.get("uuid") in referenced_news_item_uuids]
+        story_news_items = [self.create_news_item(item, source) for item in selected_news_item_objects]
+
         return story_properties, story_news_items
 
     def get_recent_taranis_events(self, misp: PyMISP) -> list[dict[str, Any]]:

--- a/src/worker/worker/connectors/base_misp_builder.py
+++ b/src/worker/worker/connectors/base_misp_builder.py
@@ -1,11 +1,13 @@
 import json
 
-from pymisp import MISPEvent
+from pymisp import MISPEvent, MISPObject
+
 from worker.connectors.definitions.misp_objects import BaseMispObject
 from worker.log import logger
 
 
 DEFAULT_MISP_OBJECTS_PATH = "worker/connectors/definitions/objects"
+DEFAULT_NEWS_ITEM_RELATIONSHIP_TYPE = "includes"
 
 
 def get_news_item_object_dict_empty() -> dict:
@@ -75,20 +77,23 @@ def init_misp_event(event: MISPEvent, data: dict, sharing_group_id: int | None =
     return None
 
 
-def add_news_item_objects(news_items: list[dict], event: MISPEvent, misp_objects_path_custom: str = DEFAULT_MISP_OBJECTS_PATH) -> None:
+def add_news_item_objects(
+    news_items: list[dict], event: MISPEvent, misp_objects_path_custom: str = DEFAULT_MISP_OBJECTS_PATH
+) -> list[MISPObject]:
+    news_item_objects: list[MISPObject] = []
     for news_item in news_items:
         news_item.pop("last_change", None)
         news_item_object_dict = get_news_item_object_dict_empty()
         news_item_object_dict.update({k: news_item[k] for k in news_item_object_dict if k in news_item})
 
-        news_item_object_dict = BaseMispObject(
+        news_item_object = BaseMispObject(
             parameters=news_item_object_dict,
             template="taranis-news-item",
             misp_objects_path_custom=misp_objects_path_custom,
         )
-        event.add_object(news_item_object_dict)
+        news_item_objects.append(event.add_object(news_item_object))
 
-    return None
+    return news_item_objects
 
 
 def get_story_object_dict(story: dict) -> dict:
@@ -112,7 +117,7 @@ def get_story_object_dict(story: dict) -> dict:
     return story_object_dict
 
 
-def add_story_object(story: dict, event: MISPEvent, misp_objects_path_custom: str = DEFAULT_MISP_OBJECTS_PATH) -> None:
+def add_story_object(story: dict, event: MISPEvent, misp_objects_path_custom: str = DEFAULT_MISP_OBJECTS_PATH) -> MISPObject:
     object_data = get_story_object_dict(story)
     object_data["attributes"] = []
 
@@ -128,11 +133,22 @@ def add_story_object(story: dict, event: MISPEvent, misp_objects_path_custom: st
     if story.get("attributes"):
         story_object.add_attributes("attributes", *attribute_list)
 
-    event.add_object(story_object)
+    return event.add_object(story_object)
+
+
+def add_story_news_item_references(
+    story_object: MISPObject,
+    news_item_objects: list[MISPObject],
+    relationship_type: str = DEFAULT_NEWS_ITEM_RELATIONSHIP_TYPE,
+) -> None:
+    for news_item_object in news_item_objects:
+        story_object.add_reference(news_item_object, relationship_type)
 
 
 def add_story_properties_to_event(story: dict, event: MISPEvent, misp_objects_path_custom: str = DEFAULT_MISP_OBJECTS_PATH) -> None:
+    news_item_objects: list[MISPObject] = []
     if news_items := story.pop("news_items", None):
-        add_news_item_objects(news_items, event, misp_objects_path_custom=misp_objects_path_custom)
+        news_item_objects = add_news_item_objects(news_items, event, misp_objects_path_custom=misp_objects_path_custom)
 
-    add_story_object(story, event, misp_objects_path_custom=misp_objects_path_custom)
+    story_object = add_story_object(story, event, misp_objects_path_custom=misp_objects_path_custom)
+    add_story_news_item_references(story_object, news_item_objects)

--- a/src/worker/worker/connectors/misp_connector.py
+++ b/src/worker/worker/connectors/misp_connector.py
@@ -77,21 +77,6 @@ class MispConnector:
             None,
         )
 
-    def add_news_item_objects(self, news_items: list[dict], event: MISPEvent) -> None:
-        """
-        For each news item in 'news_items', create a TaranisObject and add it to the event.
-        """
-        for news_item in news_items:
-            news_item.pop("last_change", None)  # key intended for internal use only
-            object_data = base_misp_builder.get_news_item_object_dict_empty()
-            # sourcery skip: dict-assign-update-to-union
-            object_data.update({k: news_item[k] for k in object_data if k in news_item})  # only keep keys that are in the object_data dict
-
-            news_item_object = BaseMispObject(
-                parameters=object_data, template="taranis-news-item", misp_objects_path_custom="worker/connectors/definitions/objects"
-            )
-            event.add_object(news_item_object)
-
     def create_event_report_content(self, story) -> str:
         return "# Story description\n" + story.get("description") + "\n\n" + "# Story comment\n" + story.get("comments")
 
@@ -116,15 +101,10 @@ class MispConnector:
             logger.error(f"Requested event to update with UUID: {event_uuid} does not exist")
             return None
 
-    def add_story_properties_to_event(self, story: dict, event: MISPEvent) -> None:
-        if news_items := story.pop("news_items", None):
-            self.add_news_item_objects(news_items, event)
-        base_misp_builder.add_story_object(story, event)
-
     def add_misp_event(self, misp: PyMISP, story: dict) -> MISPEvent | None:
         event = MISPEvent()
         base_misp_builder.init_misp_event(event, story, self.sharing_group_id, self.distribution)
-        self.add_story_properties_to_event(story, event)
+        base_misp_builder.add_story_properties_to_event(story, event)
 
         # Create a new report without reusing any UUID.
         new_report = self.create_event_report(story)
@@ -150,6 +130,10 @@ class MispConnector:
         for obj_id in objects_to_remove:
             misp.delete_object(obj_id)
             logger.info(f"Deleted Taranis news object with MISP object ID={obj_id} because its 'id' was removed from the story.")
+
+        if objects_to_remove:
+            objects_to_remove_set = set(objects_to_remove)
+            event.Object = [misp_object for misp_object in event.objects if misp_object.id not in objects_to_remove_set]
 
     def get_event_object_ids(self, event: MISPEvent) -> set:
         ids_in_misp = set()
@@ -489,15 +473,39 @@ class MispConnector:
         logger.debug(f"Proposed attributes (shadow attributes): {shadow_attributes=}")
         return shadow_attributes
 
-    def _create_event(self, story_prepared, misp_event_uuid, existing_event) -> MISPEvent:
+    def _extract_story_and_news_item_payload(self, story_prepared: dict) -> tuple[dict, list[dict]]:
+        story_payload = story_prepared.copy()
+        news_item_payload = story_payload.pop("news_items", []) or []
+        return story_payload, news_item_payload
+
+    def _build_story_and_news_item_objects(self, event: MISPEvent, story_prepared: dict) -> tuple[MISPObject, list[MISPObject]]:
+        story_payload, news_item_payload = self._extract_story_and_news_item_payload(story_prepared)
+        new_news_item_objects = base_misp_builder.add_news_item_objects(news_item_payload, event)
+        story_object = base_misp_builder.add_story_object(story_payload, event)
+        return story_object, new_news_item_objects
+
+    def _link_story_to_existing_news_items(self, story_object: MISPObject, existing_event: MISPEvent) -> None:
+        for existing_news_item_object in existing_event.objects:
+            if existing_news_item_object.name != "taranis-news-item" or not existing_news_item_object.uuid:
+                continue
+            story_object.add_reference(existing_news_item_object.uuid, base_misp_builder.DEFAULT_NEWS_ITEM_RELATIONSHIP_TYPE)
+
+    @staticmethod
+    def _get_existing_report_uuid(existing_event: MISPEvent) -> str | None:
+        if isinstance(existing_event.EventReport, list) and existing_event.EventReport:
+            return existing_event.EventReport[0].uuid
+        return None
+
+    def _create_event(self, story_prepared: dict, misp_event_uuid: str, existing_event: MISPEvent) -> MISPEvent:
         event = MISPEvent()
         base_misp_builder.init_misp_event(event, story_prepared, self.sharing_group_id, self.distribution)
-        self.add_story_properties_to_event(story_prepared, event)
+
+        story_object, new_news_item_objects = self._build_story_and_news_item_objects(event, story_prepared)
+        self._link_story_to_existing_news_items(story_object, existing_event)
+        base_misp_builder.add_story_news_item_references(story_object, new_news_item_objects)
 
         event.uuid = misp_event_uuid
-        existing_report_uuid = None
-        if isinstance(existing_event.EventReport, list) and len(existing_event.EventReport) > 0:
-            existing_report_uuid = existing_event.EventReport[0].uuid
+        existing_report_uuid = self._get_existing_report_uuid(existing_event)
         new_report = self.create_event_report(story_prepared, existing_report_uuid)
         event.EventReport = [new_report]
         return event

--- a/src/worker/worker/tests/collectors/test_collector.py
+++ b/src/worker/worker/tests/collectors/test_collector.py
@@ -5,6 +5,10 @@ from worker.config import Config
 from worker.tests.testdata import news_items
 
 
+def _attribute(relation: str, value: str) -> dict:
+    return {"object_relation": relation, "value": value}
+
+
 def test_base_web_collector_conditional_request(base_web_collector_mock, base_web_collector):
     import datetime
 
@@ -236,6 +240,104 @@ def test_misp_collector_collect(misp_collector_mock, misp_collector):
     result = misp_collector.collect(source)
 
     assert result is None
+
+
+def test_extract_story_data_uses_object_references_for_story_nesting(misp_collector):
+    event_object_dicts = [
+        {
+            "name": "taranis-story",
+            "uuid": "story-uuid",
+            "ObjectReference": [
+                {
+                    "object_uuid": "story-uuid",
+                    "referenced_uuid": "news-linked-uuid",
+                    "relationship_type": "derived-from",
+                }
+            ],
+            "Attribute": [
+                _attribute("id", "story-1"),
+                _attribute("title", "Story title"),
+            ],
+        },
+        {
+            "name": "taranis-news-item",
+            "uuid": "news-linked-uuid",
+            "ObjectReference": [],
+            "Attribute": [
+                _attribute("id", "news-linked-id"),
+                _attribute("hash", "hash-linked"),
+                _attribute("title", "Linked item"),
+                _attribute("content", "Linked content"),
+                _attribute("link", "https://linked.example"),
+                _attribute("story_id", "story-1"),
+                _attribute("source", "manual"),
+            ],
+        },
+        {
+            "name": "taranis-news-item",
+            "uuid": "news-unlinked-uuid",
+            "ObjectReference": [],
+            "Attribute": [
+                _attribute("id", "news-unlinked-id"),
+                _attribute("hash", "hash-unlinked"),
+                _attribute("title", "Unlinked item"),
+                _attribute("content", "Unlinked content"),
+                _attribute("link", "https://unlinked.example"),
+                _attribute("source", "manual"),
+            ],
+        },
+    ]
+
+    story_properties, news_items_for_story = misp_collector.extract_story_data_from_event_objects(event_object_dicts, {"id": "source-1"})
+
+    assert story_properties["id"] == "story-1"
+    assert len(news_items_for_story) == 1
+    assert news_items_for_story[0].id == "news-linked-id"
+    assert news_items_for_story[0].story_id == "story-1"
+
+
+def test_extract_story_data_returns_no_news_items_when_no_references(misp_collector):
+    event_object_dicts = [
+        {
+            "name": "taranis-story",
+            "uuid": "story-uuid",
+            "ObjectReference": [],
+            "Attribute": [
+                _attribute("id", "story-1"),
+                _attribute("title", "Story title"),
+            ],
+        },
+        {
+            "name": "taranis-news-item",
+            "uuid": "news-1-uuid",
+            "ObjectReference": [],
+            "Attribute": [
+                _attribute("id", "news-1-id"),
+                _attribute("hash", "hash-1"),
+                _attribute("title", "First item"),
+                _attribute("content", "First content"),
+                _attribute("link", "https://first.example"),
+                _attribute("source", "manual"),
+            ],
+        },
+        {
+            "name": "taranis-news-item",
+            "uuid": "news-2-uuid",
+            "ObjectReference": [],
+            "Attribute": [
+                _attribute("id", "news-2-id"),
+                _attribute("hash", "hash-2"),
+                _attribute("title", "Second item"),
+                _attribute("content", "Second content"),
+                _attribute("link", "https://second.example"),
+                _attribute("source", "manual"),
+            ],
+        },
+    ]
+
+    _, news_items_for_story = misp_collector.extract_story_data_from_event_objects(event_object_dicts, {"id": "source-1"})
+
+    assert news_items_for_story == []
 
 
 @pytest.mark.parametrize("input_news_items", [news_items, news_items[2:], news_items[:: len(news_items) - 1], [news_items[-1]]])

--- a/src/worker/worker/tests/connectors/test_misp_connector.py
+++ b/src/worker/worker/tests/connectors/test_misp_connector.py
@@ -1,10 +1,33 @@
 import json
+from copy import deepcopy
 
 import pytest
 
 from worker.config import Config
 from worker.connectors import base_misp_builder, connector_tasks
 from worker.connectors.misp_connector import MispConnector
+
+
+def _news_item_payload(news_item_id: str, hash_value: str, story_id: str = "story-1") -> dict:
+    return {
+        "id": news_item_id,
+        "hash": hash_value,
+        "title": f"title-{news_item_id}",
+        "content": f"content-{news_item_id}",
+        "link": f"https://{news_item_id}.example",
+        "source": "manual",
+        "story_id": story_id,
+    }
+
+
+def _story_payload(news_items: list[dict] | None = None) -> dict:
+    return {
+        "id": "story-1",
+        "title": "Story",
+        "description": "",
+        "comments": "",
+        "news_items": news_items or [],
+    }
 
 
 @pytest.fixture
@@ -157,3 +180,64 @@ def test_distribution_not_provided():
     connector = MispConnector()
     connector.parse_parameters({"URL": "http://localhost", "API_KEY": "abc", "SHARING_GROUP_ID": "1"})
     assert connector.distribution == 4
+
+
+def test_add_story_properties_links_story_to_news_items_with_object_references(stories):
+    from pymisp import MISPEvent
+
+    story = deepcopy(stories[0])
+    news_item_count = len(story.get("news_items", []))
+    event = MISPEvent()
+
+    base_misp_builder.add_story_properties_to_event(story, event)
+
+    story_object = next(obj for obj in event.objects if obj.name == "taranis-story")
+    news_item_objects = [obj for obj in event.objects if obj.name == "taranis-news-item"]
+
+    assert len(news_item_objects) == news_item_count
+    assert len(story_object.ObjectReference) == news_item_count
+
+    referenced_uuids = {reference.referenced_uuid for reference in story_object.ObjectReference}
+    relationship_types = {reference.relationship_type for reference in story_object.ObjectReference}
+
+    assert referenced_uuids == {obj.uuid for obj in news_item_objects}
+    assert relationship_types == {base_misp_builder.DEFAULT_NEWS_ITEM_RELATIONSHIP_TYPE}
+
+
+def test_create_event_keeps_existing_news_item_references_on_update():
+    from pymisp import MISPEvent
+
+    connector = MispConnector()
+    existing_event = MISPEvent()
+    existing_news_item = base_misp_builder.add_news_item_objects([_news_item_payload("existing", "hash-existing")], existing_event)[0]
+
+    event_to_add = connector._create_event(
+        _story_payload([]),
+        "story-1",
+        existing_event,
+    )
+
+    story_object = next(obj for obj in event_to_add.objects if obj.name == "taranis-story")
+    referenced_uuids = {reference.referenced_uuid for reference in story_object.ObjectReference}
+
+    assert referenced_uuids == {existing_news_item.uuid}
+
+
+def test_create_event_references_existing_and_new_news_items_on_update():
+    from pymisp import MISPEvent
+
+    connector = MispConnector()
+    existing_event = MISPEvent()
+    existing_news_item = base_misp_builder.add_news_item_objects([_news_item_payload("existing", "hash-existing")], existing_event)[0]
+
+    event_to_add = connector._create_event(
+        _story_payload([_news_item_payload("new", "hash-new")]),
+        "story-1",
+        existing_event,
+    )
+
+    story_object = next(obj for obj in event_to_add.objects if obj.name == "taranis-story")
+    new_news_item = next(obj for obj in event_to_add.objects if obj.name == "taranis-news-item")
+    referenced_uuids = {reference.referenced_uuid for reference in story_object.ObjectReference}
+
+    assert referenced_uuids == {existing_news_item.uuid, new_news_item.uuid}


### PR DESCRIPTION
- This change improves the machine readability of the MISP Events created by Taranis AI.
- The relationship between the story and news item is \includes\

## Summary by Sourcery

Introduce explicit MISP object references to model relationships between stories and news items and update both connector and collector logic accordingly.

New Features:
- Link story and news-item MISP objects using explicit object references with a standardized relationship type.

Enhancements:
- Refactor MISP connector to build story and news item objects together, reuse a shared base builder, and preserve existing news-item references when updating events.
- Update MISP collector to derive story-related news items from object references, improving story/news-item association robustness.
- Adjust event object removal to keep the in-memory event object list consistent after deletions.

Tests:
- Add unit tests covering story/news-item reference handling in both the MISP connector and collector, including updates combining existing and new news items.