### PR TITLE
Add local signoff 

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -9,8 +9,53 @@ env:
   UV_FROZEN: true
 
 jobs:
+  detect_signoff:
+    name: detect signoff
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: read
+    outputs:
+      signedoff: ${{ steps.detect.outputs.signedoff }}
+    steps:
+      - name: Check signoff status
+        id: detect
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const headRepo = context.payload.pull_request?.head?.repo?.full_name || process.env.GITHUB_REPOSITORY;
+            const [owner, repo] = headRepo.split("/");
+            const ref = context.payload.pull_request?.head?.sha || context.sha;
+            let signedoff = false;
+
+            try {
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                {
+                  owner,
+                  repo,
+                  ref,
+                  per_page: 100,
+                }
+              );
+              const signoff = statuses.find((status) => status.context === "signoff");
+
+              if (signoff?.state === "success") {
+                signedoff = true;
+              }
+
+              core.info(
+                `Checked signoff status for ${headRepo}@${ref}: ${signoff?.state || "missing"}`
+              );
+            } catch (error) {
+              core.warning(`Failed to read signoff status for ${headRepo}@${ref}: ${error.message}`);
+            }
+
+            core.setOutput("signedoff", signedoff ? "true" : "false");
+
   test_core:
     name: pytest core
+    needs: detect_signoff
+    if: needs.detect_signoff.outputs.signedoff != 'true'
     defaults:
       run:
         working-directory: src/core
@@ -45,6 +90,8 @@ jobs:
 
   test_frontend:
     name: pytest frontend
+    needs: detect_signoff
+    if: needs.detect_signoff.outputs.signedoff != 'true'
     defaults:
       run:
         working-directory: src/frontend
@@ -82,8 +129,9 @@ jobs:
 
   e2e_tests:
     name: End-to-End Tests
+    if: needs.detect_signoff.outputs.signedoff != 'true'
     runs-on: ubuntu-latest
-    needs: [test_core, test_frontend]
+    needs: [detect_signoff, test_core, test_frontend]
     steps:
       - uses: actions/checkout@v6
 
@@ -167,6 +215,8 @@ jobs:
 
   test_worker:
     name: pytest worker
+    needs: detect_signoff
+    if: needs.detect_signoff.outputs.signedoff != 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -201,3 +251,40 @@ jobs:
           echo "- **❌ Failed:** $(grep -oP '\d+(?= failed)' pytest_output.txt || echo 0)" >> $GITHUB_STEP_SUMMARY
           echo "- **⚠️ Skipped:** $(grep -oP '\d+(?= skipped)' pytest_output.txt || echo 0)" >> $GITHUB_STEP_SUMMARY
           echo "- **🚨 Errors:** $(grep -oP '\d+(?= error)' pytest_output.txt || echo 0)" >> $GITHUB_STEP_SUMMARY
+
+  local_or_ci:
+    name: local or ci
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - detect_signoff
+      - test_core
+      - test_frontend
+      - e2e_tests
+      - test_worker
+    permissions:
+      statuses: read
+    steps:
+      - name: Evaluate signoff or CI result
+        env:
+          SIGNEDOFF: ${{ needs.detect_signoff.outputs.signedoff }}
+          TEST_CORE_RESULT: ${{ needs.test_core.result }}
+          TEST_FRONTEND_RESULT: ${{ needs.test_frontend.result }}
+          E2E_RESULT: ${{ needs.e2e_tests.result }}
+          TEST_WORKER_RESULT: ${{ needs.test_worker.result }}
+        run: |
+          if [ "$SIGNEDOFF" = "true" ]; then
+            echo "Current head commit is signed off."
+            exit 0
+          fi
+
+          if [ "$TEST_CORE_RESULT" = "success" ] \
+            && [ "$TEST_FRONTEND_RESULT" = "success" ] \
+            && [ "$E2E_RESULT" = "success" ] \
+            && [ "$TEST_WORKER_RESULT" = "success" ]; then
+            echo "All CI jobs passed."
+            exit 0
+          fi
+
+          echo "::error ::Neither a valid local signoff nor a full successful CI run is present."
+          exit 1

