### PR TITLE
Improve OSINT source preview and story import handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# Taranis AI Copilot Instructions
+
+- Use the repository `AGENTS.md` guidance together with these repository instructions.
+- Prefer `uv` for Python dependency management. Run commands from the owning component directory under `src/core`, `src/frontend`, `src/models`, or `src/worker`.
+- Use Deno for frontend asset tasks in `src/frontend`.
+- Prefer the default local workflow in `./dev/start_dev.sh`. If you need manual setup, follow `dev/README.md`.
+- Run tests and linters from the component directory that owns the code you changed.
+- Respect the frontend and API boundary rules in `AGENTS.md`.
+- Do not introduce `pip`-based setup or ad hoc dependency installation.
+- Keep changes small, reversible, and documented when behavior or setup changes.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,64 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/copilot-instructions.md
+      - .github/workflows/copilot-setup-steps.yml
+      - dev/**
+      - src/core/**
+      - src/frontend/**
+      - src/models/**
+      - src/worker/**
+      - README.md
+  pull_request:
+    paths:
+      - .github/copilot-instructions.md
+      - .github/workflows/copilot-setup-steps.yml
+      - dev/**
+      - src/core/**
+      - src/frontend/**
+      - src/models/**
+      - src/worker/**
+      - README.md
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Sync core dependencies
+        working-directory: src/core
+        run: uv sync --all-extras --frozen
+
+      - name: Sync frontend dependencies
+        working-directory: src/frontend
+        run: uv sync --all-extras --frozen
+
+      - name: Sync models dependencies
+        working-directory: src/models
+        run: uv sync --dev --frozen
+
+      - name: Sync worker dependencies
+        working-directory: src/worker
+        run: uv sync --all-extras --frozen
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x

--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -780,7 +780,7 @@ class OSINTSourcePreview(MethodView):
         if result := task.Task.get(task_id):
             return result.to_dict(), 200
         preview_result, status = queue_manager.queue_manager.get_task(task_id)
-        if status != 404:
+        if status == 202:
             return preview_result, status
         return queue_manager.queue_manager.preview_osint_source(source_id)
 

--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -771,10 +771,17 @@ class OSINTSourceCollect(MethodView):
 class OSINTSourcePreview(MethodView):
     @auth_required("CONFIG_OSINT_SOURCE_UPDATE")
     def get(self, source_id: str):
+        return self.get_osint_source_preview_response(source_id)
+
+    @classmethod
+    def get_osint_source_preview_response(cls, source_id: str):
         task_id = f"source_preview_{source_id}"
 
         if result := task.Task.get(task_id):
             return result.to_dict(), 200
+        preview_result, status = queue_manager.queue_manager.get_task(task_id)
+        if status != 404:
+            return preview_result, status
         return queue_manager.queue_manager.preview_osint_source(source_id)
 
     @auth_required("CONFIG_OSINT_SOURCE_UPDATE")

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -631,7 +631,9 @@ class QueueManager:
             if job.is_failed:
                 response.update({"status": "FAILURE", "error": str(job.exc_info)})
                 return response, 500
-            response["status"] = "STARTED"
+            rq_status = job.get_status()
+            status_val = rq_status.value if hasattr(rq_status, "value") else str(rq_status)
+            response["status"] = status_val.upper()
             return response, 202
         except Exception as e:
             logger.error(f"Failed to get task {task_id}: {e}")

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -626,10 +626,10 @@ class QueueManager:
             job = Job.fetch(task_id, connection=self._redis)
             response: dict[str, Any] = {"id": task_id}
             if job.is_finished:
-                response.update({"status": "SUCCESS", "result": job.result})
+                response |= {"status": "SUCCESS", "result": job.result}
                 return response, 200
             if job.is_failed:
-                response.update({"status": "FAILURE", "error": str(job.exc_info)})
+                response |= {"status": "FAILURE", "error": str(job.exc_info)}
                 return response, 500
             rq_status = job.get_status()
             status_val = rq_status.value if hasattr(rq_status, "value") else str(rq_status)
@@ -637,7 +637,7 @@ class QueueManager:
             return response, 202
         except Exception as e:
             logger.error(f"Failed to get task {task_id}: {e}")
-            return {"error": "Task not found"}, 404
+            return {"id": task_id, "status": "NOT_FOUND", "error": "Task not found"}, 404
 
     def collect_osint_source(self, source_id: str, task_id: str):
         """Trigger OSINT source collection"""

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -649,7 +649,9 @@ class QueueManager:
 
     def preview_osint_source(self, source_id: str):
         """Preview OSINT source collection"""
-        if job := self.enqueue_task("collectors", "collector_preview", source_id, job_id=f"source_preview_{source_id}"):
+        task_id = f"source_preview_{source_id}"
+        self.purge_job_artifacts(exact_ids={task_id})
+        if job := self.enqueue_task("collectors", "collector_preview", source_id, job_id=task_id):
             logger.info(f"Preview for source {source_id} scheduled")
             return {"message": f"Preview for source {source_id} scheduled", "id": job.id, "status": "STARTED"}, 201
         return {"error": "Could not reach Redis"}, 500

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -588,11 +588,15 @@ class QueueManager:
 
         try:
             job = Job.fetch(task_id, connection=self._redis)
+            response: dict[str, Any] = {"id": task_id}
             if job.is_finished:
-                return {"result": job.result}, 200
+                response.update({"status": "SUCCESS", "result": job.result})
+                return response, 200
             if job.is_failed:
-                return {"error": str(job.exc_info)}, 500
-            return {"status": job.get_status()}, 202
+                response.update({"status": "FAILURE", "error": str(job.exc_info)})
+                return response, 500
+            response["status"] = "STARTED"
+            return response, 202
         except Exception as e:
             logger.error(f"Failed to get task {task_id}: {e}")
             return {"error": "Task not found"}, 404

--- a/src/core/core/model/news_item.py
+++ b/src/core/core/model/news_item.py
@@ -89,7 +89,8 @@ class NewsItem(BaseModel):
             with db.session.no_autoflush:
                 self.osint_source = osint_source
         else:
-            raise ValueError(f"OSINT Source {osint_source_id} not found")
+            logger.warning(f"OSINT Source {osint_source_id} not found. Setting osint_source_id to manual.")
+            self.osint_source_id = "manual"
         self.source = source
         self.link = link
         self.author = author
@@ -106,8 +107,12 @@ class NewsItem(BaseModel):
         return cls.from_payload(AssessNewsItem.from_input(data))
 
     @classmethod
+    def _sanitize_import_payload(cls, payload: AssessNewsItem) -> dict[str, Any]:
+        return payload.to_core_dict()
+
+    @classmethod
     def from_payload(cls, payload: AssessNewsItem) -> "NewsItem":
-        return cls(**payload.to_core_dict())
+        return cls(**cls._sanitize_import_payload(payload))
 
     @staticmethod
     def get_date_field(date_field: str | datetime | None) -> datetime:

--- a/src/core/core/model/osint_source.py
+++ b/src/core/core/model/osint_source.py
@@ -16,6 +16,7 @@ from sqlalchemy.sql import Select
 
 from core.config import Config
 from core.log import logger
+from core.managers import queue_manager
 from core.managers.db_manager import db
 from core.model.base_model import BaseModel
 from core.model.parameter_value import ParameterValue
@@ -365,6 +366,10 @@ class OSINTSource(BaseModel):
         if "parameters" in update_fields and validated_update.parameters is not None:
             osint_source.parameters = Worker.parse_parameters(osint_source.type, validated_update.parameters)
         db.session.commit()
+
+        if "parameters" in update_fields and validated_update.parameters is not None:
+            queue_manager.queue_manager.purge_job_artifacts(exact_ids={f"source_preview_{osint_source_id}"})
+
         osint_source.schedule_osint_source()
         return osint_source
 

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -592,7 +592,7 @@ class Story(BaseModel):
         data = {
             "title": news_item.title,
             "created": news_item.published,
-            "news_items": [NewsItem.from_payload(news_item)],
+            "news_items": [news_item.to_core_dict()],
             "last_change": "internal" if news_item.osint_source_id == "manual" else "external",
         }
 

--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -101,6 +101,10 @@ class Story(BaseModel):
             self.tags = NewsItemTag.load_multiple(tags)
         self.recompute_relevance(in_reports_count=0)
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Story":
+        return cls(**StoryPayload.model_validate(data).to_core_dict())
+
     def get_creation_date(self, created: datetime | str | None):
         payload = StoryPayload.model_validate({"created": created})
         return payload.created or self.utcnow()

--- a/src/core/core/service/task.py
+++ b/src/core/core/service/task.py
@@ -55,9 +55,10 @@ class TaskService:
             payload["worker_type"] = submission.worker_type
 
         result, _ = TaskModel.add_or_update(payload)
-        cls._invalidate_task_result_cache(submission)
-        if submission.status == "SUCCESS" and submission.result is not None:
-            cls._handle_success_result(submission)
+        if submission.status != "PREVIEW":
+            cls._invalidate_task_result_cache(submission)
+            if submission.status == "SUCCESS" and submission.result is not None:
+                cls._handle_success_result(submission)
         validated = TaskResponseModel.model_validate(result)
         return validated.model_dump(mode="json", exclude_none=False), 200
 

--- a/src/core/core/service/task.py
+++ b/src/core/core/service/task.py
@@ -55,10 +55,8 @@ class TaskService:
             payload["worker_type"] = submission.worker_type
 
         result, _ = TaskModel.add_or_update(payload)
-        if submission.status != "PREVIEW":
-            cls._invalidate_task_result_cache(submission)
-            if submission.status == "SUCCESS" and submission.result is not None:
-                cls._handle_success_result(submission)
+        if submission.status == "SUCCESS" and submission.result is not None:
+            cls._handle_success_result(submission)
         validated = TaskResponseModel.model_validate(result)
         return validated.model_dump(mode="json", exclude_none=False), 200
 

--- a/src/core/core/service/task.py
+++ b/src/core/core/service/task.py
@@ -55,8 +55,11 @@ class TaskService:
             payload["worker_type"] = submission.worker_type
 
         result, _ = TaskModel.add_or_update(payload)
+        task_kind = cls._resolve_task_kind(submission.id, submission.task)
         if submission.status == "SUCCESS" and submission.result is not None:
             cls._handle_success_result(submission)
+        elif task_kind == "collector_task":
+            cache_invalidation_module.cache_invalidation_service.invalidate_model("osint_source", submission.worker_id)
         validated = TaskResponseModel.model_validate(result)
         return validated.model_dump(mode="json", exclude_none=False), 200
 
@@ -93,6 +96,7 @@ class TaskService:
 
         if task_kind == "collector_task":
             logger.info(f"Collector task {submission.id} completed with result: {submission.result}")
+            cache_invalidation_module.cache_invalidation_service.invalidate_model("osint_source", submission.worker_id)
             return
 
         if task_kind == "connector_task":
@@ -138,11 +142,3 @@ class TaskService:
             NewsItemTagService.set_found_bot_tags(bot_result, change_by_bot=True)
 
         NewsItemTagService.set_worker_execution_attribute(worker_type=worker_type, worker_id=worker_id, found_tags=bot_result)
-
-    @classmethod
-    def _invalidate_task_result_cache(cls, submission: TaskSubmission) -> None:
-        if cls._resolve_task_kind(submission.id, submission.task) != "collector_task":
-            return
-        if not submission.worker_id:
-            return
-        cache_invalidation_module.cache_invalidation_service.invalidate_model("osint_source", submission.worker_id)

--- a/src/core/tests/application/admin_console/configuration/test_config_api.py
+++ b/src/core/tests/application/admin_console/configuration/test_config_api.py
@@ -160,10 +160,16 @@ class TestSourcesConfigApi(BaseTest):
         assert "Validation failed for model 'OSINTSource':" in response.json["error"]
         assert "Field 'rank': Input should be less than or equal to 5" in response.json["error"]
 
-    def test_modify_source(self, client, auth_header, cleanup_sources):
+    def test_modify_source(self, client, auth_header, cleanup_sources, monkeypatch):
+        purged_calls: list[tuple[set[str], list[str]]] = []
+        monkeypatch.setattr(
+            "core.managers.queue_manager.queue_manager.purge_job_artifacts",
+            lambda *, exact_ids=None, prefixes=None: purged_calls.append((exact_ids or set(), prefixes or [])) or (1, 1),
+        )
         source_data = {
             "description": "Sourcy McSourceFace",
             "rank": 5,
+            "parameters": {"FEED_URL": "https://example.com/updated.xml"},
         }
         source_id = cleanup_sources["id"]
         response = self.assert_put_ok(client, uri=f"osint-sources/{source_id}", json_data=source_data, auth_header=auth_header)
@@ -172,6 +178,8 @@ class TestSourcesConfigApi(BaseTest):
         source_response = self.assert_get_ok(client, uri=f"osint-sources/{source_id}", auth_header=auth_header)
         assert source_response.json["description"] == "Sourcy McSourceFace"
         assert source_response.json["rank"] == 5
+        assert source_response.json["parameters"]["FEED_URL"] == "https://example.com/updated.xml"
+        assert purged_calls == [({f"source_preview_{source_id}"}, [])]
 
     def test_modify_source_can_store_rank_zero(self, client, auth_header, cleanup_sources):
         source_id = cleanup_sources["id"]

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -221,6 +221,25 @@ def test_get_task_returns_live_rq_status(monkeypatch):
     assert response == {"id": "source_preview_123", "status": "STARTED"}
 
 
+def test_get_task_returns_queued_status(monkeypatch):
+    class FakeQueuedJob:
+        is_finished = False
+        is_failed = False
+
+        @staticmethod
+        def get_status():
+            return "queued"
+
+    monkeypatch.setattr(qm_module, "Job", type("Job", (), {"fetch": staticmethod(lambda task_id, connection=None: FakeQueuedJob())}))
+
+    qm = _make_queue_manager()
+
+    response, status = qm.get_task("source_preview_123")
+
+    assert status == 202
+    assert response == {"id": "source_preview_123", "status": "QUEUED"}
+
+
 def test_get_task_returns_success_payload(monkeypatch):
     class FakeJob:
         is_finished = True

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -202,6 +202,45 @@ def test_publish_schedule_cache_invalidation_notifies_scheduler_views(monkeypatc
     assert cache_invalidation_calls == ["schedule"]
 
 
+def test_get_task_returns_live_rq_status(monkeypatch):
+    class FakeJob:
+        is_finished = False
+        is_failed = False
+
+        @staticmethod
+        def get_status():
+            return "STARTED"
+
+    monkeypatch.setattr(qm_module, "Job", type("Job", (), {"fetch": staticmethod(lambda task_id, connection=None: FakeJob())}))
+
+    qm = _make_queue_manager()
+
+    response, status = qm.get_task("source_preview_123")
+
+    assert status == 202
+    assert response == {"id": "source_preview_123", "status": "STARTED"}
+
+
+def test_get_task_returns_success_payload(monkeypatch):
+    class FakeJob:
+        is_finished = True
+        is_failed = False
+        result = [{"title": "Preview item"}]
+
+        @staticmethod
+        def get_status():
+            return "FINISHED"
+
+    monkeypatch.setattr(qm_module, "Job", type("Job", (), {"fetch": staticmethod(lambda task_id, connection=None: FakeJob())}))
+
+    qm = _make_queue_manager()
+
+    response, status = qm.get_task("source_preview_123")
+
+    assert status == 200
+    assert response == {"id": "source_preview_123", "status": "SUCCESS", "result": [{"title": "Preview item"}]}
+
+
 def test_get_active_jobs_uses_registry(monkeypatch):
     class FakeJob:
         def __init__(self, job_id):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -241,6 +241,27 @@ def test_get_task_returns_success_payload(monkeypatch):
     assert response == {"id": "source_preview_123", "status": "SUCCESS", "result": [{"title": "Preview item"}]}
 
 
+def test_preview_osint_source_purges_existing_preview_artifacts(monkeypatch):
+    purged_calls: list[tuple[set[str], list[str]]] = []
+
+    class FakeJob:
+        id = "source_preview_123"
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(
+        qm,
+        "purge_job_artifacts",
+        lambda *, exact_ids=None, prefixes=None: purged_calls.append((exact_ids or set(), prefixes or [])) or (1, 1),
+    )
+    monkeypatch.setattr(qm, "enqueue_task", lambda *args, **kwargs: FakeJob())
+
+    response, status = qm.preview_osint_source("123")
+
+    assert purged_calls == [({"source_preview_123"}, [])]
+    assert status == 201
+    assert response == {"message": "Preview for source 123 scheduled", "id": "source_preview_123", "status": "STARTED"}
+
+
 def test_get_active_jobs_uses_registry(monkeypatch):
     class FakeJob:
         def __init__(self, job_id):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -221,25 +221,6 @@ def test_get_task_returns_live_rq_status(monkeypatch):
     assert response == {"id": "source_preview_123", "status": "STARTED"}
 
 
-def test_get_task_returns_queued_status(monkeypatch):
-    class FakeQueuedJob:
-        is_finished = False
-        is_failed = False
-
-        @staticmethod
-        def get_status():
-            return "queued"
-
-    monkeypatch.setattr(qm_module, "Job", type("Job", (), {"fetch": staticmethod(lambda task_id, connection=None: FakeQueuedJob())}))
-
-    qm = _make_queue_manager()
-
-    response, status = qm.get_task("source_preview_123")
-
-    assert status == 202
-    assert response == {"id": "source_preview_123", "status": "QUEUED"}
-
-
 def test_get_task_returns_success_payload(monkeypatch):
     class FakeJob:
         is_finished = True

--- a/src/core/tests/application/admin_console/operations/test_admin_api.py
+++ b/src/core/tests/application/admin_console/operations/test_admin_api.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import datetime, timedelta, timezone
 
 from tests.application.support.api_test_base import BaseTest
@@ -111,6 +112,40 @@ def test_export_stories_and_metadata(client, full_story, api_header, auth_header
     # Attribute we set should be present
     # attrs = {a.get("key"): a.get("value") for a in data[0].get("attributes", [])}
     # assert attrs.get("status") == "updated"
+
+
+def test_import_stories_ignores_export_only_fields(client, auth_header):
+    story_id = str(uuid.uuid4())
+    news_item_id = str(uuid.uuid4())
+    payload = [
+        {
+            "id": story_id,
+            "title": "Imported Story",
+            "relevance_override": 7,
+            "links": ["https://example.com/story/export-only"],
+            "news_items": [
+                {
+                    "id": news_item_id,
+                    "title": "Imported Story News 1",
+                    "content": "content",
+                    "source": "https://example.com/source",
+                    "link": "https://example.com/news",
+                    "osint_source_id": "manual",
+                    "links": ["https://example.com/news/export-only"],
+                }
+            ],
+        }
+    ]
+
+    response = client.post("/api/assess/import", json=payload, headers=auth_header)
+
+    assert response.status_code == 200
+    imported_story = response.get_json()["imported_stories"][0]
+    assert imported_story["id"] == story_id
+    assert imported_story["relevance_override"] == 7
+    assert imported_story["links"] == ["https://example.com/news"]
+    assert imported_story["news_items"][0]["id"] == news_item_id
+    assert imported_story["news_items"][0]["link"] == "https://example.com/news"
 
 
 def test_export_stories_rejects_invalid_datetime_filters(client, auth_header):

--- a/src/core/tests/test_revision_tracking.py
+++ b/src/core/tests/test_revision_tracking.py
@@ -146,6 +146,22 @@ def test_story_add_single_news_item_detects_duplicates_by_title_and_link():
 
 
 @pytest.mark.usefixtures("session")
+def test_story_from_dict_accepts_tag_mapping():
+    story_payload = {
+        "title": f"Story {uuid.uuid4()}",
+        "tags": {
+            "Example": {"name": "Example", "tag_type": "Organization"},
+        },
+        "news_items": [_news_item_payload(source="manual")],
+    }
+
+    story = Story.from_dict(story_payload)
+
+    assert len(story.tags) == 1
+    assert story.tags[0].name == "Example"
+
+
+@pytest.mark.usefixtures("session")
 def test_news_item_service_update_rejects_duplicate_title_and_link_hash(admin_user):
     first_story = _create_story()
     second_story = _create_story()

--- a/src/core/tests/unit/test_osint_source_preview.py
+++ b/src/core/tests/unit/test_osint_source_preview.py
@@ -1,62 +1,30 @@
-import core.managers.queue_manager as qm_module
-import core.model.task as task_module
 from core.api.config import OSINTSourcePreview
-
-
-class _FakeQueueManager:
-    def __init__(self, get_task_result, preview_result=None):
-        self._get_task_result = get_task_result
-        self._preview_result = preview_result
-
-    def get_task(self, task_id):
-        return self._get_task_result(task_id)
-
-    def preview_osint_source(self, source_id):
-        if self._preview_result is None:
-            raise AssertionError("preview should not be re-enqueued")
-        return self._preview_result
 
 
 def test_preview_response_uses_live_rq_status_without_requeue(monkeypatch):
     task_id = "source_preview_123"
 
-    fake_qm = _FakeQueueManager(get_task_result=lambda tid: ({"id": tid, "status": "STARTED"}, 202))
-    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
-    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
+    def _fail_requeue(*_args, **_kwargs):
+        raise AssertionError("preview should not be re-enqueued")
+
+    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
+    monkeypatch.setattr(
+        "core.api.config.queue_manager.queue_manager.get_task",
+        lambda preview_task_id: ({"id": preview_task_id, "status": "STARTED"}, 202),
+    )
+    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.preview_osint_source", _fail_requeue)
 
     response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
 
-    assert status == 202
-    assert response == {"id": task_id, "status": "STARTED"}
-
-
-def test_preview_response_falls_back_to_enqueue_when_job_missing(monkeypatch):
     task_id = "source_preview_123"
     scheduled_response = {"message": "Preview for source 123 scheduled", "id": task_id, "status": "STARTED"}
 
-    fake_qm = _FakeQueueManager(
-        get_task_result=lambda tid: ({"error": "Task not found"}, 404),
-        preview_result=(scheduled_response, 201),
+    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
+    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.get_task", lambda preview_task_id: ({"error": "Task not found"}, 404))
+    monkeypatch.setattr(
+        "core.api.config.queue_manager.queue_manager.preview_osint_source",
+        lambda source_id: (scheduled_response, 201),
     )
-    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
-    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
-
-    response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
-
-    assert status == 201
-    assert response == scheduled_response
-
-
-def test_preview_response_reenqueues_failed_job(monkeypatch):
-    task_id = "source_preview_123"
-    scheduled_response = {"message": "Preview for source 123 scheduled", "id": task_id, "status": "STARTED"}
-
-    fake_qm = _FakeQueueManager(
-        get_task_result=lambda tid: ({"id": tid, "status": "FAILURE", "error": "collector crashed"}, 500),
-        preview_result=(scheduled_response, 201),
-    )
-    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
-    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
 
     response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
 

--- a/src/core/tests/unit/test_osint_source_preview.py
+++ b/src/core/tests/unit/test_osint_source_preview.py
@@ -1,0 +1,37 @@
+from core.api.config import OSINTSourcePreview
+
+
+def test_preview_response_uses_live_rq_status_without_requeue(monkeypatch):
+    task_id = "source_preview_123"
+
+    def _fail_requeue(*_args, **_kwargs):
+        raise AssertionError("preview should not be re-enqueued")
+
+    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
+    monkeypatch.setattr(
+        "core.api.config.queue_manager.queue_manager.get_task",
+        lambda preview_task_id: ({"id": preview_task_id, "status": "STARTED"}, 202),
+    )
+    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.preview_osint_source", _fail_requeue)
+
+    response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
+
+    assert status == 202
+    assert response == {"id": task_id, "status": "STARTED"}
+
+
+def test_preview_response_falls_back_to_enqueue_when_job_missing(monkeypatch):
+    task_id = "source_preview_123"
+    scheduled_response = {"message": "Preview for source 123 scheduled", "id": task_id, "status": "STARTED"}
+
+    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
+    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.get_task", lambda preview_task_id: ({"error": "Task not found"}, 404))
+    monkeypatch.setattr(
+        "core.api.config.queue_manager.queue_manager.preview_osint_source",
+        lambda source_id: (scheduled_response, 201),
+    )
+
+    response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
+
+    assert status == 201
+    assert response == scheduled_response

--- a/src/core/tests/unit/test_osint_source_preview.py
+++ b/src/core/tests/unit/test_osint_source_preview.py
@@ -1,18 +1,28 @@
+import core.managers.queue_manager as qm_module
+import core.model.task as task_module
 from core.api.config import OSINTSourcePreview
+
+
+class _FakeQueueManager:
+    def __init__(self, get_task_result, preview_result=None):
+        self._get_task_result = get_task_result
+        self._preview_result = preview_result
+
+    def get_task(self, task_id):
+        return self._get_task_result(task_id)
+
+    def preview_osint_source(self, source_id):
+        if self._preview_result is None:
+            raise AssertionError("preview should not be re-enqueued")
+        return self._preview_result
 
 
 def test_preview_response_uses_live_rq_status_without_requeue(monkeypatch):
     task_id = "source_preview_123"
 
-    def _fail_requeue(*_args, **_kwargs):
-        raise AssertionError("preview should not be re-enqueued")
-
-    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
-    monkeypatch.setattr(
-        "core.api.config.queue_manager.queue_manager.get_task",
-        lambda preview_task_id: ({"id": preview_task_id, "status": "STARTED"}, 202),
-    )
-    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.preview_osint_source", _fail_requeue)
+    fake_qm = _FakeQueueManager(get_task_result=lambda tid: ({"id": tid, "status": "STARTED"}, 202))
+    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
+    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
 
     response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
 
@@ -24,12 +34,29 @@ def test_preview_response_falls_back_to_enqueue_when_job_missing(monkeypatch):
     task_id = "source_preview_123"
     scheduled_response = {"message": "Preview for source 123 scheduled", "id": task_id, "status": "STARTED"}
 
-    monkeypatch.setattr("core.api.config.task.Task.get", lambda preview_task_id: None)
-    monkeypatch.setattr("core.api.config.queue_manager.queue_manager.get_task", lambda preview_task_id: ({"error": "Task not found"}, 404))
-    monkeypatch.setattr(
-        "core.api.config.queue_manager.queue_manager.preview_osint_source",
-        lambda source_id: (scheduled_response, 201),
+    fake_qm = _FakeQueueManager(
+        get_task_result=lambda tid: ({"error": "Task not found"}, 404),
+        preview_result=(scheduled_response, 201),
     )
+    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
+    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
+
+    response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
+
+    assert status == 201
+    assert response == scheduled_response
+
+
+def test_preview_response_reenqueues_failed_job(monkeypatch):
+    task_id = "source_preview_123"
+    scheduled_response = {"message": "Preview for source 123 scheduled", "id": task_id, "status": "STARTED"}
+
+    fake_qm = _FakeQueueManager(
+        get_task_result=lambda tid: ({"id": tid, "status": "FAILURE", "error": "collector crashed"}, 500),
+        preview_result=(scheduled_response, 201),
+    )
+    monkeypatch.setattr(task_module.Task, "get", staticmethod(lambda preview_task_id: None))
+    monkeypatch.setattr(qm_module, "queue_manager", fake_qm, raising=False)
 
     response, status = OSINTSourcePreview.get_osint_source_preview_response("123")
 

--- a/src/frontend/deno.lock
+++ b/src/frontend/deno.lock
@@ -12,6 +12,7 @@
     "npm:@codemirror/state@^6.6.0": "6.6.0",
     "npm:@codemirror/view@*": "6.41.1",
     "npm:@codemirror/view@^6.41.1": "6.41.1",
+    "npm:@tailwindcss/cli@*": "4.2.4",
     "npm:@tailwindcss/cli@^4.2.4": "4.2.4",
     "npm:alpinejs@*": "3.15.11",
     "npm:alpinejs@^3.15.11": "3.15.11",

--- a/src/frontend/frontend/core_api.py
+++ b/src/frontend/frontend/core_api.py
@@ -152,6 +152,13 @@ class CoreApi:
             logger.error(f"Retrieving OSINT source preview failed: {e}")
             return None
 
+    def retrigger_osint_source_preview(self, osint_source_id: str):
+        try:
+            return self.api_post(f"/config/osint-sources/{osint_source_id}/preview")
+        except Exception as e:
+            logger.error(f"Retriggering OSINT source preview failed: {e}")
+            return None
+
     def collect_osint_source(self, osint_source_id: str):
         try:
             return self.api_post(f"/config/osint-sources/{osint_source_id}/collect")

--- a/src/frontend/frontend/router/admin.py
+++ b/src/frontend/frontend/router/admin.py
@@ -186,6 +186,12 @@ def init(app: Flask):
         methods=["GET"],
         endpoint="osint_source_preview",
     )
+    admin_bp.add_url_rule(
+        "/source_preview/<string:osint_source_id>",
+        view_func=SourceView.retrigger_osint_source_preview_view,
+        methods=["POST"],
+        endpoint="osint_source_preview_retrigger",
+    )
     admin_bp.add_url_rule("/source_collect", view_func=OSINTSourceCollect.as_view("collect_osint_source_all"))
     admin_bp.add_url_rule("/source_collect/<string:osint_source_id>", view_func=OSINTSourceCollect.as_view("collect_osint_source"))
 

--- a/src/frontend/frontend/templates/assess/story_edit_content.html
+++ b/src/frontend/frontend/templates/assess/story_edit_content.html
@@ -54,12 +54,12 @@
       </div>
       <div class="flex flex-col gap-3">
         <div class="flex justify-end gap-2">
-          <button type="submit" form="story-edit-form" class="btn btn-sm btn-primary w-42" {% if has_rt_id %}disabled{% endif %}>
-            {{ heroicon_mini("check") }}
+          <button type="submit" form="story-edit-form" class="btn btn-sm btn-primary w-38" {% if has_rt_id %}disabled{% endif %}>
+            {{ heroicon_mini("check", class="h-4 w-4") }}
             <span>Save changes</span>
           </button>
-          <a href="{{ url_for('assess.story', story_id=story.id) }}" class="btn btn-sm btn-outline w-42">
-            {{ heroicon_mini("arrow-uturn-left") }}
+          <a href="{{ url_for('assess.story', story_id=story.id) }}" class="btn btn-sm btn-outline w-38">
+            {{ heroicon_mini("arrow-uturn-left", class="h-4 w-4") }}
             <span>Return to story</span>
           </a>
           <button type="button"
@@ -77,8 +77,8 @@
             </span>
           </button>
           <div class="join">
-            <a href="?layout=advanced" class="btn btn-sm join-item btn-outline {% if layout == 'advanced' %}btn-info btn-active{% endif %}">Advanced view</a>
-            <a href="?layout=simple" class="btn btn-sm join-item btn-outline {% if layout == 'simple' %}btn-info btn-active{% endif %}">Simple view</a>
+            <a href="?layout=advanced" class="btn btn-sm join-item btn-outline {% if layout == 'advanced' %}btn-info btn-active{% endif %}">Advanced</a>
+            <a href="?layout=simple" class="btn btn-sm join-item btn-outline {% if layout == 'simple' %}btn-info btn-active{% endif %}">Simple</a>
           </div>
           {{ story_edit_actions(story) }}
         </div>

--- a/src/frontend/frontend/templates/osint_source/osint_source_form.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_form.html
@@ -8,7 +8,18 @@
   <div class="join gap-4 mb-5 w-3/4 ml-[10%]">
     <h1 class="text-3xl font-bold">{{ submit_text }}</h1>
     {% if not read_only %}
-      {% include "osint_source/state_button.html" %}
+      <div class="flex flex-wrap items-center gap-2">
+        {% include "osint_source/state_button.html" %}
+        {% if osint_id != "0" %}
+          <a class="btn btn-outline" href="{{ url_for('admin.osint_source_preview', osint_source_id=osint_id) }}">Preview</a>
+          <button type="button"
+                  class="btn btn-secondary"
+                  hx-post="{{ url_for('admin.collect_osint_source', osint_source_id=osint_id) }}"
+                  hx-target="#notification-bar"
+                  hx-target-error="#notification-bar"
+                  hx-swap="outerHTML">Collect</button>
+        {% endif %}
+      </div>
     {% endif %}
   </div>
 

--- a/src/frontend/frontend/templates/osint_source/osint_source_preview.html
+++ b/src/frontend/frontend/templates/osint_source/osint_source_preview.html
@@ -8,7 +8,7 @@
         <div class="alert alert-info my-5 mx-5" hx-get hx-trigger="every 20s" hx-target="#source_preview" hx-swap="outerHTML" hx-select="#source_preview">
           <p>OSINT source preview is currently being processed. Please wait...</p>
         </div>
-      {% elif task_result.status == 'SUCCESS' %}
+      {% elif task_result.status in ['SUCCESS', 'PREVIEW'] %}
         {% if task_result.result %}
           {% for story in task_result.result %}{{ preview_story_card(story) }}{% endfor %}
         {% else %}
@@ -16,6 +16,19 @@
             <p>No results found for this OSINT source.</p>
           </div>
         {% endif %}
+      {% elif task_result.status == 'FAILURE' %}
+        <div class="alert alert-error my-5 mx-5 flex flex-col gap-4">
+          <div>
+            <p class="font-semibold">OSINT source preview failed.</p>
+            {% if task_result.result %}<p class="mt-2 text-sm opacity-80">{{ task_result.result }}</p>{% endif %}
+          </div>
+          <button type="button"
+                  class="btn btn-primary btn-sm"
+                  hx-post="{{ url_for('admin.osint_source_preview_retrigger', osint_source_id=osint_source_id) }}"
+                  hx-target="#source_preview"
+                  hx-swap="outerHTML"
+                  hx-select="#source_preview">Retrigger preview</button>
+        </div>
       {% endif %}
     {% else %}
       <div class="alert alert-info my-5 mx-5">

--- a/src/frontend/frontend/views/admin_views/source_views.py
+++ b/src/frontend/frontend/views/admin_views/source_views.py
@@ -259,8 +259,15 @@ class SourceView(AdminMixin, BaseView):
         task_result = None
         if response := CoreApi().get_osint_source_preview(osint_source_id):
             task_result = Task(**response)
-        logger.debug(f"Task result for OSINT source preview: {task_result}")
-        return render_template("osint_source/osint_source_preview.html", task_result=task_result)
+        return render_template("osint_source/osint_source_preview.html", task_result=task_result, osint_source_id=osint_source_id)
+
+    @classmethod
+    @admin_required()
+    def retrigger_osint_source_preview_view(cls, osint_source_id: str):
+        task_result = None
+        if response := CoreApi().retrigger_osint_source_preview(osint_source_id):
+            task_result = Task(**response)
+        return render_template("osint_source/osint_source_preview.html", task_result=task_result, osint_source_id=osint_source_id)
 
     @classmethod
     def delete_view(cls, object_id: str | int) -> tuple[str, int]:

--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -9,6 +9,12 @@ from flask.typing import ResponseReturnValue
 from flask_jwt_extended import current_user
 from markupsafe import Markup, escape
 from models.assess import (
+    NEWS_ITEM_IMPORT_FIELDS as _NEWS_ITEM_IMPORT_FIELDS,
+)
+from models.assess import (
+    STORY_IMPORT_FIELDS as _STORY_IMPORT_FIELDS,
+)
+from models.assess import (
     AssessSource,
     BulkAction,
     Connector,
@@ -32,44 +38,6 @@ from frontend.utils.form_data_parser import parse_formdata
 from frontend.utils.router_helpers import parse_paging_data
 from frontend.utils.validation_helpers import format_pydantic_errors
 from frontend.views.base_view import BaseView
-
-
-_STORY_IMPORT_FIELDS = {
-    "id",
-    "title",
-    "description",
-    "created",
-    "likes",
-    "dislikes",
-    "relevance",
-    "read",
-    "important",
-    "summary",
-    "comments",
-    "revision",
-    "attributes",
-    "tags",
-    "news_items",
-    "last_change",
-}
-
-_NEWS_ITEM_IMPORT_FIELDS = {
-    "id",
-    "title",
-    "source",
-    "content",
-    "osint_source_id",
-    "review",
-    "author",
-    "link",
-    "language",
-    "hash",
-    "attributes",
-    "last_change",
-    "published",
-    "collected",
-    "story_id",
-}
 
 
 def _sanitize_news_item_import_payload(news_item_data: dict[str, Any], story_id: str | None = None) -> dict[str, Any]:
@@ -573,7 +541,7 @@ class StoryView(BaseView):
             notification = {"message": format_pydantic_errors(e, NewsItem), "error": True}
             notification_html = render_template("notification/index.html", notification=notification)
             return make_response(notification_html, 400)
-        core_response = CoreApi().api_post("/assess/news-items", json_data=news_item.model_dump(mode="json"))
+        core_response = CoreApi().api_post("/assess/news-items", json_data=news_item.to_core_dict())
         return cls.news_item_edit_view(core_response)
 
     @classmethod
@@ -588,7 +556,7 @@ class StoryView(BaseView):
             notification_html = render_template("notification/index.html", notification=notification)
             return make_response(notification_html, 400)
 
-        core_response = CoreApi().api_put(f"/assess/news-items/{news_item_id}", json_data=news_item.model_dump(mode="json"))
+        core_response = CoreApi().api_put(f"/assess/news-items/{news_item_id}", json_data=news_item.to_core_dict())
 
         return cls._handle_news_item_response(
             core_response,
@@ -778,7 +746,7 @@ class StoryView(BaseView):
         try:
             paging_data = PagingData(query_params={"story_ids": story_ids}, limit=len(story_ids))
             stories = DataPersistenceLayer().get_objects(Story, paging_data)
-            export_data = [story.model_dump(mode="json") for story in stories.items]
+            export_data = [story.to_core_dict() for story in stories.items]
 
             response_data = json.dumps({"total_count": len(export_data), "items": export_data}, indent=2)
             flask_response = make_response(response_data, 200)

--- a/src/frontend/tests/playwright/test_e2e_user.py
+++ b/src/frontend/tests/playwright/test_e2e_user.py
@@ -299,7 +299,7 @@ class TestEndToEndUser(BaseE2ETest):
             page.get_by_test_id("tag-name-input").nth(1).fill("tag 2")
             page.get_by_test_id("tag-value-input").nth(1).fill("value2")
             page.get_by_role("button", name="Save changes").click()
-            page.get_by_role("link", name="Advanced view").click()
+            page.get_by_role("link", name="Advanced").click()
             expect(page.get_by_role("complementary")).to_contain_text("Story status")
             page.get_by_text("Cybersecurity · Not Classified").click()
             expect(page.get_by_role("complementary")).to_contain_text("Cybersecurity · Not Classified")

--- a/src/frontend/tests/unit/views/test_story_view.py
+++ b/src/frontend/tests/unit/views/test_story_view.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from flask import url_for
 from lxml import html
+from models.assess import Story
 from werkzeug.exceptions import Forbidden
 
 from frontend.config import Config
@@ -87,6 +88,9 @@ def test_normalize_story_import_payload_strips_export_only_fields():
             {
                 "id": "story-1",
                 "title": "Imported Story",
+                "relevance_override": 7,
+                "user_vote": "like",
+                "in_reports_count": 3,
                 "updated": "2026-03-12T10:00:00",
                 "links": ["https://example.com/story"],
                 "news_items": [
@@ -109,6 +113,7 @@ def test_normalize_story_import_payload_strips_export_only_fields():
         {
             "id": "story-1",
             "title": "Imported Story",
+            "relevance_override": 7,
             "news_items": [
                 {
                     "id": "news-1",
@@ -121,6 +126,36 @@ def test_normalize_story_import_payload_strips_export_only_fields():
             ],
         }
     ]
+
+
+def test_story_to_core_dict_strips_export_only_fields():
+    story = Story.model_validate(
+        {
+            "id": "story-1",
+            "title": "Imported Story",
+            "updated": "2026-03-12T10:00:00",
+            "links": ["https://example.com/story"],
+            "relevance_override": 7,
+            "user_vote": "like",
+            "in_reports_count": 3,
+            "news_items": [
+                {
+                    "osint_source_id": "manual",
+                    "title": "Imported Story News 1",
+                    "links": ["https://example.com/news"],
+                }
+            ],
+        }
+    )
+
+    normalized = story.to_core_dict()
+
+    assert normalized["relevance_override"] == 7
+    assert "updated" not in normalized
+    assert "links" not in normalized
+    assert "user_vote" not in normalized
+    assert "in_reports_count" not in normalized
+    assert "links" not in normalized["news_items"][0]
 
 
 def test_manual_news_item_form_routes_htmx_errors_to_notification_bar(authenticated_client):

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import pytest
 from flask import render_template
 from models.admin import OSINTSource
+from models.task import Task
 from models.types import COLLECTOR_TYPES
 
 from frontend.cache import add_user_to_cache, cache
@@ -288,6 +289,23 @@ class TestSourceView:
         mock_store.assert_called_once()
         processed_data = mock_store.call_args.args[0]
         assert processed_data["icon"] == ""
+
+    def test_osint_source_preview_shows_failure_and_retrigger_action(self, app):
+        task_result = Task(id="source_preview_42", status="FAILURE", result="Connection refused")
+
+        with app.test_request_context("/"):
+            rendered = render_template(
+                "osint_source/osint_source_preview.html",
+                task_result=task_result,
+                osint_source_id="42",
+            )
+
+        assert "OSINT source preview failed." in rendered
+        assert "Connection refused" in rendered
+        assert "hx-post=" in rendered
+        assert "source_preview/42" in rendered
+        assert 'hx-target="#source_preview"' in rendered
+        assert "Retrigger preview" in rendered
 
 
 def test_report_item_type_submitted_form_model_uses_shared_normalization(app):

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -368,6 +368,10 @@ def test_osint_source_form_shows_current_icon_and_delete_option(app):
     assert 'value="3"' in html
     assert 'aria-label="3 stars"' in html
     assert "News items in database: 7" in html
+    assert "source_preview/source-with-icon" in html
+    assert "source_collect/source-with-icon" in html
+    assert "Preview" in html
+    assert "Collect" in html
     assert "checked" in html
 
 
@@ -405,6 +409,8 @@ def test_osint_source_form_disables_rank_for_manual_source(app):
     assert "News items in database: 13" in html
     assert html.count('name="rank"') == 7
     assert html.count("disabled") >= 6
+    assert "source_preview/manual" not in html
+    assert "source_collect/manual" not in html
 
 
 def test_admin_dashboard_renders_health_card(authenticated_client, auth_user, responses_mock, monkeypatch):

--- a/src/models/models/assess.py
+++ b/src/models/models/assess.py
@@ -13,6 +13,54 @@ from models.base import TaranisBaseModel
 from models.types import CONNECTOR_TYPES
 
 
+NEWS_ITEM_IMPORT_FIELDS = frozenset(
+    {
+        "id",
+        "title",
+        "source",
+        "content",
+        "osint_source_id",
+        "review",
+        "author",
+        "link",
+        "language",
+        "hash",
+        "attributes",
+        "last_change",
+        "published",
+        "collected",
+        "story_id",
+    }
+)
+
+STORY_IMPORT_FIELDS = frozenset(
+    {
+        "id",
+        "title",
+        "description",
+        "created",
+        "likes",
+        "dislikes",
+        "relevance",
+        "relevance_override",
+        "read",
+        "important",
+        "summary",
+        "comments",
+        "revision",
+        "attributes",
+        "tags",
+        "news_items",
+        "last_change",
+    }
+)
+
+
+def _dump_core_fields(model: TaranisBaseModel, allowed_fields: frozenset[str]) -> dict[str, Any]:
+    data = model.model_dump(mode="json")
+    return {key: value for key, value in data.items() if key in allowed_fields}
+
+
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
@@ -132,7 +180,7 @@ class NewsItem(TaranisBaseModel):
         return cls.normalize_datetime(date, default_to_now=True) or _utcnow()
 
     def to_core_dict(self) -> dict[str, Any]:
-        return self.model_dump(exclude={"updated"})
+        return _dump_core_fields(self, NEWS_ITEM_IMPORT_FIELDS)
 
 
 class StoryTag(TaranisBaseModel):
@@ -176,6 +224,12 @@ class Story(TaranisBaseModel):
     @classmethod
     def sanitize_story_dates(cls, date: str | None | datetime) -> datetime | None:
         return cls.normalize_datetime(date)
+
+    def to_core_dict(self) -> dict[str, Any]:
+        data = _dump_core_fields(self, STORY_IMPORT_FIELDS)
+        if self.news_items is not None:
+            data["news_items"] = [news_item.to_core_dict() if isinstance(news_item, NewsItem) else news_item for news_item in self.news_items]
+        return data
 
 
 class AssessSource(TaranisBaseModel):

--- a/src/models/models/assess.py
+++ b/src/models/models/assess.py
@@ -3,7 +3,7 @@ import hashlib
 import re
 from datetime import datetime, timezone
 from typing import Annotated, Any, Literal, Self
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 import language_tags
 from bs4 import BeautifulSoup
@@ -164,7 +164,7 @@ class NewsItem(TaranisBaseModel):
     @field_validator("link", mode="before")
     @classmethod
     def sanitize_url(cls, url: str, info: ValidationInfo) -> str:
-        return quote(url or "", safe="/:@?&=+$,;")
+        return quote(unquote(url or ""), safe="/:@?&=+$,;")
 
     @model_validator(mode="after")
     def ensure_hash(self) -> Self:
@@ -219,6 +219,18 @@ class Story(TaranisBaseModel):
     @classmethod
     def normalize_datetime(cls, date: str | datetime | None) -> datetime | None:
         return _normalize_datetime(date)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_story_payload(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        normalized = dict(value)
+        tags = normalized.get("tags")
+        if isinstance(tags, dict):
+            normalized["tags"] = list(tags.values())
+        return normalized
 
     @field_validator("created", "updated", mode="before")
     @classmethod

--- a/src/worker/uv.lock
+++ b/src/worker/uv.lock
@@ -206,16 +206,16 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.4.4"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -611,16 +611,16 @@ wheels = [
 
 [[package]]
 name = "ioc-finder"
-version = "8.0.1"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "ioc-fanger" },
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/32/2d433ce4025868a17c29420b37c89e7da594289645f8eb87210c1e2cba9e/ioc_finder-8.0.1.tar.gz", hash = "sha256:8345ef4f3057a6b5bdda642d3e475f8ea252a943b6201481aea2e0811fc4db79", size = 161540, upload-time = "2026-03-16T12:29:27.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/36/2457f23ace34034cc10ce80c2e2b000fcda08f0de29186b878b0559a88c2/ioc_finder-9.1.1.tar.gz", hash = "sha256:f030ea7ec3e8b4d467f9aea32a38049e302857dc6f4b0b50e7cd88e3ca5babc9", size = 171724, upload-time = "2026-04-29T10:19:18.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/41/270f3e99c997c580d655cca39197d865d239d70028b3fcd1dce045380933/ioc_finder-8.0.1-py3-none-any.whl", hash = "sha256:9979e82e677e593637300bf4456ffdb4db94caa1be1525d4a73619f7ae6c29d8", size = 37746, upload-time = "2026-03-16T12:29:26.12Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c2/d0b283508155090c94af7a15184604e4d5407a5ed74b2d9d389aa2d58c5f/ioc_finder-9.1.1-py3-none-any.whl", hash = "sha256:fe3a7fa57ae00c30daf1131f7ba4a7225f6b6ab34496416e5c4749f6b7b2eb25", size = 42521, upload-time = "2026-04-29T10:19:16.843Z" },
 ]
 
 [[package]]
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "misp-stix"
-version = "2026.4.17"
+version = "2026.4.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cybox" },
@@ -851,9 +851,9 @@ dependencies = [
     { name = "stix-edh" },
     { name = "stix2" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/73/759312f474ba8f2f8a79f9b9ef5a3db041f72d30b277fa1d66de70dde44d/misp_stix-2026.4.17.tar.gz", hash = "sha256:02b1e72ab43770055069c99f4312d46f3f04ea225105a558296901f5f86b6122", size = 34796750, upload-time = "2026-04-22T07:37:42.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ad/3a01d96b97a91a3e5b875b02b2992178c2fdabe82f433bfb4144d3e2bec7/misp_stix-2026.4.28.tar.gz", hash = "sha256:38d665f67e19ffd425b9ba5445ec5a727a0fd97e4207f436a854ffc10b515631", size = 34797339, upload-time = "2026-04-28T13:29:16.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/8e/76b98fbaed762377de96c4ba540d36d52fc4295922ab496b288cb2cdd88f/misp_stix-2026.4.17-py3-none-any.whl", hash = "sha256:2e51404a6cc72c41307cf20db79655613f6dfdd783594b6b40a0d92f18a60b5d", size = 62454587, upload-time = "2026-04-22T07:37:52.814Z" },
+    { url = "https://files.pythonhosted.org/packages/12/14/2da7867bfa94806e12ea78fc70e0e24bd42aa8971f036ef2e07991f57dcd/misp_stix-2026.4.28-py3-none-any.whl", hash = "sha256:cd28c5b4aa7fcaa0e7efbf24ab1fbd5c28a645c3595bcf1d56f733bcd2d2e900", size = 62455329, upload-time = "2026-04-28T13:29:26.782Z" },
 ]
 
 [[package]]
@@ -979,21 +979,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.58.0"
+version = "1.59.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
 ]
 
 [[package]]
@@ -1159,16 +1159,16 @@ wheels = [
 
 [[package]]
 name = "pymisp"
-version = "2.5.33.2"
+version = "2.5.34.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/c2/aa90cbe90ca687cc33b373fb9a25947102670b5db19387ac26d91a03315d/pymisp-2.5.33.2.tar.gz", hash = "sha256:ed45ae12bb58082c5dd7e8bd35bee3a3b7eee54196d3451fa4bb7051535dbd2e", size = 2071292, upload-time = "2026-04-21T14:22:57.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/59/d195ab701e1cb2c1fb44cdfb83fbef46cf40b3a206ce313666817cfb9098/pymisp-2.5.34.1.tar.gz", hash = "sha256:dc7d44213064b5fc920dfeb8feae21165eb6543288e3809f2a5c6dd86ec37fa5", size = 2071382, upload-time = "2026-04-28T12:07:12.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/5b/c0f11c3058be558f21b723dfc711c75f77d62f1f0d3f5bc56b08ecd6a5c2/pymisp-2.5.33.2-py3-none-any.whl", hash = "sha256:6aa2a96061c74131b008bee6d1ccb795f82831ae97250d1ce7c38f280b5b2cba", size = 544169, upload-time = "2026-04-21T14:22:55.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/64/3746646025f649d233f769e14ee4ab1da41d6dd36812c78b1f969393e1ff/pymisp-2.5.34.1-py3-none-any.whl", hash = "sha256:7ed974fa4ab325ddcb8eee4be7d6723636f849516c54a055da1ea1638cbfcd37", size = 544181, upload-time = "2026-04-28T12:07:10.535Z" },
 ]
 
 [[package]]
@@ -1223,11 +1223,11 @@ wheels = [
 
 [[package]]
 name = "pyparsing"
-version = "3.1.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/fe/65c989f70bd630b589adfbbcd6ed238af22319e90f059946c26b4835e44b/pyparsing-3.1.1.tar.gz", hash = "sha256:ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db", size = 884814, upload-time = "2023-07-30T15:07:02.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/92/8486ede85fcc088f1b3dba4ce92dd29d126fd96b0008ea213167940a2475/pyparsing-3.1.1-py3-none-any.whl", hash = "sha256:32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb", size = 103139, upload-time = "2023-07-30T15:06:59.829Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]

--- a/src/worker/worker/collectors/base_collector.py
+++ b/src/worker/worker/collectors/base_collector.py
@@ -69,7 +69,7 @@ class BaseCollector:
     def preview(self, news_items: list[NewsItem], source: dict) -> list[dict]:
         news_items = self.process_news_items(news_items, source)
         logger.info(f"Previewing {len(news_items)} news items")
-        return [n.model_dump() for n in news_items]
+        return [n.model_dump(mode="json") for n in news_items]
 
     def process_news_items(self, news_items: list[NewsItem], source: dict) -> list[NewsItem]:
         if word_lists := source.get("word_lists"):

--- a/src/worker/worker/collectors/collector_tasks.py
+++ b/src/worker/worker/collectors/collector_tasks.py
@@ -178,6 +178,7 @@ def collector_preview(osint_source_id: str):
         Preview data from the collector
     """
     job = get_current_job()
+    core_api = CoreApi()
     collector = Collector()
     source = collector.get_source(osint_source_id)
     collector_impl = collector.get_collector(source)
@@ -193,10 +194,13 @@ def collector_preview(osint_source_id: str):
             preview_result = collector_impl.preview_collector(source)
         except NoChangeError as e:
             logger.info(f"No changes detected: {e}")
-            return f"'{source.get('name')}': {str(e)}"
+            preview_result = []
         except Exception as e:
             logger.error(f"Collector preview task failed: {task_description}")
             raise RuntimeError(e) from e
+
+    if job:
+        core_api.save_task_result(job.id, "", preview_result, "SUCCESS")
 
     return preview_result
 

--- a/src/worker/worker/collectors/collector_tasks.py
+++ b/src/worker/worker/collectors/collector_tasks.py
@@ -187,7 +187,6 @@ def collector_preview(osint_source_id: str):
         Preview data from the collector
     """
     job = get_current_job()
-    core_api = CoreApi()
     collector = Collector()
     source = collector.get_source(osint_source_id)
     collector_impl = collector.get_collector(source)
@@ -206,10 +205,12 @@ def collector_preview(osint_source_id: str):
             preview_result = []
         except Exception as e:
             logger.error(f"Collector preview task failed: {task_description}")
+            if job:
+                collector.core_api.save_task_result(job.id, "collector_preview", str(e), "FAILURE")
             raise RuntimeError(e) from e
 
     if job:
-        core_api.save_task_result(job.id, "", preview_result, "SUCCESS")
+        collector.core_api.save_task_result(job.id, "collector_preview", preview_result, "PREVIEW")
 
     return preview_result
 

--- a/src/worker/worker/collectors/playwright_manager.py
+++ b/src/worker/worker/collectors/playwright_manager.py
@@ -7,9 +7,20 @@ from worker.log import logger
 
 class PlaywrightManager:
     def __init__(self, proxies: dict | None = None, headers: dict | None = None) -> None:
+        self.proxies = proxies
+        self.headers = headers
+        self.playwright = None
+        self.browser = None
+        self.context = None
+        self.page = None
+
+    def _ensure_started(self) -> None:
+        if self.playwright and self.browser and self.context and self.page:
+            return
+
         self.playwright = sync_playwright().start()
-        self.browser = self.playwright.chromium.launch(proxy=self.parse_proxies(proxies))  # type: ignore
-        self.context = self.setup_context(headers)
+        self.browser = self.playwright.chromium.launch(proxy=self.parse_proxies(self.proxies))  # type: ignore
+        self.context = self.setup_context(self.headers)
         self.page = self.context.new_page()
 
     def setup_context(self, headers: dict | None = None) -> BrowserContext:
@@ -48,6 +59,7 @@ class PlaywrightManager:
 
     def fetch_content_with_js(self, url: str, xpath: str = "") -> str:
         logger.debug(f"Getting web content with JS for {url} - {xpath=}")
+        self._ensure_started()
         try:
             self.page.goto(url)
 

--- a/src/worker/worker/tests/collectors/test_collector_tasks.py
+++ b/src/worker/worker/tests/collectors/test_collector_tasks.py
@@ -91,3 +91,53 @@ def test_fetch_single_news_item_accepts_simple_web_source_payload(current_job, m
         "type": "simple_web_collector",
         "parameters": {"WEB_URL": "https://example.com/story", "XPATH": "//article"},
     }
+
+
+def test_collector_preview_persists_with_preview_status(current_job, requests_mock, monkeypatch):
+    source = {"id": "source-1", "name": "Source 1", "type": "rss_collector", "parameters": {}}
+    preview_items = [{"title": "Item 1"}, {"title": "Item 2"}]
+
+    class FakeCollector:
+        name = "RSS Collector"
+
+        def preview_collector(self, source_data):
+            return preview_items
+
+    monkeypatch.setattr(collector_tasks.Collector, "get_source", lambda self, osint_source_id: source)
+    monkeypatch.setattr(collector_tasks.Collector, "get_collector", lambda self, source_data: FakeCollector())
+    requests_mock.post(f"{Config.TARANIS_CORE_URL}/tasks", json={"message": "saved"})
+
+    result = collector_tasks.collector_preview("source-1")
+
+    assert result == preview_items
+
+    post_calls = [req for req in requests_mock.request_history if req.method == "POST" and req.url.endswith("/tasks")]
+    assert len(post_calls) == 1
+    assert post_calls[0].json() == {
+        "id": "test-job-123",
+        "task": "collector_preview",
+        "result": preview_items,
+        "status": "PREVIEW",
+    }
+
+
+def test_collector_preview_persists_failure_on_exception(current_job, requests_mock, monkeypatch):
+    source = {"id": "source-1", "name": "Source 1", "type": "rss_collector", "parameters": {}}
+
+    class FakeCollector:
+        name = "RSS Collector"
+
+        def preview_collector(self, source_data):
+            raise ValueError("connection refused")
+
+    monkeypatch.setattr(collector_tasks.Collector, "get_source", lambda self, osint_source_id: source)
+    monkeypatch.setattr(collector_tasks.Collector, "get_collector", lambda self, source_data: FakeCollector())
+    requests_mock.post(f"{Config.TARANIS_CORE_URL}/tasks", json={"message": "saved"})
+
+    with pytest.raises(RuntimeError):
+        collector_tasks.collector_preview("source-1")
+
+    post_calls = [req for req in requests_mock.request_history if req.method == "POST" and req.url.endswith("/tasks")]
+    assert len(post_calls) == 1
+    assert post_calls[0].json()["status"] == "FAILURE"
+    assert post_calls[0].json()["task"] == "collector_preview"


### PR DESCRIPTION
- Move import field sets to models layer and expose them as `NEWS_ITEM_IMPORT_FIELDS` / `STORY_IMPORT_FIELDS` constants
- Add `Story.to_core_dict()` and update `NewsItem.to_core_dict()` to use the canonical field allowlists
- Use `to_core_dict()` when posting news items to core API
- Add `Story.from_dict()` factory method
- Fallback unknown `osint_source_id` to `"manual"` instead of raising
- Include `relevance_override` in story import fields
- Persist preview results via `save_task_result` in the worker so subsequent GET requests can retrieve them without re-enqueueing
- Check live RQ job status in `OSINTSourcePreview` before falling back to enqueue
- Normalise `get_task` response shape to include `id` and string status
- Shorten button labels and fix icon sizing in story edit template

## Summary by Sourcery

Standardize story/news item import/export payloads and improve OSINT source preview task handling and UX.

New Features:
- Expose canonical import field allowlists for news items and stories via shared model-layer constants.
- Add conversion helpers for stories and news items to generate core API payloads and construct story instances from dictionaries.

Bug Fixes:
- Handle unknown OSINT source IDs by defaulting to a manual source instead of raising an error.
- Ensure story and news item imports ignore export-only fields while preserving relevant overrides.
- Return consistent task metadata, including ID and status, when querying background jobs for OSINT source previews.

Enhancements:
- Reuse the canonical core payload helpers when posting and exporting stories and news items to the core API.
- Leverage saved worker task results and live RQ job status for OSINT source previews before re-enqueuing new preview jobs.
- Normalize queue manager task responses to a consistent shape with explicit SUCCESS/FAILURE/STARTED statuses.
- Tweak story edit UI button labels, widths, and icon sizing for a cleaner layout and clearer view toggle labels.

Tests:
- Add unit tests covering task status responses, OSINT source preview behavior, and import/export field filtering for stories and news items.