### PR TITLE
Add HTTPException handling across multiple views and core API interactions

### DIFF
--- a/src/frontend/frontend/auth.py
+++ b/src/frontend/frontend/auth.py
@@ -8,7 +8,7 @@ from flask_jwt_extended import JWTManager, current_user, get_jwt_identity, unset
 from flask_jwt_extended.exceptions import JWTExtendedException
 from models.user import UserProfile
 from requests.models import Response as ReqResponse
-from werkzeug.exceptions import MethodNotAllowed, NotFound
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound
 from werkzeug.routing import RequestRedirect
 
 from frontend.cache import add_user_to_cache, get_user_from_cache
@@ -128,6 +128,8 @@ def logout() -> tuple[str, int] | Response:
     error_msg = "Logout failed"
     try:
         core_response: ReqResponse = CoreApi().logout()
+    except HTTPException:
+        raise
     except Exception as exc:
         # If the core isn't reachable, fall back to the login page without crashing.
         logger.error(f"Core logout failed: {exc}")

--- a/src/frontend/frontend/core_api.py
+++ b/src/frontend/frontend/core_api.py
@@ -2,6 +2,7 @@ from typing import IO, Any, cast
 
 import requests
 from flask import Response, request
+from werkzeug.exceptions import Forbidden, HTTPException
 from werkzeug.wsgi import wrap_file
 
 from frontend.config import Config
@@ -20,6 +21,17 @@ class CoreApi:
         self.session.verify = self.verify
         self.timeout = Config.REQUESTS_TIMEOUT
 
+    @staticmethod
+    def _extract_forbidden_message(response: requests.Response) -> str:
+        message = "Access denied"
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                message = payload.get("error") or payload.get("message") or message
+        except Exception:
+            message = response.text or message
+        return message
+
     def get_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.jwt_token}", "Content-type": "application/json"}
 
@@ -27,6 +39,10 @@ class CoreApi:
         return request.cookies.get(Config.JWT_ACCESS_COOKIE_NAME)
 
     def check_response(self, response: requests.Response, url: str):
+        if response.status_code == 403:
+            message = self._extract_forbidden_message(response)
+            logger.error(f"Call to {url} failed {response.status_code}: {response.text}")
+            raise Forbidden(description=message)
         try:
             if response.ok:
                 return response.json()
@@ -121,6 +137,8 @@ class CoreApi:
     def load_default_osint_sources(self):
         try:
             return self.api_get("/static/default_sources.json")
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Load default OSINT sources failed: {e}")
             return None
@@ -128,6 +146,8 @@ class CoreApi:
     def get_osint_source_preview(self, osint_source_id: str):
         try:
             return self.api_get(f"/config/osint-sources/{osint_source_id}/preview")
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Retrieving OSINT source preview failed: {e}")
             return None
@@ -163,6 +183,8 @@ class CoreApi:
     def load_default_word_lists(self):
         try:
             return self.api_get("/static/default_word_lists.json")
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Load default word lists failed: {e}")
             return None

--- a/src/frontend/frontend/views/admin_views/bot_views.py
+++ b/src/frontend/frontend/views/admin_views/bot_views.py
@@ -4,6 +4,7 @@ from flask import render_template, request, url_for
 from models.admin import Bot
 from models.dashboard import Dashboard
 from models.types import BOT_TYPES
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import admin_required
 from frontend.core_api import CoreApi
@@ -69,6 +70,8 @@ class BotView(AdminMixin, BaseView):
             if dashboard := DataPersistenceLayer().get_first(Dashboard):
                 if worker_status := dashboard.worker_status:
                     return worker_status.get("bot_task", {}).get("failures", 0)
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error retrieving dashboard for bot admin menu badge")
 

--- a/src/frontend/frontend/views/admin_views/dashboard_views.py
+++ b/src/frontend/frontend/views/admin_views/dashboard_views.py
@@ -1,5 +1,6 @@
 from flask import abort, render_template
 from models.dashboard import Dashboard
+from werkzeug.exceptions import HTTPException
 
 from frontend.config import Config
 from frontend.data_persistence import DataPersistenceLayer
@@ -28,6 +29,8 @@ class AdminDashboardView(AdminMixin, BaseView):
         data_persistence = DataPersistenceLayer()
         try:
             dashboard = data_persistence.get_first(Dashboard)
