### PR TITLE
Refactor post-save handling of BaseView

### DIFF
--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -238,31 +238,44 @@ class BaseView(MethodView):
         object_id: int | str,
         error: str | None = None,
         form_error: str | None = None,
-        resp_obj: dict[str, Any] | None = None,
+        model_instance: TaranisBaseModel | None = None,
+        response_message: str | None = None,
+        form_action_object_id: int | str | None = None,
     ) -> dict[str, Any]:
-        submit = f"Update {cls.pretty_name()}"
+        model_context_key = cls.model_name()
 
-        context = cls._common_context(object_id=object_id)
-        context.update(
-            {
-                "error": error,
-                "form_error": form_error,
-                "form_action": cls.get_form_action(object_id),
-                "submit_text": submit,
-            }
-        )
+        context = {
+            **cls._common_context(object_id=object_id),
+            "error": error,
+            "form_error": form_error,
+            "form_action": cls.get_form_action(form_action_object_id if form_action_object_id is not None else object_id),
+            "submit_text": f"Update {cls.pretty_name()}",
+        }
 
-        if resp_obj:
-            if model_instance := resp_obj.get(cls.model_name()):
-                context[cls.model_name()] = cls.model(**model_instance)
-            if msg := resp_obj.get("message"):
-                context["message"] = msg
-            if new_id := resp_obj.get("id"):
-                context["form_action"] = cls.get_form_action(new_id)
-        else:
-            context[cls.model_name()] = cls.model.model_construct(id="0")
+        context[model_context_key] = model_instance or cls.model.model_construct(id="0")
+
+        if response_message:
+            context["message"] = response_message
 
         return cls.get_extra_context(base_context=context)
+
+    @classmethod
+    def resolve_update_response(
+        cls, object_id: int | str, resp_obj: dict[str, Any] | None
+    ) -> tuple[int | str, TaranisBaseModel | None, str | None]:
+        if not resp_obj:
+            return object_id, None, None
+
+        response_object_id = resp_obj.get("id", object_id)
+        persisted_object_id = None if response_object_id in {0, "0", None, ""} else response_object_id
+        model_instance = None
+
+        if model_payload := resp_obj.get(cls.model_name()):
+            model_instance = cls.model(**model_payload)
+        elif persisted_object_id is not None:
+            model_instance = DataPersistenceLayer().get_object(cls.model, persisted_object_id)
+
+        return response_object_id, model_instance, resp_obj.get("message")
 
     @classmethod
     def get_default_actions(cls) -> list[dict[str, Any]]:
@@ -304,16 +317,29 @@ class BaseView(MethodView):
     @classmethod
     def update_view(cls, object_id: int | str = 0):
         core_response, error = cls.process_form_data(object_id)
+        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, core_response)
         if not core_response or error:
             return render_template(
                 cls.get_update_template(),
-                **cls.get_update_context(object_id, error=error, resp_obj=core_response),
+                **cls.get_update_context(
+                    object_id,
+                    error=error,
+                    model_instance=model_instance,
+                    response_message=response_message,
+                    form_action_object_id=response_object_id,
+                ),
             ), 400
 
         notification_response = cls.render_response_notification(core_response)
         response = notification_response + render_template(
             cls.get_update_template(),
-            **cls.get_update_context(object_id, error=error, resp_obj=core_response),
+            **cls.get_update_context(
+                object_id,
+                error=error,
+                model_instance=model_instance,
+                response_message=response_message,
+                form_action_object_id=response_object_id,
+            ),
         )
         flask_response = make_response(response, 200)
         flask_response.headers["HX-Push-Url"] = cls.get_edit_route(**{cls._get_object_key(): core_response.get("id", object_id)})
@@ -501,7 +527,18 @@ class BaseView(MethodView):
         cls, object_id: int | str, error: str | None = None, resp_obj: dict[str, Any] | None = None
     ) -> tuple[str, int]:
         submitted_model = cls._submitted_form_model(object_id)
-        context = cls.get_create_context() if object_id == 0 else cls.get_update_context(object_id, error=error, resp_obj=resp_obj)
+        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
+        context = (
+            cls.get_create_context()
+            if object_id == 0
+            else cls.get_update_context(
+                object_id,
+                error=error,
+                model_instance=model_instance,
+                response_message=response_message,
+                form_action_object_id=response_object_id,
+            )
+        )
 
         if object_id == 0:
             if error:
