### PR TITLE
Fix Story/NewsItem delete render issues

### DIFF
--- a/src/core/core/service/news_item.py
+++ b/src/core/core/service/news_item.py
@@ -46,8 +46,11 @@ class NewsItemService:
             return {"error": f"Story with: {story_id} assigned to a report"}, 400
 
         story.last_change = "internal"
+        deleted_title = news_item.title
         story.news_items.remove(news_item)
         news_item.delete_item()
+        if story.news_items and story.title == deleted_title:
+            story.title = story.news_items[0].title
         story.update_status()
         story.record_revision(user, note="delete_news_item")
         db.session.commit()

--- a/src/core/tests/test_revision_tracking.py
+++ b/src/core/tests/test_revision_tracking.py
@@ -199,6 +199,34 @@ def test_news_item_attribute_update_creates_story_revisions():
 
 
 @pytest.mark.usefixtures("session")
+def test_delete_primary_news_item_promotes_story_title_to_remaining_item(admin_user):
+    first_item = _news_item_payload(source="manual")
+    first_item["title"] = "Primary title"
+    second_item = _news_item_payload(source="manual")
+    second_item["title"] = "Fallback title"
+
+    result, status = Story.add(
+        {
+            "title": "Primary title",
+            "description": "initial desc",
+            "news_items": [first_item, second_item],
+        }
+    )
+    assert status == 200
+
+    story = Story.get(result["story_id"])
+    assert story is not None
+
+    response, status = NewsItemService.delete(story.news_items[0].id, admin_user)
+
+    assert status == 200
+    assert response["story_id"] == story.id
+
+    db.session.refresh(story)
+    assert story.title == "Fallback title"
+
+
+@pytest.mark.usefixtures("session")
 def test_story_creation_creates_created_revision():
     story = _create_story()
 

--- a/src/frontend/frontend/templates/assess/news_item_card.html
+++ b/src/frontend/frontend/templates/assess/news_item_card.html
@@ -28,6 +28,8 @@
                   data-testid="delete-newsitem-{{ news_item.id }}"
                   hx-delete="{{ url_for('assess.delete_news_item', news_item_id=news_item.id) }}"
                   hx-confirm="Are you sure you want to delete this news item?"
+                  hx-select="#story-{{ news_item.story_id }}"
+                  hx-swap="outerHTML"
                   hx-target="#story-{{ news_item.story_id }}">{{ heroicon_mini("trash") }}</button>
         </div>
 

--- a/src/frontend/frontend/templates/assess/story_actions.html
+++ b/src/frontend/frontend/templates/assess/story_actions.html
@@ -1,4 +1,4 @@
-{% macro story_actions(story, size='xs') %}
+{% macro story_actions(story, size='xs', delete_target=None, delete_swap=None) %}
   {% set story_id = story.id %}
   {% set toggled_read = (not (story.read | default(false))) | tojson %}
   {% set toggled_important = (not (story.important | default(false))) | tojson %}
@@ -66,6 +66,8 @@
   <button type="button"
           class="btn btn-outline btn-{{ size }} w-full join-item justify-start gap-2"
           hx-delete="{{ url_for('assess.story_delete', story_id=story_id) }}"
+          {% if delete_target %}hx-target="{{ delete_target }}"{% endif %}
+          {% if delete_swap %}hx-swap="{{ delete_swap }}"{% endif %}
           hx-confirm="Are you sure you want to delete this story? This will delete all associated news items as well."
           data-testid="delete-story">
     {{ heroicon_mini("trash") }}
@@ -73,12 +75,12 @@
   </button>
 {% endmacro %}
 
-{% macro story_card_actions(story, compact_view=False) %}
+{% macro story_card_actions(story, compact_view=False, detail_view=False) %}
   {% set story_id = story.id %}
   {% set card_id = 'story-' ~ story_id %}
   {% set news_count = story.news_items | length %}
   {% set news_count_text = '[' ~ news_count ~ ']' if news_count > 1 else '' %}