+        except HTTPException:
+            raise
         except Exception as exc:
             dashboard = None
             error = str(exc)

--- a/src/frontend/frontend/views/admin_views/publisher_views.py
+++ b/src/frontend/frontend/views/admin_views/publisher_views.py
@@ -3,6 +3,7 @@ from typing import Any
 from flask import render_template, request
 from models.admin import ProductType, PublisherPreset, ReportItemType, Template
 from models.types import PRESENTER_TYPES, PUBLISHER_TYPES
+from werkzeug.exceptions import HTTPException
 
 from frontend.data_persistence import DataPersistenceLayer
 from frontend.filters import render_item_type
@@ -89,6 +90,8 @@ class ProductTypeView(AdminMixin, BaseView):
         try:
             form_data = parse_formdata(request.form)
             return cls.store_form_data(form_data, object_id)
+        except HTTPException:
+            raise
         except Exception as exc:
             return None, str(exc)
 

--- a/src/frontend/frontend/views/admin_views/role_views.py
+++ b/src/frontend/frontend/views/admin_views/role_views.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from models.admin import Permission, Role
+from werkzeug.exceptions import HTTPException
 
 from frontend.data_persistence import DataPersistenceLayer
 from frontend.filters import render_count
@@ -19,6 +20,8 @@ class RoleView(AdminMixin, BaseView):
         try:
             dpl = DataPersistenceLayer()
             base_context["permissions"] = [p.model_dump() for p in dpl.get_objects(Permission)]
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error retrieving permissions")
         return base_context

--- a/src/frontend/frontend/views/admin_views/scheduler_views.py
+++ b/src/frontend/frontend/views/admin_views/scheduler_views.py
@@ -2,6 +2,7 @@ from flask import render_template, request
 from flask.views import MethodView
 from models.admin import ActiveJob, FailedJob, Job, QueueStatus, SchedulerDashboardData, WorkerStats
 from models.task import TaskHistoryResponse
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required
 from frontend.config import Config
@@ -68,6 +69,8 @@ class SchedulerView(AdminMixin, BaseView):
 
             return render_template("schedule/dashboard.html", **context), 200
 
+        except HTTPException:
+            raise
         except Exception as e:
             from frontend.log import logger
 
@@ -86,6 +89,8 @@ class ScheduleJobsAPI(MethodView):
             jobs = DataPersistenceLayer().get_objects(Job)
             jobs.sort(key=lambda job: (job.next_run_time is None, job.next_run_time or ""))
             return render_template("schedule/jobs_table.html", jobs=jobs)
+        except HTTPException:
+            raise
         except Exception as exc:  # pragma: no cover - defensive rendering path
             return BaseView.render_response_notification({"error": f"Failed to load jobs: {exc}"}), 500
 
@@ -102,6 +107,8 @@ class ScheduleQueuesAPI(MethodView):
             queues = persistence.get_objects(QueueStatus)
             worker_stats = persistence.get_object(WorkerStats)
             return render_template("schedule/queue_cards.html", queues=queues, worker_stats=worker_stats)
+        except HTTPException:
+            raise
         except Exception as exc:  # pragma: no cover - defensive rendering path
             return BaseView.render_response_notification({"error": f"Failed to load queues: {exc}"}), 500
 
@@ -117,6 +124,8 @@ class ScheduleActiveJobsAPI(MethodView):
             active_jobs = DataPersistenceLayer().get_objects(ActiveJob)
             active_jobs.sort(key=lambda job: job.started_at or "")
             return render_template("schedule/active_jobs.html", active_jobs=active_jobs)
+        except HTTPException:
+            raise
         except Exception as exc:  # pragma: no cover - defensive rendering path
             return BaseView.render_response_notification({"error": f"Failed to load active jobs: {exc}"}), 500
 
@@ -132,6 +141,8 @@ class ScheduleFailedJobsAPI(MethodView):
             failed_jobs = DataPersistenceLayer().get_objects(FailedJob)
             failed_jobs.sort(key=lambda job: job.failed_at or "", reverse=True)
             return render_template("schedule/failed_jobs.html", failed_jobs=failed_jobs)
+        except HTTPException:
+            raise
         except Exception as exc:  # pragma: no cover - defensive rendering path
             return BaseView.render_response_notification({"error": f"Failed to load failed jobs: {exc}"}), 500
 
