### PR TITLE
Handle connector loading failures in story sharing dialog

### DIFF
--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -158,7 +158,7 @@ class StoryView(BaseView):
         try:
             connectors = DataPersistenceLayer().get_objects(Connector)
         except Exception as e:
-            logger.exception(f"Failed to fetch connectors for share dialog: {e}")
+            logger.error(f"Failed to fetch connectors for share dialog: {e}")
             connectors = []
         return render_template(
             "assess/story_sharing_dialog.html", connectors=connectors, story_ids=story_ids, mail_sharing_link=mail_sharing_link

--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -155,7 +155,11 @@ class StoryView(BaseView):
             story_ids = [story_id]
 
         mail_sharing_link = cls.share_story_link(story_ids)
-        connectors = DataPersistenceLayer().get_objects(Connector)
+        try:
+            connectors = DataPersistenceLayer().get_objects(Connector)
+        except Exception as e:
+            logger.exception(f"Failed to fetch connectors for share dialog: {e}")
+            connectors = []
         return render_template(
             "assess/story_sharing_dialog.html", connectors=connectors, story_ids=story_ids, mail_sharing_link=mail_sharing_link
         )

--- a/src/frontend/tests/unit/views/test_story_view.py
+++ b/src/frontend/tests/unit/views/test_story_view.py
@@ -167,3 +167,30 @@ def test_story_sharing_dialog_loads_connectors_from_assess_endpoint(authenticate
     assert connector_id in response.text
     assert "MISP Connector" in response.text
     assert all(call.request.url != f"{Config.TARANIS_CORE_URL}/config/connectors" for call in responses_mock.calls)
+
+
+def test_story_sharing_dialog_still_renders_when_connector_loading_fails(authenticated_client_basic, monkeypatch, responses_mock):
+    story_id = "story-1"
+
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}",
+        json={"id": story_id, "title": "Shared Story", "links": ["https://example.com/story"]},
+    )
+
+    def raise_connector_loading_error(*args, **kwargs):
+        raise RuntimeError("permission lookup failed")
+
+    monkeypatch.setattr("frontend.views.story_views.DataPersistenceLayer.get_objects", raise_connector_loading_error)
+
+    response = authenticated_client_basic.get(url_for("assess.share_story", story_id=story_id))
+
+    assert response.status_code == 200
+    assert "Share Stories" in response.text
+    assert "Shared Story" not in response.text
+
+    tree = html.fromstring(response.text)
+    connector_select = tree.xpath('//select[@id="connector"]')
+    assert len(connector_select) == 1
+    options = connector_select[0].xpath("./option")
+    assert len(options) == 1
+    assert options[0].text == "Select a connector"


### PR DESCRIPTION
Safe handling of the Assess sharing dialog when `CONNECTOR_USER_ACCESS` is not assigned.

It produces such frontend logs now:
```
[2026-04-14 16:08:12] [Frontend] [ERROR] - Call to http://local.taranis.ai/api/assess/connectors failed 403: { "error": "forbidden"}
[2026-04-14 16:08:12] [Frontend] [ERROR] - Failed to fetch connectors for share dialog: Failed to fetch Connector from: /assess/connectors
127.0.0.1 - - [14/Apr/2026 16:08:12] "GET /frontend/story/sharing?story_id=c17aad2c-d0b5-49f2-8917-735ce3d3fa35 HTTP/1.0" 200 -
```

## Summary by Sourcery

Handle failures when loading connectors in the story sharing dialog so the dialog still renders without connectors.

Enhancements:
- Wrap connector loading in the story sharing dialog with error handling and log failures, falling back to an empty connector list.

Tests:
- Add a unit test verifying the story sharing dialog renders with a fallback connector selector when connector loading raises an exception.