### PR TITLE
Simplify admin dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ See .github/workflows for how tests are configured in CI.
 
 ## Development Guidelines
 
+- When creating branches, use only `fix/`, `feature/`, or `chore/` prefixes.
 - never use `git add -A` or in general do not add "all" files lying around
 - use specific git add commands for the files you want to commit
 - don't commit how many tests passed (statistics in commit messages are not useful)

--- a/src/core/tests/application/admin_console/operations/test_admin_api.py
+++ b/src/core/tests/application/admin_console/operations/test_admin_api.py
@@ -1,7 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
 
-from core.service.story import StoryService
 from tests.application.support.api_test_base import BaseTest
 
 
@@ -33,13 +32,6 @@ class TestAdminApi(BaseTest):
 
         assert response_settings["message"] == "Successfully updated settings"
         assert response_settings["settings"] == test_settings["settings"]
-
-    def test_rebuild_story_search_vectors(self, client, auth_header, monkeypatch):
-        monkeypatch.setattr(StoryService, "rebuild_search_vectors", staticmethod(lambda: 7))
-
-        response = self.assert_post_ok(client, "rebuild-story-search-vectors", {}, auth_header)
-
-        assert response.get_json() == {"message": "Rebuilt search vectors for 7 stories", "updated": 7}
 
 
 def test_export_stories_and_metadata(client, full_story, api_header, auth_header):

--- a/src/core/tests/application/mixed_flows/system/test_health_service.py
+++ b/src/core/tests/application/mixed_flows/system/test_health_service.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 import pytest
 
 from core.service import health