@@ -164,6 +175,8 @@ class ScheduleHistoryAPI(MethodView):
                 total_failures=task_history.totals.failures,
                 overall_success_rate=task_history.totals.overall_success_rate,
             )
+        except HTTPException:
+            raise
         except Exception as exc:  # pragma: no cover - defensive rendering path
             return BaseView.render_response_notification({"error": f"Failed to load history: {exc}"}), 500
 

--- a/src/frontend/frontend/views/admin_views/source_groups_views.py
+++ b/src/frontend/frontend/views/admin_views/source_groups_views.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from models.admin import OSINTSource, OSINTSourceGroup, WordList
+from werkzeug.exceptions import HTTPException
 
 from frontend.data_persistence import DataPersistenceLayer
 from frontend.filters import render_count
@@ -24,11 +25,15 @@ class SourceGroupView(AdminMixin, BaseView):
             word_lists = [
                 w.model_dump(include={"id", "name"}, mode="json") for w in dpl.get_objects(WordList) if "COLLECTOR_INCLUDELIST" in w.usage
             ]
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error retrieving word lists for source group form")
 
         try:
             osint_sources = [p.model_dump(include={"id", "name"}, mode="json") for p in dpl.get_objects(OSINTSource)]
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error retrieving OSINT sources for source group form")
 

--- a/src/frontend/frontend/views/admin_views/source_views.py
+++ b/src/frontend/frontend/views/admin_views/source_views.py
@@ -8,6 +8,7 @@ from models.dashboard import Dashboard
 from models.task import Task
 from models.types import COLLECTOR_TYPES
 from pydantic import ValidationError
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import admin_required
 from frontend.config import Config
@@ -38,6 +39,8 @@ class SourceView(AdminMixin, BaseView):
             if dashboard := DataPersistenceLayer().get_first(Dashboard):
                 if worker_status := dashboard.worker_status:
                     return worker_status.get("collector_task", {}).get("failures", 0)
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error retrieving dashboard for source admin menu badge")
 
@@ -172,6 +175,8 @@ class SourceView(AdminMixin, BaseView):
         except ValidationError as exc:
             logger.error(format_pydantic_errors(exc, cls.model))
             return None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error storing form data")
             return None, "Error storing form data"

--- a/src/frontend/frontend/views/admin_views/template_views.py
+++ b/src/frontend/frontend/views/admin_views/template_views.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from flask import request
 from models.admin import Template
+from werkzeug.exceptions import HTTPException
 
 from frontend.data_persistence import DataPersistenceLayer
 from frontend.log import logger
@@ -62,6 +63,8 @@ class TemplateView(AdminMixin, BaseView):
             dpl = DataPersistenceLayer()
             result = dpl.store_object(obj) if object_id == 0 else dpl.update_object(obj, object_id)
             return (result.json(), None) if result.ok else (None, result.json().get("error"))
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error storing form data: {str(exc)}")
             return None, str(exc)

--- a/src/frontend/frontend/views/auth_views.py
+++ b/src/frontend/frontend/views/auth_views.py
@@ -3,6 +3,7 @@ import contextlib
 import requests
 from flask import Response, make_response, request, url_for
 from flask.views import MethodView
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import is_safe_redirect_target, logout, render_login_page
 from frontend.config import Config
@@ -25,6 +26,8 @@ class AuthView(MethodView):
 
             try:
                 core_response = CoreApi().external_login(auth_headers)
+            except HTTPException:
+                raise
             except Exception as exc:
                 logger.warning(f"External login request failed on attempt {attempt}: {exc}")
 
@@ -83,6 +86,8 @@ class AuthView(MethodView):
 
         try:
             core_response = CoreApi().login(username, password)
+        except HTTPException:
+            raise
         except Exception:
             return render_login_page(login_error="Login failed, no response from server"), 500
 

--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -7,6 +7,7 @@ from jinja2 import TemplateNotFound
 from models.base import TaranisBaseModel
 from pydantic import ValidationError
 from requests import Response as RequestsResponse
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required
 from frontend.cache_models import CacheObject
@@ -131,6 +132,8 @@ class BaseView(MethodView):
         except ValidationError as exc:
             logger.error(format_pydantic_errors(exc, cls.model))
             return None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error storing form data: {str(exc)}")
             return None, str(exc)