--- a/dev/README.md
+++ b/dev/README.md
@@ -2,6 +2,24 @@
 
 Dependency updates use [Renovate](https://docs.renovatebot.com/) with [`.github/renovate.json`](../.github/renovate.json).
 
+## Optional local signoff
+
+This repo accepts either a successful `test and lint` workflow run or a successful local `gh signoff` on the current PR head commit. See [basecamp/gh-signoff](https://github.com/basecamp/gh-signoff/blob/main/README.md) for upstream details.
+
+Setup:
+
+```bash
+gh auth login
+gh extension install basecamp/gh-signoff
+```
+
+Workflow:
+
+1. Push your branch and create or update the pull request.
+2. Run `./dev/signoff.sh` from the repository root. It runs the same local lint, unit test, and e2e scope as the PR workflow, then calls `gh signoff` only if everything passes.
+3. Run `./dev/signoff.sh` again after every new commit you push.
+4. If you do not use local signoff, the normal `test and lint` GitHub Actions workflow remains the fallback path.
+
 ## Easy Mode
 
 Clone Repository

--- a/dev/signoff.sh
+++ b/dev/signoff.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+run_step() {
+  printf '\n==> %s\n' "$1"
+}
+
+run_in_dir() {
+  local dir="$1"
+  shift
+  (
+    cd "$dir"
+    "$@"
+  )
+}
+
+require_command git
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)" || fail "Run this command from inside the taranis-ai git worktree."
+cd "$ROOT_DIR"
+
+require_command uv
+require_command gh
+
+if [ -n "$(git status --short --untracked-files=normal)" ]; then
+  fail "Working tree is not clean. Commit or stash changes before running signoff."
+fi
+
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  fail "GitHub CLI is not authenticated for github.com. Run 'gh auth login'."
+fi
+
+if ! gh extension list | grep -Fq 'basecamp/gh-signoff'; then
+  fail "gh-signoff is not installed. Run 'gh extension install basecamp/gh-signoff'."
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  fail "Docker Compose is required for frontend e2e tests."
+fi
+
+export DEBUG=true
+
+run_step "src/core"
+run_in_dir src/core uv sync --all-extras
+run_in_dir src/core uv run ruff check
+run_in_dir src/core uv run pytest
+
+run_step "src/frontend"
+run_in_dir src/frontend uv sync --all-extras
+run_in_dir src/frontend uv run ruff check
+run_in_dir src/frontend uv run djlint --profile=jinja --check frontend/templates
+run_in_dir src/frontend uv run pytest
+
+run_step "src/frontend e2e"
+run_in_dir src/frontend uv run pytest --e2e-ci
+
+run_step "src/worker"
+run_in_dir src/worker uv sync --all-extras
+run_in_dir src/worker uv run ruff check
+run_in_dir src/worker uv run pytest
+
+run_step "gh signoff"
+gh signoff

--- a/dev/signoff.sh
+++ b/dev/signoff.sh
@@ -53,23 +53,25 @@ fi
 export DEBUG=true
 
 run_step "src/core"
-run_in_dir src/core uv sync --all-extras
-run_in_dir src/core uv run ruff check
-run_in_dir src/core uv run pytest
+run_in_dir src/core uv sync --frozen --all-extras
+run_in_dir src/core uv run --frozen --no-sync ruff check
+run_in_dir src/core uv run --frozen --no-sync pytest
 
 run_step "src/frontend"
-run_in_dir src/frontend uv sync --all-extras
-run_in_dir src/frontend uv run ruff check
-run_in_dir src/frontend uv run djlint --profile=jinja --check frontend/templates
-run_in_dir src/frontend uv run pytest
+run_in_dir src/frontend uv sync --frozen --all-extras
+run_in_dir src/frontend uv run --frozen --no-sync ruff check
+run_in_dir src/frontend uv run --frozen --no-sync djlint --profile=jinja --check frontend/templates
+run_in_dir src/frontend uv run --frozen --no-sync pytest
 
 run_step "src/frontend e2e"
-run_in_dir src/frontend uv run pytest --e2e-ci
+run_in_dir src/frontend uv run --frozen --no-sync pytest --e2e-ci
 
 run_step "src/worker"
-run_in_dir src/worker uv sync --all-extras
-run_in_dir src/worker uv run ruff check
-run_in_dir src/worker uv run pytest
+run_in_dir src/worker uv sync --frozen --all-extras
+run_in_dir src/worker uv run --frozen --no-sync ruff check
+run_in_dir src/worker uv run --frozen --no-sync pytest
+
+ensure_clean_worktree "Working tree changed during local validation. Review the changes before running signoff."
 
 run_step "gh signoff"
 gh signoff

--- a/dev/signoff.sh
+++ b/dev/signoff.sh
@@ -10,6 +10,12 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
 }
 
+ensure_clean_worktree() {
+  if [ -n "$(git status --short --untracked-files=normal)" ]; then
+    fail "$1"
+  fi
+}
+
 run_step() {
   printf '\n==> %s\n' "$1"
 }
@@ -30,9 +36,7 @@ cd "$ROOT_DIR"
 require_command uv
 require_command gh
 
-if [ -n "$(git status --short --untracked-files=normal)" ]; then
-  fail "Working tree is not clean. Commit or stash changes before running signoff."
-fi
+ensure_clean_worktree "Working tree is not clean. Commit or stash changes before running signoff."
 
 if ! gh auth status --hostname github.com >/dev/null 2>&1; then
   fail "GitHub CLI is not authenticated for github.com. Run 'gh auth login'."


### PR DESCRIPTION
Adds a local helper script to 1. run tests like the test-and-lint workflow in CI does and 2. do a `gh signoff`

## Summary by Sourcery

Introduce an optional local signoff flow that mirrors the CI test-and-lint workflow and teaches CI to accept either a successful local signoff or a full green run.

New Features:
- Add a local signoff helper script that runs core, frontend, e2e, and worker checks before signing off the current PR head via `gh signoff`.

Enhancements:
- Extend the linting CI workflow to short-circuit test jobs when a successful signoff status is present and to enforce that each PR has either a valid local signoff or fully passing CI.

Documentation:
- Document the optional local signoff workflow, including setup steps and usage within the development README.