@@ -19,29 +17,3 @@ def test_check_seed_data(monkeypatch, manual_exists, product_type_exists, expect
     monkeypatch.setattr("core.model.product_type.ProductType.get_first", lambda query: object() if product_type_exists else None)
 
     assert health.check_seed_data() == expected
-
-
-def test_broker_health_applicable_uses_redis_url(monkeypatch):
-    qm = type("QueueManagerStub", (), {"redis_url": "redis://localhost:6379/0", "_redis": None})()
-    monkeypatch.setattr(health, "queue_manager", SimpleNamespace(queue_manager=qm))
-
-    assert health.broker_health_applicable() is True
-
-
-def test_check_broker_uses_redis_ping(monkeypatch):
-    class FakeRedis:
-        def ping(self):
-            return True
-
-    qm = type("QueueManagerStub", (), {"_redis": FakeRedis()})()
-    monkeypatch.setattr(health, "queue_manager", SimpleNamespace(queue_manager=qm))
-
-    assert health.check_broker() == "up"
-
-
-def test_check_workers_uses_rq_workers(monkeypatch):
-    qm = type("QueueManagerStub", (), {"_redis": object()})()
-    monkeypatch.setattr(health, "queue_manager", SimpleNamespace(queue_manager=qm))
-    monkeypatch.setattr("rq.worker.Worker.all", lambda connection=None: [object()])
-
-    assert health.check_workers() == "up"

--- a/src/core/tests/test_api.py
+++ b/src/core/tests/test_api.py
@@ -26,19 +26,6 @@ def test_is_alive_fail(client):
     assert b'"isalive": false' not in response.data
 
 
-def test_health_returns_service_response(client, monkeypatch):
-    expected_body = {
-        "healthy": False,
-        "services": {"database": "down", "seed_data": "down", "broker": "n/a", "workers": "n/a"},
-    }
-    monkeypatch.setattr("core.api.health.health_service.get_health_response", lambda: (expected_body, 503))
-
-    response = client.get("/api/health")
-
-    assert response.status_code == 503
-    assert response.json == expected_body
-
-
 def test_auth_login(client):
     body = {"username": "user", "password": os.getenv("PRE_SEED_PASSWORD_USER")}
     response = client.post("/api/auth/login", json=body)

--- a/src/frontend/frontend/templates/admin_dashboard/index.html
+++ b/src/frontend/frontend/templates/admin_dashboard/index.html
@@ -32,15 +32,15 @@
                   <div>
                     Tag: <b>{{ section_build_info.get("tag") }}</b>
                   </div>
-                {% endif %}
-                {% if section_build_info.get("HEAD") %}
+                {% elif section_build_info.get("HEAD") or section_build_info.get("branch") %}
                   <div>
-                    Commit: <b>{{ section_build_info.get("HEAD") }}</b>
-                  </div>
-                {% endif %}
-                {% if section_build_info.get("branch") %}
-                  <div>
-                    Branch: <b>{{ section_build_info.get("branch") }}</b>
+                    Commit / Branch:
+                    {% if section_build_info.get("HEAD") %}
+                      <b>{{ section_build_info.get("HEAD") }}</b>
+                    {% else %}
+                      <span class="text-base-content/60">Unavailable</span>
+                    {% endif %}
+                    {% if section_build_info.get("branch") %}<span class="text-base-content/60">/</span><b>{{ section_build_info.get("branch") }}</b>{% endif %}
                   </div>
                 {% endif %}
               {% else %}

--- a/src/frontend/frontend/views/admin_views/dashboard_views.py
+++ b/src/frontend/frontend/views/admin_views/dashboard_views.py
@@ -80,9 +80,26 @@ class AdminDashboardView(AdminMixin, BaseView):
     @staticmethod
     def get_dashboard_health(dashboard: Dashboard) -> dict[str, bool | dict[str, str]]:
         if health_status := dashboard.health_status:
-            return {"healthy": bool(health_status.healthy), "services": health_status.services.model_dump()}
+            services = health_status.services.model_dump()
+            return {
+                "healthy": bool(health_status.healthy),
+                "services": {
+                    "Database": services.get("database", "n/a"),
+                    "Pre-seeded": services.get("seed_data", "n/a"),
+                    "Redis": services.get("broker", "n/a"),
+                    "Workers": services.get("workers", "n/a"),
+                },
+            }
 
-        return {"healthy": False, "services": {"database": "n/a", "seed_data": "n/a", "broker": "n/a", "workers": "n/a"}}
+        return {
+            "healthy": False,
+            "services": {
+                "Database": "n/a",
+                "Pre-seeded": "n/a",
+                "Redis": "n/a",
+                "Workers": "n/a",
+            },
+        }
 
     def get(self, **kwargs):
         return self.static_view()

--- a/src/frontend/tests/playwright/test_e2e_admin.py
+++ b/src/frontend/tests/playwright/test_e2e_admin.py
@@ -21,10 +21,10 @@ def remove_tz(date_time: str) -> str:
 
 DASHBOARD_BASELINE_QUEUE_TEXT = "There are 1 tasks scheduled."
 DASHBOARD_HEALTH_SERVICES = {
-    "database": "up",
-    "seed_data": "up",
-    "broker": "up",
-    "workers": "up",
+    "Database": "up",
+    "Pre-seeded": "up",
+    "Redis": "up",
+    "Workers": "up",
 }
 SCHEDULER_BASELINE_TOTAL_TEXT = "Total: 1 scheduled jobs"
 

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -442,14 +442,16 @@ def test_admin_dashboard_renders_health_card(authenticated_client, responses_moc
     assert "Core" in html
     assert "Frontend" in html
     assert "1.3.4" in html
-    assert "core123" in html
     assert "1.3.5" in html
-    assert "front456" in html
+    assert "Commit / Branch:" not in html
+    assert "core123" not in html
+    assert "front456" not in html
     assert "System Health" in html
     assert "Degraded" in html
-    assert "database" in html
-    assert "broker" in html
-    assert "workers" in html
+    assert "Database" in html
+    assert "Pre-seeded" in html
+    assert "Redis" in html
+    assert "Workers" in html
 
 
 def test_admin_dashboard_renders_frontend_release_info_when_core_build_info_fails(authenticated_client, responses_mock, monkeypatch):
@@ -458,7 +460,7 @@ def test_admin_dashboard_renders_frontend_release_info_when_core_build_info_fail
             cache.delete(key)
 
     monkeypatch.setattr(Config, "BUILD_DATE", datetime.fromisoformat("2025-01-16T08:45:00+00:00"))
-    monkeypatch.setattr(Config, "GIT_INFO", {"tag": "1.3.5", "HEAD": "front456", "branch": "master"})
+    monkeypatch.setattr(Config, "GIT_INFO", {"HEAD": "front456", "branch": "master"})
 
     responses_mock.get(
         f"{Config.TARANIS_CORE_URL}{AdminDashboardView.model._core_endpoint}",
@@ -501,6 +503,7 @@ def test_admin_dashboard_renders_frontend_release_info_when_core_build_info_fail
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert "Frontend" in html
-    assert "1.3.5" in html
+    assert "Commit / Branch:" in html
     assert "front456" in html
+    assert "master" in html
     assert "Unavailable" in html


### PR DESCRIPTION
## What changed
- Simplified the admin dashboard health card and release info display.
- Removed useless mock-only tests and updated the remaining dashboard tests.
- Added branch naming guidance to AGENTS.md.

## Validation
- `uv run pytest tests/unit/views/test_views.py -k "admin_dashboard_renders_health_card or admin_dashboard_renders_frontend_release_info_when_core_build_info_fails" -q`
- `uv run ruff check frontend/views/admin_views/dashboard_views.py tests/unit/views/test_views.py tests/playwright/test_e2e_admin.py`
- repo commit hooks passed on commit (ruff, ruff format, trim trailing whitespace, djlint).

## Summary by Sourcery

Simplify the admin dashboard health and release information display while cleaning up obsolete tests and updating contribution guidelines.

Bug Fixes:
- Align admin dashboard health service labels and defaults with the new UI expectations for services and release information.

Enhancements:
- Simplify the admin dashboard health card by mapping internal service keys to user-friendly labels and adjusting default values.
- Condense build information display into a single Commit / Branch line that gracefully handles missing data.
- Remove obsolete health and admin API tests that relied on mocks or unused endpoints.

Documentation:
- Add branch naming guidance to AGENTS.md limiting prefixes to fix/, feature/, or chore/.
- Update admin dashboard unit and end-to-end tests to reflect the simplified health card and release information layout.

Tests:
- Adjust admin dashboard unit and Playwright tests to validate the new health service labels and Commit / Branch display behavior.