@@ -519,9 +556,16 @@ class BaseView(MethodView):
 
     @classmethod
     def handle_submit_error(cls, object_id: int | str, error: str | None = None, resp_obj: dict[str, Any] | None = None) -> tuple[str, int]:
+        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
         return render_template(
             cls.get_update_template(),
-            **cls.get_update_context(object_id, error=error, resp_obj=resp_obj),
+            **cls.get_update_context(
+                object_id,
+                error=error,
+                model_instance=model_instance,
+                response_message=response_message,
+                form_action_object_id=response_object_id,
+            ),
         ), 400
 
     @classmethod

--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -213,7 +213,7 @@ class BaseView(MethodView):
             }
         )
 
-        context[cls.model_name()] = DataPersistenceLayer().get_object(cls.model, object_id)
+        context[cls.model_name()] = cls.get_object_by_id(object_id)
         return cls.get_extra_context(context)
 
     @classmethod
@@ -260,11 +260,15 @@ class BaseView(MethodView):
         return cls.get_extra_context(base_context=context)
 
     @classmethod
+    def get_object_by_id(cls, object_id: int | str) -> TaranisBaseModel | None:
+        return DataPersistenceLayer().get_object(cls.model, object_id)
+
+    @classmethod
     def resolve_update_response(
         cls, object_id: int | str, resp_obj: dict[str, Any] | None
-    ) -> tuple[int | str, TaranisBaseModel | None, str | None]:
+    ) -> tuple[int | str | None, TaranisBaseModel | None, str | None]:
         if not resp_obj:
-            return object_id, None, None
+            return None if object_id in {0, "0", None, ""} else object_id, None, None
 
         response_object_id = resp_obj.get("id", object_id)
         persisted_object_id = None if response_object_id in {0, "0", None, ""} else response_object_id
@@ -273,9 +277,9 @@ class BaseView(MethodView):
         if model_payload := resp_obj.get(cls.model_name()):
             model_instance = cls.model(**model_payload)
         elif persisted_object_id is not None:
-            model_instance = DataPersistenceLayer().get_object(cls.model, persisted_object_id)
+            model_instance = cls.get_object_by_id(persisted_object_id)
 
-        return response_object_id, model_instance, resp_obj.get("message")
+        return persisted_object_id, model_instance, resp_obj.get("message")
 
     @classmethod
     def get_default_actions(cls) -> list[dict[str, Any]]:
@@ -317,7 +321,7 @@ class BaseView(MethodView):
     @classmethod
     def update_view(cls, object_id: int | str = 0):
         core_response, error = cls.process_form_data(object_id)
-        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, core_response)
+        persisted_object_id, model_instance, response_message = cls.resolve_update_response(object_id, core_response)
         if not core_response or error:
             return render_template(
                 cls.get_update_template(),
@@ -326,7 +330,7 @@ class BaseView(MethodView):
                     error=error,
                     model_instance=model_instance,
                     response_message=response_message,
-                    form_action_object_id=response_object_id,
+                    form_action_object_id=persisted_object_id,
                 ),
             ), 400
 
@@ -338,7 +342,7 @@ class BaseView(MethodView):
                 error=error,
                 model_instance=model_instance,
                 response_message=response_message,
-                form_action_object_id=response_object_id,
+                form_action_object_id=persisted_object_id,
             ),
         )
         flask_response = make_response(response, 200)
@@ -530,13 +534,13 @@ class BaseView(MethodView):
         if object_id == 0:
             context = cls.get_create_context()
         else:
-            response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
+            persisted_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
             context = cls.get_update_context(
                 object_id,
                 error=error,
                 model_instance=model_instance,
                 response_message=response_message,
-                form_action_object_id=response_object_id,
+                form_action_object_id=persisted_object_id,
             )
 
         if object_id == 0:
@@ -555,7 +559,7 @@ class BaseView(MethodView):
 
     @classmethod
     def handle_submit_error(cls, object_id: int | str, error: str | None = None, resp_obj: dict[str, Any] | None = None) -> tuple[str, int]:
-        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
+        persisted_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
         return render_template(
             cls.get_update_template(),
             **cls.get_update_context(
@@ -563,7 +567,7 @@ class BaseView(MethodView):
                 error=error,
                 model_instance=model_instance,
                 response_message=response_message,
-                form_action_object_id=response_object_id,
+                form_action_object_id=persisted_object_id,
             ),
         ), 400
 

--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -252,7 +252,7 @@ class BaseView(MethodView):
             "submit_text": f"Update {cls.pretty_name()}",
         }
 