@@ -145,6 +148,8 @@ class BaseView(MethodView):
         except ValidationError as exc:
             logger.error(format_pydantic_errors(exc, cls.model))
             return None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error storing form data: {str(exc)}")
             return None, str(exc)
@@ -325,6 +330,8 @@ class BaseView(MethodView):
         except ValidationError as exc:
             logger.exception(format_pydantic_errors(exc, cls.model))
             items, error = None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Error retrieving {cls.model_name()} items")
             items, error = None, str(exc)
@@ -345,6 +352,8 @@ class BaseView(MethodView):
             logger.exception(format_pydantic_errors(exc, cls.model))
             items, error = None, format_pydantic_errors(exc, cls.model)
             status_code = 400
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Error retrieving {cls.model_name()} items")
             items, error = None, str(exc)
@@ -357,6 +366,8 @@ class BaseView(MethodView):
         try:
             items = DataPersistenceLayer().get_objects(cls.model)
             error = None
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Error retrieving {cls.model_name()} items")
             items, error = None, str(exc)

--- a/src/frontend/frontend/views/dashboard_views.py
+++ b/src/frontend/frontend/views/dashboard_views.py
@@ -7,6 +7,7 @@ from flask.typing import ResponseReturnValue
 from flask_jwt_extended import current_user
 from models.dashboard import Cluster, Dashboard, NewsItemConflict, StoryConflict, TrendingCluster
 from models.user import ProfileSettingsDashboard
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required, update_current_user_cache
 from frontend.core_api import CoreApi
@@ -34,6 +35,8 @@ class DashboardView(BaseView):
                 dashboard = dashboard_items[0]
             else:
                 return render_template("errors/404.html", error="No Dashboard items found"), 404
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error retrieving {cls.model_name()} items: {exc}")
             return render_template("errors/404.html", error="No Dashboard items found"), 404
@@ -41,6 +44,8 @@ class DashboardView(BaseView):
         try:
             trending_clusters = DataPersistenceLayer().get_objects(TrendingCluster)
             dashboard_config = current_user.profile.dashboard
+        except HTTPException:
+            raise
         except Exception:
             trending_clusters = []
             dashboard_config = ProfileSettingsDashboard()
@@ -68,6 +73,8 @@ class DashboardView(BaseView):
         except ValueError:
             logger.exception(f"No cluster found for type: {cluster_name}")
             cluster = None
+        except HTTPException:
+            raise
         except Exception:
             logger.exception(f"Error fetching cluster for type: {cluster_name}")
             cluster = None
@@ -103,6 +110,8 @@ class DashboardView(BaseView):
             trending_clusters = CoreApi().api_get("/dashboard/cluster-names")
             if trending_clusters:
                 trending_clusters = trending_clusters.get("items", [])
+        except HTTPException:
+            raise
         except Exception:
             trending_clusters = []
 
@@ -146,6 +155,8 @@ class DashboardView(BaseView):
                 remaining_stories=remaining_stories,
                 story_summaries=story_summaries,
             )
+        except HTTPException:
+            raise
         except Exception as error:
             logger.exception(f"Failed to render News Item Conflict View: {error}")
             return render_template("errors/404.html", error="No news item conflicts found"), 404
@@ -240,6 +251,8 @@ class DashboardView(BaseView):
             for conflict in conflict_cache_object.items:
                 if conflict.incoming_story_id == incoming_story_id:
                     return conflict.incoming_story
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Failed loading incoming story snapshot for {incoming_story_id}: {exc}")
         return None
@@ -403,6 +416,8 @@ class DashboardView(BaseView):
 
             return cls.news_item_conflict_view()
 
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Failed POST add-unique-items: {exc}")
             return make_response("Internal error adding unique news items", 500)
@@ -430,6 +445,8 @@ class DashboardView(BaseView):
 
             return cls.news_item_conflict_view()
 
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Failed PUT news-item conflict resolve: {exc}")
             return make_response("Internal error resolving conflict", 500)

--- a/src/frontend/frontend/views/product_views.py
+++ b/src/frontend/frontend/views/product_views.py
@@ -3,6 +3,7 @@ from typing import Any
 from flask import abort, render_template, request
 from flask.typing import ResponseReturnValue
 from models.product import Product, ProductType, PublisherPreset
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required
 from frontend.core_api import CoreApi
