### PR TITLE
Enforce report item TLP access

### DIFF
--- a/src/core/core/model/report_item.py
+++ b/src/core/core/model/report_item.py
@@ -88,7 +88,7 @@ class ReportItem(BaseModel):
         item = cls.get(item_id)
         if not item:
             return {"error": f"{cls.__name__} {item_id} not found"}, 404
-        if user and not item.allowed_with_acl(user, False):
+        if user and not item.access_allowed(user, False):
             return {"error": f"User {user.id} is not allowed to read Report {item.id}"}, 403
 
         return item.to_detail_dict(), 200
@@ -287,7 +287,7 @@ class ReportItem(BaseModel):
         if not report:
             return {"error": "Report not found"}, 404
 
-        if not report.allowed_with_acl(user, True):
+        if not report.access_allowed(user, True):
             return {"error": "Permission Denied"}, 403
 
         new_report = report.clone_report(user=user)
@@ -314,7 +314,7 @@ class ReportItem(BaseModel):
         report_item = cls.from_dict(sanitized_data)
 
         if user:
-            if not report_item.allowed_with_acl(user, True):
+            if not report_item.access_allowed(user, True):
                 return {"error": f"User {user.id} is not allowed to create Report {report_item.id}"}, 403
 
             report_item.user_id = user.id
@@ -360,7 +360,24 @@ class ReportItem(BaseModel):
                 self.attributes.append(ReportItemAttribute(**attr))
                 next_index += 1
 
-    def allowed_with_acl(self, user, require_write_access) -> bool:
+    def access_allowed(self, user, require_write_access=False) -> bool:
+        if not user:
+            return True
+
+        return self._allowed_with_acl(user, require_write_access) and self._allowed_with_tlp(user)
+
+    def _allowed_with_tlp(self, user) -> bool:
+        user_tlp_level = user.get_highest_tlp()
+        if user_tlp_level.value == "red":
+            return True
+
+        accessible_tlps = user_tlp_level.get_accessible_levels()
+        if item_tlp_attributes := [attr for attr in self.attributes if attr.attribute_type == AttributeType.TLP]:
+            return all(tlp_attr.value in accessible_tlps for tlp_attr in item_tlp_attributes)
+
+        return True
+
+    def _allowed_with_acl(self, user, require_write_access) -> bool:
         if not RoleBasedAccess.is_enabled() or not user:
             return True
 
@@ -424,7 +441,7 @@ class ReportItem(BaseModel):
         if not (report_item := cls.get(report_id)):
             return None, {"error": "Report Item not Found"}, 404
 
-        if not report_item.allowed_with_acl(user, True):
+        if not report_item.access_allowed(user, True):
             return None, {"error": f"User {user.id} is not allowed to update Report {report_item.id}"}, 403
 
         return report_item, {}, 200

--- a/src/core/tests/application/mixed_flows/security/test_rbac.py
+++ b/src/core/tests/application/mixed_flows/security/test_rbac.py
@@ -5,6 +5,38 @@ from core.model.role import TLPLevel
 
 
 class TestRBAC:
+    def test_report_item_tlp_gate_blocks_read_and_update_below_required_level(self, report_items):
+        from core.model.report_item import ReportItem
+
+        _, report_item_amber, _, _ = report_items
+
+        clear_user = Mock()
+        clear_user.id = "clear-user"
+        clear_user.get_highest_tlp.return_value = TLPLevel.CLEAR
+
+        amber_user = Mock()
+        amber_user.id = "amber-user"
+        amber_user.get_highest_tlp.return_value = TLPLevel.AMBER
+
+        read_error, read_status = ReportItem.get_for_api(report_item_amber.id, clear_user)
+        assert read_status == 403
+        assert read_error == {"error": f"User {clear_user.id} is not allowed to read Report {report_item_amber.id}"}
+
+        blocked_report, update_error, update_status = ReportItem.get_report_item_and_check_permission(report_item_amber.id, clear_user)
+        assert blocked_report is None
+        assert update_status == 403
+        assert update_error == {"error": f"User {clear_user.id} is not allowed to update Report {report_item_amber.id}"}
+
+        read_data, read_status = ReportItem.get_for_api(report_item_amber.id, amber_user)
+        assert read_status == 200
+        assert read_data["id"] == report_item_amber.id
+
+        allowed_report, update_error, update_status = ReportItem.get_report_item_and_check_permission(report_item_amber.id, amber_user)
+        assert allowed_report is not None
+        assert allowed_report.id == report_item_amber.id
+        assert update_status == 200
+        assert update_error == {}
+
     def test_filter_report_query_with_tlp(self, report_items):
         from core.model.report_item import ReportItem
         from core.service.role_based_access import RoleBasedAccessService


### PR DESCRIPTION
## Summary by Sourcery

Enforce TLP-based access control on report items and incorporate it into existing permission checks.

Bug Fixes:
- Prevent users with insufficient TLP clearance from reading or updating TLP-restricted report items.

Enhancements:
- Introduce a unified access_allowed helper that combines ACL and TLP checks for report item permissions.
- Add internal TLP access evaluation based on user TLP level and report item TLP attributes.

Tests:
- Add RBAC test coverage to verify that TLP constraints block read and update operations for under-cleared users while allowing access for appropriately cleared users.