### PR TITLE
Update authlib dependency to version 1.7.1 and adjust version specifications

### DIFF
--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "granian",
     "psycopg",
     "requests",
-    "authlib>=1.7.1,<1.8",
+    "authlib",
     "setuptools",
     "taranis-models>=1.3.3.dev5",
     "sentry-sdk[flask]",

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "granian",
     "psycopg",
     "requests",
-    "authlib",
+    "authlib>=1.7.1,<1.8",
     "setuptools",
     "taranis-models>=1.3.3.dev5",
     "sentry-sdk[flask]",

--- a/src/core/uv.lock
+++ b/src/core/uv.lock
@@ -41,15 +41,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.0"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f2/e05664d5275ce811fd4e9df0a2b3f0086ee19a8a80358d95499fa82fd50c/authlib-1.7.1.tar.gz", hash = "sha256:8c09b0f9d080c823e594b52316af70f79a1fa4eed64d0363a076233c04ef063a", size = 175884, upload-time = "2026-05-04T08:11:25.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/730650ee5e5b598b7bfdc291b784bc2f6fe02a5671695485403365101088/authlib-1.7.1-py2.py3-none-any.whl", hash = "sha256:8470f4aa6b5590ac41bd81d6e6ee12448ce36a0da0af19bbed69fb53fb4e8ad9", size = 258826, upload-time = "2026-05-04T08:11:23.208Z" },
 ]
 
 [[package]]
@@ -1438,7 +1438,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "authlib" },
+    { name = "authlib", specifier = ">=1.7.1,<1.8" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "click" },
     { name = "croniter", specifier = ">=6.0.0" },


### PR DESCRIPTION
Fix

```
../code/taranis-ai/src/core/.venv/lib/python3.13/site-packages/authlib/_joserfc_helpers.py:8: AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead.
It will be compatible before version 2.0.0.
  from authlib.jose import ECKey
```

## Summary by Sourcery

Update Python core project dependency constraints for authlib to use a specific supported version range.

Bug Fixes:
- Constrain authlib dependency to version 1.7.1 to avoid deprecation issues with the jose module.

Enhancements:
- Tighten version specifier for authlib to a bounded range (>=1.7.1,<1.8) in pyproject configuration.

Build:
- Adjust dependency version constraints in pyproject.toml for authlib package.