@@ -70,6 +71,8 @@ class ProductView(BaseView):
                 error = error_payload.get("error", "Unknown error")
 
             logger.error(f"Download product failed with status {core_resp.status_code}: {error}")
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Download product failed: {str(e)}")
             error = f"Failed to download product - {str(e)}"
@@ -87,6 +90,8 @@ class ProductView(BaseView):
 
             message = core_resp.json().get("message", "Unknown error")
             return render_template("notification/index.html", notification={"message": message, "error": False}), 200
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Render product failed: {str(e)}")
             error = f"Failed to render product - {str(e)}"
@@ -104,6 +109,8 @@ class ProductView(BaseView):
 
             message = core_resp.json().get("message", "Unknown error")
             return render_template("notification/index.html", notification={"message": message, "error": False}), 200
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Publish product failed: {str(e)}")
             error = f"Failed to publish product - {str(e)}"

--- a/src/frontend/frontend/views/report_views.py
+++ b/src/frontend/frontend/views/report_views.py
@@ -5,6 +5,7 @@ from flask.typing import ResponseReturnValue
 from models.assess import Story
 from models.report import ReportItem, ReportItemAttributeGroup, ReportTypes
 from pydantic import ValidationError
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required
 from frontend.core_api import CoreApi
@@ -75,6 +76,8 @@ class ReportItemView(BaseView):
                 "layout": layout,
                 "actions": cls.get_report_actions(),
             }
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Error getting extra context for ReportItemView")
 
@@ -181,6 +184,8 @@ class ReportItemView(BaseView):
         except ValidationError as exc:
             logger.error(format_pydantic_errors(exc, cls.model))
             return None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error storing form data: {str(exc)}")
             return None, str(exc)

--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -12,6 +12,7 @@ from models.assess import AssessSource, BulkAction, Connector, FilterLists, News
 from models.report import ReportItem
 from pydantic import ValidationError
 from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required
 from frontend.cache import add_model_to_cache, get_model_from_cache
@@ -158,6 +159,8 @@ class StoryView(BaseView):
         mail_sharing_link = cls.share_story_link(story_ids)
         try:
             connectors = DataPersistenceLayer().get_objects(Connector)
+        except HTTPException:
+            raise
         except Exception as e:
             logger.error(f"Failed to fetch connectors for share dialog: {e}")
             connectors = []
@@ -181,6 +184,8 @@ class StoryView(BaseView):
             core_response = CoreApi().api_post(f"/assess/story/{connector_id}/share", json_data={"story_ids": story_ids})
             notification_html = cls.get_notification_from_response(core_response)
             status_code = getattr(core_response, "status_code", 500) or 500
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to share stories with connector.")
             notification_html = cls.render_response_notification({"error": "Failed to share stories with connector."})
@@ -350,6 +355,8 @@ class StoryView(BaseView):
         except ValidationError as exc:
             logger.exception(format_pydantic_errors(exc, cls.model))
             items, error = None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.exception(f"Error retrieving {cls.model_name()} items")
             items, error = None, str(exc)
@@ -451,6 +458,8 @@ class StoryView(BaseView):
         try:
             response = api.api_post("/assess/stories/botactions", json_data={"story_id": story_id, "bot_id": bot_id})
             payload = response.json()
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to decode bot action response.")
             notification = {"message": "Failed to decode bot action response", "error": True}
@@ -471,6 +480,8 @@ class StoryView(BaseView):
         api = CoreApi()
         try:
             tags = api.api_get(f"/assess/taglist?search={query}")
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to fetch tag suggestions.")
             tags = []
@@ -567,6 +578,8 @@ class StoryView(BaseView):
             core_response = CoreApi().api_post("/assess/import", json_data=json_data)
             cls.add_flash_notification(core_response)
             return cls.redirect_htmx(url_for("assess.get_news_item", news_item_id=core_response.json().get("id", "0")))
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to create news item from file.")
             flash("Failed to create news item from file", "error")
@@ -589,6 +602,8 @@ class StoryView(BaseView):
         except JSONDecodeError:
             logger.warning("Failed to decode story import JSON payload.")
             return make_response(cls.render_response_notification({"error": "Invalid JSON file."}), 400)
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to import stories.")
             return make_response(cls.render_response_notification({"error": "Failed to import stories."}), 500)