-        context[model_context_key] = model_instance or cls.model.model_construct(id="0")
+        context[model_context_key] = model_instance if model_instance is not None else cls.model.model_construct(id="0")
 
         if response_message:
             context["message"] = response_message
@@ -527,18 +527,17 @@ class BaseView(MethodView):
         cls, object_id: int | str, error: str | None = None, resp_obj: dict[str, Any] | None = None
     ) -> tuple[str, int]:
         submitted_model = cls._submitted_form_model(object_id)
-        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
-        context = (
-            cls.get_create_context()
-            if object_id == 0
-            else cls.get_update_context(
+        if object_id == 0:
+            context = cls.get_create_context()
+        else:
+            response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, resp_obj)
+            context = cls.get_update_context(
                 object_id,
                 error=error,
                 model_instance=model_instance,
                 response_message=response_message,
                 form_action_object_id=response_object_id,
             )
-        )
 
         if object_id == 0:
             if error:

--- a/src/frontend/frontend/views/report_views.py
+++ b/src/frontend/frontend/views/report_views.py
@@ -144,16 +144,29 @@ class ReportItemView(BaseView):
     @classmethod
     def update_view(cls, object_id: int | str = 0):
         core_response, error = cls.process_form_data(object_id)
+        response_object_id, model_instance, response_message = cls.resolve_update_response(object_id, core_response)
         if not core_response or error:
             return render_template(
                 cls.get_update_template(),
-                **cls.get_update_context(object_id, error=error, resp_obj=core_response),
+                **cls.get_update_context(
+                    object_id,
+                    error=error,
+                    model_instance=model_instance,
+                    response_message=response_message,
+                    form_action_object_id=response_object_id,
+                ),
             ), 400
 
         notification_response = cls.render_response_notification(core_response)
         response = notification_response + render_template(
             cls.get_update_template(),
-            **cls.get_update_context(object_id, error=error, resp_obj=core_response),
+            **cls.get_update_context(
+                object_id,
+                error=error,
+                model_instance=model_instance,
+                response_message=response_message,
+                form_action_object_id=response_object_id,
+            ),
         )
         flask_response = make_response(response, 200)
         flask_response.headers["HX-Push-Url"] = cls.get_edit_route(**{cls._get_object_key(): core_response.get("id", object_id)})

--- a/src/frontend/tests/unit/views/test_report_view.py
+++ b/src/frontend/tests/unit/views/test_report_view.py
@@ -1,6 +1,8 @@
 from flask import url_for
+from models.report import ReportItem, ReportTypes
 
 from frontend.config import Config
+from frontend.views.report_views import ReportItemView
 
 
 def test_report_view_renders_access_denied_page_when_core_returns_403(app, authenticated_client_basic, responses_mock):
