### PR TITLE
Change story title if "primary" news item was removed

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -1059,6 +1059,7 @@ class Story(BaseModel):
         try:
             processed_stories = set()
             new_stories_ids = []
+            removed_titles_by_story: dict[Story, set[str]] = {}
             for item in newsitem_ids:
                 news_item = NewsItem.get(item)
                 if not news_item or not user:
@@ -1068,10 +1069,13 @@ class Story(BaseModel):
                 story = Story.get(news_item.story_id)
                 if not story:
                     continue
+                removed_titles_by_story.setdefault(story, set()).add(news_item.title)
                 story.news_items.remove(news_item)
                 processed_stories.add(story)
                 new_stories_ids.append(cls.create_from_item(news_item, commit=False))
             for story in processed_stories:
+                if story.news_items and story.title in removed_titles_by_story.get(story, set()):
+                    story.title = story.news_items[0].title
                 story.update_status()
             for story in processed_stories:
                 story.record_revision(user, note="ungroup_news_items")

--- a/src/core/tests/application/user_workspace/assessment/test_story_relevance.py
+++ b/src/core/tests/application/user_workspace/assessment/test_story_relevance.py
@@ -197,3 +197,32 @@ def test_partial_ungroup_keeps_original_feedback_and_new_story_starts_clean(
     assert new_story.important is False
     assert new_story.relevance_override == 0
     assert new_story.relevance_feedback == 0
+
+
+@pytest.mark.usefixtures("app")
+def test_partial_ungroup_replaces_story_title_when_primary_news_item_is_removed(
+    session, story_relevance_news_item_payload_factory, story_relevance_story_payload_factory
+):
+    source = create_osint_source(rank=4)
+    primary_title = "Primary grouped item"
+    fallback_title = "Secondary grouped item"
+    story = create_story(
+        story_relevance_story_payload_factory(
+            [
+                story_relevance_news_item_payload_factory(source.id, title=primary_title),
+                story_relevance_news_item_payload_factory(source.id, title=fallback_title),
+            ],
+            title=primary_title,
+        )
+    )
+
+    admin = User.find_by_name("admin")
+    assert admin is not None
+
+    primary_news_item_id = story.news_items[0].id
+    response, status = Story.ungroup_news_items_from_story([primary_news_item_id], user=admin)
+    assert status == 200, response
+
+    updated_story = Story.get(story.id)
+    assert updated_story is not None
+    assert updated_story.title == fallback_title


### PR DESCRIPTION
Currently, if you remove (ungroup) the primary news item from a story, the story title remains unchanged:

<img width="1553" height="194" alt="image" src="https://github.com/user-attachments/assets/ce62655f-8507-4ba4-9cdb-a9e44a35d3fd" />

<img width="1783" height="209" alt="image" src="https://github.com/user-attachments/assets/78b00b32-104a-4c60-88a2-ca3fa67a9eaf" />

<img width="1538" height="220" alt="image" src="https://github.com/user-attachments/assets/d1edb201-8ae0-4fd2-bf69-000db93c43c5" />

Explicitly set the title of the remaining story to the new "primary" news item (news item with index 0)

## Summary by Sourcery

Ensure story titles are updated when the primary news item is ungrouped from a story.

Bug Fixes:
- Update remaining story title to the first remaining news item when the previous primary news item is removed from the story.

Tests:
- Add regression test verifying that ungrouping the primary news item updates the story title to the next news item.