@@ -613,6 +628,8 @@ class StoryView(BaseView):
         try:
             core_response = CoreApi().api_post("/assess/news-items/fetch", json_data={"url": url})
             return cls.news_item_edit_view(core_response)
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to create news item from URL.")
             return cls.render_response_notification({"error": "Failed to create news item from URL."})
@@ -622,6 +639,8 @@ class StoryView(BaseView):
     def delete_news_item(cls, news_item_id: str):
         try:
             core_response = CoreApi().api_delete(f"/assess/news-items/{news_item_id}")
+        except HTTPException:
+            raise
         except Exception:
             return cls.render_response_notification({"error": "Failed to delete news item"})
 
@@ -636,6 +655,8 @@ class StoryView(BaseView):
     def delete_story(cls, story_id: str):
         try:
             core_response = CoreApi().api_delete(f"/assess/story/{story_id}")
+        except HTTPException:
+            raise
         except Exception:
             return cls.render_response_notification({"error": "Failed to delete story"})
 
@@ -687,6 +708,8 @@ class StoryView(BaseView):
                 notification_html = cls.get_notification_from_response(response)
                 content = cls._get_action_response_content(story_id)
                 return make_response(notification_html + content, 200)
+            except HTTPException:
+                raise
             except Exception:
                 logger.exception("Failed to ungroup news item.")
                 return cls.render_response_notification({"error": "Failed to ungroup news item."})
@@ -695,6 +718,8 @@ class StoryView(BaseView):
                 core_response = CoreApi().api_put("/assess/stories/ungroup", json_data=[story_id])
                 cls.add_flash_notification(core_response)
                 return cls.redirect_htmx(url_for("assess.assess"))
+            except HTTPException:
+                raise
             except Exception:
                 logger.exception("Failed to ungroup story.")
                 return cls.render_response_notification({"error": "Failed to ungroup story."})
@@ -719,6 +744,8 @@ class StoryView(BaseView):
                 f'attachment; filename="stories_export_{datetime.datetime.now().strftime("%Y%m%d_%H%M%S")}.json"'
             )
             return flask_response
+        except HTTPException:
+            raise
         except Exception:
             logger.exception("Failed to export stories.")
             return cls.render_response_notification({"error": "Failed to export stories."}), 500

--- a/src/frontend/frontend/views/user_views.py
+++ b/src/frontend/frontend/views/user_views.py
@@ -5,6 +5,7 @@ from flask.typing import ResponseReturnValue
 from flask_jwt_extended import current_user
 from models.user import ProfileSettings, UserProfile
 from pydantic import ValidationError
+from werkzeug.exceptions import HTTPException
 
 from frontend.auth import auth_required, update_current_user_cache
 from frontend.core_api import CoreApi
@@ -85,6 +86,8 @@ class UserProfileView(BaseView):
         except ValidationError as exc:
             logger.error(format_pydantic_errors(exc, cls.model))
             return None, format_pydantic_errors(exc, cls.model)
+        except HTTPException:
+            raise
         except Exception as exc:
             logger.error(f"Error storing form data: {str(exc)}")
             return None, str(exc)