@@ -35,3 +37,76 @@ def test_story_view_renders_access_denied_page_when_core_returns_403(app, authen
     assert response.status_code == 403
     html = response.get_data(as_text=True)
     assert "403 - Access denied" in html
+
+
+def test_report_update_response_fetches_saved_report_when_core_response_only_contains_id(app, monkeypatch):
+    saved_report_id = "8124ae6f-3c85-49b4-93a1-9f3dc6516310"
+    saved_report = ReportItem.model_construct(id=saved_report_id, title="test title", report_item_type_id=4)
+
+    def mock_get_object(_self, model, object_id):
+        assert model is ReportItem
+        assert object_id == saved_report_id
+        return saved_report
+
+    def mock_get_objects(_self, model, *args, **kwargs):
+        assert model is ReportTypes
+        return [ReportTypes.model_construct(id=4, title="CERT Report")]
+
+    monkeypatch.setattr("frontend.views.base_view.DataPersistenceLayer.get_object", mock_get_object)
+    monkeypatch.setattr("frontend.views.report_views.DataPersistenceLayer.get_objects", mock_get_objects)
+
+    with app.test_request_context("/report/0?layout=split"):
+        response_object_id, model_instance, response_message = ReportItemView.resolve_update_response(
+            0, {"id": saved_report_id, "message": "Report item created"}
+        )
+        context = ReportItemView.get_update_context(
+            0,
+            model_instance=model_instance,
+            response_message=response_message,
+            form_action_object_id=response_object_id,
+        )
+
+    assert context["report"].id == saved_report_id
+    assert context["report"].title == "test title"
+    assert context["submit_text"] == "Update Report"
+    assert "hx-put=" in context["form_action"]
+
+
+def test_report_create_post_renders_saved_report_when_core_response_only_contains_id(
+    app, authenticated_client_basic, monkeypatch, responses_mock
+):
+    saved_report_id = "8124ae6f-3c85-49b4-93a1-9f3dc6516310"
+    saved_report = ReportItem.model_construct(id=saved_report_id, title="test title", report_item_type_id=4)
+
+    responses_mock.post(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items",
+        json={"id": saved_report_id, "message": "Report item created"},
+        status=200,
+        content_type="application/json",
+    )
+
+    def mock_get_object(_self, model, object_id):
+        assert model is ReportItem
+        assert object_id == saved_report_id
+        return saved_report
+
+    def mock_get_objects(_self, model, *args, **kwargs):
+        assert model is ReportTypes
+        return [ReportTypes.model_construct(id=4, title="CERT Report")]
+
+    monkeypatch.setattr("frontend.views.base_view.DataPersistenceLayer.get_object", mock_get_object)
+    monkeypatch.setattr("frontend.views.report_views.DataPersistenceLayer.get_objects", mock_get_objects)
+
+    with app.test_request_context():
+        response = authenticated_client_basic.post(
+            url_for("analyze.report", report_id="0"),
+            data={"title": "test title", "report_item_type_id": "4", "layout": "split"},
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["HX-Push-Url"].endswith(f"/report/{saved_report_id}")
+    html = response.get_data(as_text=True)
+    assert f"ID: {saved_report_id}" in html
+    assert 'value="test title"' in html
+    assert "New Product from Report" in html

--- a/src/frontend/tests/unit/views/test_report_view.py
+++ b/src/frontend/tests/unit/views/test_report_view.py
@@ -52,18 +52,20 @@ def test_report_update_response_fetches_saved_report_when_core_response_only_con
         assert model is ReportTypes
         return [ReportTypes.model_construct(id=4, title="CERT Report")]
 
-    monkeypatch.setattr("frontend.views.base_view.DataPersistenceLayer.get_object", mock_get_object)
+    monkeypatch.setattr(
+        "frontend.views.base_view.BaseView.get_object_by_id", classmethod(lambda cls, object_id: mock_get_object(None, cls.model, object_id))
+    )
     monkeypatch.setattr("frontend.views.report_views.DataPersistenceLayer.get_objects", mock_get_objects)
 
     with app.test_request_context("/report/0?layout=split"):
-        response_object_id, model_instance, response_message = ReportItemView.resolve_update_response(
+        persisted_object_id, model_instance, response_message = ReportItemView.resolve_update_response(
             0, {"id": saved_report_id, "message": "Report item created"}
         )
         context = ReportItemView.get_update_context(
             0,
             model_instance=model_instance,
             response_message=response_message,
-            form_action_object_id=response_object_id,
+            form_action_object_id=persisted_object_id,
         )
 
     assert context["report"].id == saved_report_id
@@ -94,7 +96,9 @@ def test_report_create_post_renders_saved_report_when_core_response_only_contain
         assert model is ReportTypes
         return [ReportTypes.model_construct(id=4, title="CERT Report")]
 
-    monkeypatch.setattr("frontend.views.base_view.DataPersistenceLayer.get_object", mock_get_object)
+    monkeypatch.setattr(
+        "frontend.views.base_view.BaseView.get_object_by_id", classmethod(lambda cls, object_id: mock_get_object(None, cls.model, object_id))
+    )
     monkeypatch.setattr("frontend.views.report_views.DataPersistenceLayer.get_objects", mock_get_objects)
 
     with app.test_request_context():


### PR DESCRIPTION
Refactor post-submit update handling in BaseView by extracting response resolution from get_update_context() into a dedicated helper. This preserves the saved-object rehydration fix for partial core responses ({id, message}) while making get_update_context() a pure context builder.

## Summary by Sourcery

Refactor BaseView post-submit update handling to separate response resolution from context building while preserving correct model rehydration from partial core responses.

Enhancements:
- Introduce a resolve_update_response helper in BaseView to derive object ID, model instance, and message from core update responses, including reloading saved objects when only an ID is returned.
- Simplify and purify get_update_context to focus on building the template context from a resolved model instance and response metadata, and update its call sites in BaseView and ReportItemView accordingly.

Tests:
- Add unit tests for report views to verify that update handling fetches and renders the persisted ReportItem when the core service responds with only an ID and message, including correct form action and push URL behavior.