### PR TITLE
Change llm-bot targetPort from 5500 to 8000

### DIFF
--- a/deploy/kubernetes-optional-bots/20-services.yaml
+++ b/deploy/kubernetes-optional-bots/20-services.yaml
@@ -8,4 +8,4 @@ spec:
   ports:
     - name: http
       port: 5500
-      targetPort: 5500
+      targetPort: 8000


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Change llm-bot service targetPort from 5500 to 8000 to match the application’s listening port.