--- a/src/frontend/tests/unit/test_http_exception_lint.py
+++ b/src/frontend/tests/unit/test_http_exception_lint.py
@@ -1,0 +1,92 @@
+import ast
+from pathlib import Path
+
+
+REQUEST_METHOD_NAMES = {
+    "api_delete",
+    "api_get",
+    "api_patch",
+    "api_post",
+    "api_put",
+    "delete_object",
+    "get_first",
+    "get_object",
+    "get_objects",
+    "get_objects_by_endpoint",
+    "store_object",
+    "update_object",
+}
+
+TARGET_PATHS = (
+    Path("frontend/auth.py"),
+    Path("frontend/views"),
+)
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for target in TARGET_PATHS:
+        if target.is_file():
+            files.append(target)
+            continue
+        files.extend(sorted(path for path in target.rglob("*.py") if path.is_file()))
+    return files
+
+
+def _contains_request_call(try_node: ast.Try) -> bool:
+    for node in try_node.body:
+        for nested in ast.walk(node):
+            if not isinstance(nested, ast.Call):
+                continue
+            if isinstance(nested.func, ast.Name) and nested.func.id in {"CoreApi", "DataPersistenceLayer"}:
+                return True
+            if isinstance(nested.func, ast.Attribute) and nested.func.attr in REQUEST_METHOD_NAMES:
+                return True
+    return False
+
+
+def _is_http_exception_type(handler_type: ast.expr | None) -> bool:
+    if handler_type is None:
+        return False
+    if isinstance(handler_type, ast.Name):
+        return handler_type.id == "HTTPException"
+    if isinstance(handler_type, ast.Attribute):
+        return handler_type.attr == "HTTPException"
+    if isinstance(handler_type, ast.Tuple):
+        return any(_is_http_exception_type(element) for element in handler_type.elts)
+    return False
+
+
+def _is_broad_exception_type(handler_type: ast.expr | None) -> bool:
+    if handler_type is None:
+        return True
+    if isinstance(handler_type, ast.Name):
+        return handler_type.id == "Exception"
+    if isinstance(handler_type, ast.Attribute):
+        return handler_type.attr == "Exception"
+    if isinstance(handler_type, ast.Tuple):
+        return any(_is_broad_exception_type(element) for element in handler_type.elts)
+    return False
+
+
+def test_request_try_blocks_preserve_http_exceptions():
+    violations: list[str] = []
+
+    for path in _iter_python_files():
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try) or not _contains_request_call(node):
+                continue
+
+            saw_http_exception_handler = False
+            for handler in node.handlers:
+                if _is_http_exception_type(handler.type):
+                    saw_http_exception_handler = True
+                    continue
+                if _is_broad_exception_type(handler.type) and not saw_http_exception_handler:
+                    violations.append(
+                        f"{path}:{handler.lineno} catches Exception for a request-making try block without first re-raising HTTPException"
+                    )
+                    break
+
+    assert not violations, "\n".join(violations)

--- a/src/frontend/tests/unit/views/test_report_view.py
+++ b/src/frontend/tests/unit/views/test_report_view.py
@@ -1,0 +1,37 @@
+from flask import url_for
+
+from frontend.config import Config
+
+
+def test_report_view_renders_access_denied_page_when_core_returns_403(app, authenticated_client_basic, responses_mock):
+    report_id = "12676a74-0850-4eef-971b-a4efd9d526e6"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items/{report_id}",
+        json={"error": f"User 2 is not allowed to read Report {report_id}"},
+        status=403,
+        content_type="application/json",
+    )
+
+    with app.test_request_context():
+        response = authenticated_client_basic.get(url_for("analyze.report", report_id=report_id))
+
+    assert response.status_code == 403
+    html = response.get_data(as_text=True)
+    assert "403 - Access denied" in html
+
+
+def test_story_view_renders_access_denied_page_when_core_returns_403(app, authenticated_client_basic, responses_mock):
+    story_id = "12676a74-0850-4eef-971b-a4efd9d526e6"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}",
+        json={"error": f"User 2 is not allowed to read Story {story_id}"},
+        status=403,
+        content_type="application/json",
+    )
+
+    with app.test_request_context():
+        response = authenticated_client_basic.get(url_for("assess.story", story_id=story_id))
+
+    assert response.status_code == 403
+    html = response.get_data(as_text=True)
+    assert "403 - Access denied" in html


### PR DESCRIPTION
We catch exceptions very broadly with 
```
catch Exception...
```

To make the behaviour work more nicely in cases 403 is returned from `core`, I suggest catching the `HTTPException`.
The `src/frontend/tests/unit/test_http_exception_lint.py` is supposed to validate that this is not forgotten to be added.

## Summary by Sourcery

Ensure HTTP-related exceptions from core API and persistence calls are propagated correctly while introducing centralized handling of 403 Forbidden responses.

Bug Fixes:
- Preserve HTTPException propagation in views and core API helpers so framework-level error handlers can render appropriate HTTP responses.
- Handle 403 Forbidden responses from the core API by raising a Forbidden HTTPException with a meaningful error message extracted from the response payload.

Enhancements:
- Add an AST-based unit test that enforces try/except blocks around CoreApi and DataPersistenceLayer calls to re-raise HTTPException before catching broad exceptions.
- Improve error messaging for forbidden core API calls by extracting error details from JSON or text responses.

Tests:
- Add unit tests verifying that report and story views render an access denied page when the core service returns HTTP 403.