### PR TITLE
Added to flask port for dev in README file

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -41,11 +41,12 @@ Starting from the git root:
 cd $(git rev-parse --show-toplevel)
 ```
 
-Copy env.dev to worker and core
+Copy env.dev to worker and core and set up the core Flask port
 
 ```bash
-cp dev/env.dev src/core/.env
 cp dev/env.dev src/worker/.env
+cp dev/env.dev src/core/.env
+echo "FLASK_RUN_PORT=5001" >> src/core/.env
 ```
 
 Copy env.dev to frontend and set the frontend Flask port


### PR DESCRIPTION
Added `FLASK_RUN_PORT=5001` to `dev/README.md` to match `start_dev.sh`, like we did for the frontend port.

## Summary by Sourcery

Documentation:
- Update dev README to instruct setting FLASK_RUN_PORT=5001 in core .env to align with the dev startup script.