-  {% set actions = story_actions(story) %}
+  {% set actions = story_actions(story, delete_target='#assess', delete_swap='outerHTML') if not detail_view else story_actions(story) %}
 
   <button type="button"
           class="btn btn-outline btn-xs w-full join-item justify-start gap-2"

--- a/src/frontend/frontend/templates/assess/story_card.html
+++ b/src/frontend/frontend/templates/assess/story_card.html
@@ -147,7 +147,7 @@
 
         <!-- actions column -->
         <section class="flex flex-col items-end gap-1 text-xs lg:flex-shrink-0 lg:ml-auto" @click.stop>
-          {{ story_card_actions(story, compact_view=compact_view) }}
+          {{ story_card_actions(story, compact_view=compact_view, detail_view=detail_view) }}
         </section>
       </div>
 

--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -655,6 +655,18 @@ class StoryView(BaseView):
         except Exception:
             return cls.render_response_notification({"error": "Failed to delete news item"})
 
+        payload = core_response.json()
+        story_id = payload.get("story_id") or payload.get("story_ids", [""])[0]
+
+        current_url_path = cls._get_current_url_path()
+        if story_id and current_url_path in {
+            url_for("assess.story", story_id=story_id),
+            url_for("assess.story_edit", story_id=story_id),
+        }:
+            if CoreApi().api_get(f"/assess/stories/{story_id}") is None:
+                cls.add_flash_notification(core_response)
+                return cls.redirect_htmx(url_for("assess.assess"))
+
         return cls._handle_news_item_response(
             core_response,
             content_builder=cls._get_action_response_content,
@@ -670,6 +682,10 @@ class StoryView(BaseView):
             raise
         except Exception:
             return cls.render_response_notification({"error": "Failed to delete story"})
+
+        if cls._get_current_url_path() == url_for("assess.assess"):
+            notification_html = cls.get_notification_from_response(core_response)
+            return cls.rerender_list(notification=notification_html)
 
         cls.add_flash_notification(core_response)
         return cls.redirect_htmx(url_for("assess.assess"))


### PR DESCRIPTION
Fixes these issues:

- Deleting a story in Assess view causes a "jump" (referenced in #722), see gifs below

Before:

https://github.com/user-attachments/assets/72943030-db63-4644-887f-e48adadd37a0

After:


https://github.com/user-attachments/assets/3c7d706e-8119-4248-8dfe-0de90e51fa1a


This is fixed by setting hx-swap to outerHTML in the delete button in story_actions.html
This is conditional, since when in "Edit" or "Detail" View, we want a plain redirect to /assess

- Deleting the last news item of a story shows 404
<img width="1883" height="458" alt="image" src="https://github.com/user-attachments/assets/747b4d62-9158-40e1-99c3-a8dd828ec3a6" />

Now the user is redirected to /assess (change in story_views.py -> delete_news_item)

- Deleting a News item causes "nested" cards in "Open" View
<img width="1884" height="781" alt="image" src="https://github.com/user-attachments/assets/cbcdbf35-bd6b-48a6-91aa-3e89f36e88d8" />

Fixed by introducing hx-swap=outerHTML into news_item_card.html

- Deleting the primary news item now changes title of story
fixed in news_item.py

## Summary by Sourcery

Resolve various rendering and navigation issues when deleting stories and news items in the Assess views.

Bug Fixes:
- Prevent layout jump when deleting a story from the Assess list by updating the list container in place.
- Avoid 404 errors after deleting the last news item of a story by redirecting back to the Assess page when the story no longer exists.
- Fix nested story card rendering after deleting a news item in the Open view by swapping the full story card HTML instead of a nested fragment.
- Ensure deleting a primary news item promotes the story title to a remaining news item instead of leaving an outdated title.

Tests:
- Add a regression test to verify that deleting the primary news item updates the story title to the remaining news item.