### PR TITLE
Refactor revision diff rendering

### DIFF
--- a/src/core/tests/test_revision_diff.py
+++ b/src/core/tests/test_revision_diff.py
@@ -1,0 +1,162 @@
+from models.revision_diff import build_report_revision_diff_payload, build_story_revision_diff_payload
+
+
+def test_build_story_revision_diff_payload_formats_inline_and_collection_changes():
+    payload = build_story_revision_diff_payload(
+        "story-1",
+        "Story title",
+        {
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {
+                "title": "Kill Chain im Krieg verkurzt",
+                "description": "First draft",
+                "summary": "Summary A",
+                "comments": "Comment A",
+                "tags": [{"name": "old-tag"}],
+                "news_items": [{"id": "news-1", "title": "Old news"}],
+                "attributes": [{"key": "TLP", "value": "clear"}],
+            },
+        },
+        {
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {
+                "title": "Kill Chain im Krieg deutlich verkurzt",
+                "description": "First draft",
+                "summary": "Summary B",
+                "comments": "Comment A",
+                "tags": [{"name": "new-tag"}],
+                "news_items": [{"id": "news-2", "title": "New news"}],
+                "attributes": [{"key": "TLP", "value": "amber"}],
+            },
+        },
+    )
+
+    assert payload.resource.model_dump(mode="json") == {"id": "story-1", "title": "Story title"}
+    assert payload.from_revision.revision == 1
+    assert payload.to_revision.created_by == "bob"
+
+    title_change = next(change for change in payload.changes if change.field == "Title")
+    assert any(segment.highlighted for segment in title_change.new_segments)
+    assert title_change.old_segments
+    assert any(change.field == "Tags Added" and change.new_value == "new-tag" for change in payload.changes)
+    assert any(change.field == "News Items Added" and change.new_value == "New news" for change in payload.changes)
+    assert any(change.field == "TLP" and change.old_value == "clear" and change.new_value == "amber" for change in payload.changes)
+
+
+def test_build_story_revision_diff_payload_returns_no_changes_for_identical_data():
+    payload = build_story_revision_diff_payload(
+        "story-1",
+        "Story title",
+        {
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {"title": "Story title", "tags": [], "news_items": [], "attributes": []},
+        },
+        {
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {"title": "Story title", "tags": [], "news_items": [], "attributes": []},
+        },
+    )
+
+    assert payload.changes == []
+
+
+def test_build_report_revision_diff_payload_formats_story_and_group_changes():
+    payload = build_report_revision_diff_payload(
+        "report-1",
+        "Report title",
+        {
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {
+                "title": "Report Draft",
+                "completed": False,
+                "stories": [{"id": "story-1", "title": "Story One"}],
+                "grouped_attributes": [
+                    {
+                        "title": "Summary",
+                        "attributes": [{"title": "Threat", "type": "STORY", "value": "story-1"}],
+                    }
+                ],
+            },
+        },
+        {
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {
+                "title": "Report Final",
+                "completed": True,
+                "stories": [{"id": "story-2", "title": "Story Two"}],
+                "grouped_attributes": [
+                    {
+                        "title": "Summary",
+                        "attributes": [{"title": "Threat", "type": "STORY", "value": "story-2"}],
+                    }
+                ],
+            },
+        },
+    )
+
+    assert payload.resource.model_dump(mode="json") == {"id": "report-1", "title": "Report title"}
+    assert any(change.field == "Title" for change in payload.changes)
+    assert any(change.field == "Completed" and change.new_value is True for change in payload.changes)
+    assert any(
+        change.field == "Threat" and change.group == "Summary" and change.old_value == "Story One" and change.new_value == "Story Two"
+        for change in payload.changes
+    )
+    assert any(change.field == "Stories Added" and change.new_value == "Story Two" for change in payload.changes)
+    assert any(change.field == "Stories Removed" and change.old_value == "Story One" for change in payload.changes)
+
+
+def test_build_report_revision_diff_payload_returns_no_changes_for_identical_data():
+    payload = build_report_revision_diff_payload(
+        "report-1",
+        "Report title",
+        {
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {"title": "Report title", "completed": False, "stories": [], "grouped_attributes": []},
+        },
+        {
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {"title": "Report title", "completed": False, "stories": [], "grouped_attributes": []},
+        },
+    )
+
+    assert payload.changes == []

--- a/src/frontend/frontend/templates/analyze/report_diff.html
+++ b/src/frontend/frontend/templates/analyze/report_diff.html
@@ -1,16 +1,17 @@
 {% extends "base.html" %}
+{% from "shared/revision_diff_macros.html" import render_change_row %}
 
 {% block content %}
   <div class="p-4 card bg-base-100 shadow">
     <div class="card-body gap-4">
       <div class="flex items-center gap-3">
-        <a href="{{ url_for('analyze.report_versions', report_id=report.id) }}" class="btn btn-sm btn-ghost">
+        <a href="{{ url_for('analyze.report_versions', report_id=report_id) }}" class="btn btn-sm btn-ghost">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
           </svg>
           Back to Versions
         </a>
-        <h2 class="card-title flex-1">Changes: {{ report.title }}</h2>
+        <h2 class="card-title flex-1">Changes: {{ diff.resource.title or report_id }}</h2>
       </div>
 
       <div class="flex gap-4 p-4 bg-base-200 rounded-lg">
@@ -49,29 +50,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for change in diff.changes %}
-                <tr>
-                  <td class="font-semibold">{{ change.field }}</td>
-                  <td>
-                    {% if change.old_value is not none %}
-                      <div class="bg-error/10 text-error p-2 rounded">
-                        <span class="line-through">{{ change.old_value }}</span>
-                      </div>
-                    {% else %}
-                      <span class="text-base-content/40">-</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if change.new_value is not none %}
-                      <div class="bg-success/10 text-success p-2 rounded">
-                        <span>{{ change.new_value }}</span>
-                      </div>
-                    {% else %}
-                      <span class="text-base-content/40">-</span>
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
+              {% for change in diff.changes %}{{ render_change_row(change) }}{% endfor %}
             </tbody>
           </table>
         </div>

--- a/src/frontend/frontend/templates/assess/story_diff.html
+++ b/src/frontend/frontend/templates/assess/story_diff.html
@@ -1,16 +1,17 @@
 {% extends "base.html" %}
+{% from "shared/revision_diff_macros.html" import render_change_row %}
 
 {% block content %}
   <div class="p-4 card bg-base-100 shadow">
     <div class="card-body gap-4">
       <div class="flex items-center gap-3">
-        <a href="{{ url_for('assess.story_versions', story_id=story.id) }}" class="btn btn-sm btn-ghost">
+        <a href="{{ url_for('assess.story_versions', story_id=story_id) }}" class="btn btn-sm btn-ghost">
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
           </svg>
           Back to Versions
         </a>
-        <h2 class="card-title flex-1">Changes: {{ story.title }}</h2>
+        <h2 class="card-title flex-1">Changes: {{ diff.resource.title or story_id }}</h2>
         <h3 class="text-warning">Warning: Experimental Feature</h3>
       </div>
 
@@ -50,37 +51,7 @@
               </tr>
             </thead>
             <tbody>
-              {% for change in diff.changes %}
-                <tr>
-                  <td class="font-semibold">{{ change.field }}</td>
-                  <td>
-                    {% if change.old_value is not none %}
-                      {% if change.inline_diff %}
-                        <div class="bg-error/10 p-2 rounded whitespace-pre-wrap break-words">{{ change.old_value_diff }}</div>
-                      {% else %}
-                        <div class="bg-error/10 text-error p-2 rounded">
-                          <span class="line-through">{{ change.old_value }}</span>
-                        </div>
-                      {% endif %}
-                    {% else %}
-                      <span class="text-base-content/40">-</span>
-                    {% endif %}
-                  </td>
-                  <td>
-                    {% if change.new_value is not none %}
-                      {% if change.inline_diff %}
-                        <div class="bg-success/10 p-2 rounded whitespace-pre-wrap break-words">{{ change.new_value_diff }}</div>
-                      {% else %}
-                        <div class="bg-success/10 text-success p-2 rounded">
-                          <span>{{ change.new_value }}</span>
-                        </div>
-                      {% endif %}
-                    {% else %}
-                      <span class="text-base-content/40">-</span>
-                    {% endif %}
-                  </td>
-                </tr>
-              {% endfor %}
+              {% for change in diff.changes %}{{ render_change_row(change) }}{% endfor %}
             </tbody>
           </table>
         </div>

--- a/src/frontend/frontend/templates/shared/revision_diff_macros.html
+++ b/src/frontend/frontend/templates/shared/revision_diff_macros.html
@@ -1,0 +1,38 @@
+{% macro render_diff_value(change, side) -%}
+  {% set segments = change.old_segments if side == 'old' else change.new_segments %}
+  {% set value = change.old_value if side == 'old' else change.new_value %}
+  {% set container_class = 'bg-error/10 text-error' if side == 'old' else 'bg-success/10 text-success' %}
+  {% set highlight_class = 'line-through bg-error/20 text-error' if side == 'old' else 'bg-success/20 text-success' %}
+  {% if segments %}
+    <div class="{{ container_class }} p-2 rounded whitespace-pre-wrap break-words">
+      {% for segment in segments %}
+        {% if segment.highlighted %}
+          <span class="{{ highlight_class }} rounded px-0.5">{{ segment.text }}</span>
+        {% else %}
+          {{ segment.text }}
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% elif value is not none %}
+    <div class="{{ container_class }} p-2 rounded">
+      {% if side == 'old' %}
+        <span class="line-through">{{ value }}</span>
+      {% else %}
+        <span>{{ value }}</span>
+      {% endif %}
+    </div>
+  {% else %}
+    <span class="text-base-content/40">-</span>
+  {% endif %}
+{%- endmacro %}
+
+{% macro render_change_row(change) -%}
+  <tr>
+    <td class="font-semibold">
+      {{ change.field }}
+      {% if change.group %}<div class="text-xs text-base-content/60">{{ change.group }}</div>{% endif %}
+    </td>
+    <td>{{ render_diff_value(change, 'old') }}</td>
+    <td>{{ render_diff_value(change, 'new') }}</td>
+  </tr>
+{%- endmacro %}

--- a/src/frontend/frontend/views/report_views.py
+++ b/src/frontend/frontend/views/report_views.py
@@ -4,6 +4,7 @@ from flask import Response, abort, make_response, render_template, request, url_
 from flask.typing import ResponseReturnValue
 from models.assess import Story
 from models.report import ReportItem, ReportItemAttributeGroup, ReportTypes
+from models.revision_diff import build_report_revision_diff_payload
 from pydantic import ValidationError
 from werkzeug.exceptions import HTTPException
 
@@ -224,139 +225,20 @@ class ReportItemView(BaseView):
         if not report_id:
             return abort(400, description="No report ID provided.")
 
-        # Get report data
-        report = DataPersistenceLayer().get_object(ReportItem, report_id)
-        if not report:
-            return abort(404, description="Report not found.")
-
-        # Get revision data from core API
-        from_data = CoreApi().api_get(f"/analyze/report-items/{report_id}/revisions/{from_rev}")
-        to_data = CoreApi().api_get(f"/analyze/report-items/{report_id}/revisions/{to_rev}")
-
-        if not from_data or not to_data:
+        core_api = CoreApi()
+        from_revision = core_api.api_get(f"/analyze/report-items/{report_id}/revisions/{from_rev}")
+        to_revision = core_api.api_get(f"/analyze/report-items/{report_id}/revisions/{to_rev}")
+        if not from_revision or not to_revision:
             return abort(404, description="Revision not found.")
 
-        # Calculate diff
-        from_revision_data = from_data.get("data", {})
-        to_revision_data = to_data.get("data", {})
-
-        # Prepare diff data
-        diff_data = {
-            "from_revision": from_data,
-            "to_revision": to_data,
-            "changes": _calculate_diff(from_revision_data, to_revision_data),
-        }
+        report_title = to_revision.get("data", {}).get("title") or from_revision.get("data", {}).get("title")
+        diff = build_report_revision_diff_payload(report_id, report_title, from_revision, to_revision)
 
         context = {
-            "report": report,
-            "diff": diff_data,
+            "diff": diff,
             "from_rev": from_rev,
             "to_rev": to_rev,
+            "report_id": report_id,
         }
 
         return render_template("analyze/report_diff.html", **context), 200
-
-
-# TODO: Enhance diff calculation to handle more complex attribute types and nested structures, and to provide better formatting of changes in the UI.
-def _calculate_diff(from_data: dict, to_data: dict) -> list[dict[str, Any]]:
-    """Calculate differences between two report data dictionaries"""
-    changes = []
-
-    # Compare title
-    if from_data.get("title") != to_data.get("title"):
-        changes.append(
-            {
-                "field": "Title",
-                "old_value": from_data.get("title"),
-                "new_value": to_data.get("title"),
-            }
-        )
-
-    # Compare completed status
-    if from_data.get("completed") != to_data.get("completed"):
-        changes.append(
-            {
-                "field": "Completed",
-                "old_value": from_data.get("completed"),
-                "new_value": to_data.get("completed"),
-            }
-        )
-
-    # Build story ID to title mapping for resolving STORY attribute values
-    story_map = {}
-    for story in from_data.get("stories", []) + to_data.get("stories", []):
-        if story.get("id"):
-            story_map[story["id"]] = story.get("title", story["id"])
-
-    # Compare attributes
-    from_attrs = from_data.get("grouped_attributes", [])
-    to_attrs = to_data.get("grouped_attributes", [])
-
-    # Create flattened attribute dictionaries for comparison, with type info
-    from_attr_dict = {}
-    from_attr_types = {}
-    for group in from_attrs:
-        for attr in group.get("attributes", []):
-            key = f"{group.get('title', '')}.{attr.get('title', '')}"
-            from_attr_dict[key] = attr.get("value")
-            from_attr_types[key] = attr.get("type")
-
-    to_attr_dict = {}
-    to_attr_types = {}
-    for group in to_attrs:
-        for attr in group.get("attributes", []):
-            key = f"{group.get('title', '')}.{attr.get('title', '')}"
-            to_attr_dict[key] = attr.get("value")
-            to_attr_types[key] = attr.get("type")
-
-    # Find changed and new attributes
-    for key in sorted(set(from_attr_dict.keys()) | set(to_attr_dict.keys())):
-        from_val = from_attr_dict.get(key)
-        to_val = to_attr_dict.get(key)
-
-        if from_val != to_val:
-            # Resolve STORY attribute values to titles
-            attr_type = from_attr_types.get(key) or to_attr_types.get(key)
-            if attr_type == "STORY":
-                from_display = story_map.get(from_val, from_val) if from_val else None
-                to_display = story_map.get(to_val, to_val) if to_val else None
-            else:
-                from_display = from_val
-                to_display = to_val
-
-            changes.append(
-                {
-                    "field": key,
-                    "old_value": from_display,
-                    "new_value": to_display,
-                }
-            )
-
-    # Compare stories
-    from_story_ids = {s.get("id") for s in from_data.get("stories", [])}
-    to_story_ids = {s.get("id") for s in to_data.get("stories", [])}
-
-    added_stories = to_story_ids - from_story_ids
-    removed_stories = from_story_ids - to_story_ids
-
-    if added_stories:
-        story_titles = [s.get("title", s.get("id")) for s in to_data.get("stories", []) if s.get("id") in added_stories]
-        changes.append(
-            {
-                "field": "Stories Added",
-                "old_value": None,
-                "new_value": ", ".join(story_titles),
-            }
-        )
-
-    if removed_stories:
-        story_titles = [s.get("title", s.get("id")) for s in from_data.get("stories", []) if s.get("id") in removed_stories]
-        changes.append(
-            {
-                "field": "Stories Removed",
-                "old_value": ", ".join(story_titles),
-                "new_value": None,
-            }
-        )
-
-    return changes

--- a/src/frontend/frontend/views/story_views.py
+++ b/src/frontend/frontend/views/story_views.py
@@ -1,5 +1,4 @@
 import datetime
-from difflib import SequenceMatcher
 from json import JSONDecodeError
 from typing import Any, Callable
 from urllib.parse import parse_qs, quote, urlencode, urlparse
@@ -7,7 +6,6 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse
 from flask import Response, abort, flash, json, make_response, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from flask_jwt_extended import current_user
-from markupsafe import Markup, escape
 from models.assess import (
     NEWS_ITEM_IMPORT_FIELDS as _NEWS_ITEM_IMPORT_FIELDS,
 )
@@ -24,6 +22,7 @@ from models.assess import (
     StoryUpdatePayload,
 )
 from models.report import ReportItem
+from models.revision_diff import build_story_revision_diff_payload
 from pydantic import ValidationError
 from werkzeug.datastructures import FileStorage
 from werkzeug.exceptions import HTTPException
@@ -832,176 +831,20 @@ class StoryView(BaseView):
         if not story_id:
             return abort(400, description="No story ID provided.")
 
-        # Get story data
-        story = DataPersistenceLayer().get_object(Story, story_id)
-        if not story:
-            return abort(404, description="Story not found.")
-
-        # Get revision data from core API
-        from_data = CoreApi().api_get(f"/assess/stories/{story_id}/revisions/{from_rev}")
-        to_data = CoreApi().api_get(f"/assess/stories/{story_id}/revisions/{to_rev}")
-
-        if not from_data or not to_data:
+        core_api = CoreApi()
+        from_revision = core_api.api_get(f"/assess/stories/{story_id}/revisions/{from_rev}")
+        to_revision = core_api.api_get(f"/assess/stories/{story_id}/revisions/{to_rev}")
+        if not from_revision or not to_revision:
             return abort(404, description="Revision not found.")
 
-        # Calculate diff
-        from_revision_data = from_data.get("data", {})
-        to_revision_data = to_data.get("data", {})
-
-        # Prepare diff data
-        diff_data = {
-            "from_revision": from_data,
-            "to_revision": to_data,
-            "changes": _calculate_story_diff(from_revision_data, to_revision_data),
-        }
+        story_title = to_revision.get("data", {}).get("title") or from_revision.get("data", {}).get("title")
+        diff = build_story_revision_diff_payload(story_id, story_title, from_revision, to_revision)
 
         context = {
-            "story": story,
-            "diff": diff_data,
+            "diff": diff,
             "from_rev": from_rev,
             "to_rev": to_rev,
+            "story_id": story_id,
         }
 
         return render_template("assess/story_diff.html", **context), 200
-
-
-def _calculate_story_diff(from_data: dict, to_data: dict) -> list[dict[str, Any]]:
-    """Calculate differences between two story data dictionaries"""
-    changes = []
-
-    def _inline_text_diff(old_text: str, new_text: str) -> tuple[Markup, Markup]:
-        old_parts: list[str] = []
-        new_parts: list[str] = []
-        matcher = SequenceMatcher(a=old_text, b=new_text)
-
-        for tag, i1, i2, j1, j2 in matcher.get_opcodes():
-            old_segment = escape(old_text[i1:i2])
-            new_segment = escape(new_text[j1:j2])
-
-            if tag == "equal":
-                old_parts.append(str(old_segment))
-                new_parts.append(str(new_segment))
-                continue
-
-            if tag in {"delete", "replace"} and i1 != i2:
-                old_parts.append(f'<span class="line-through bg-error/20 text-error rounded px-0.5">{old_segment}</span>')
-
-            if tag in {"insert", "replace"} and j1 != j2:
-                new_parts.append(f'<span class="bg-success/20 text-success rounded px-0.5">{new_segment}</span>')
-
-        return Markup("".join(old_parts)), Markup("".join(new_parts))
-
-    def _append_text_change(field: str, old_value: Any, new_value: Any) -> None:
-        if old_value == new_value:
-            return
-
-        change: dict[str, Any] = {
-            "field": field,
-            "old_value": old_value,
-            "new_value": new_value,
-        }
-
-        if isinstance(old_value, str) and isinstance(new_value, str):
-            old_value_diff, new_value_diff = _inline_text_diff(old_value, new_value)
-            change["old_value_diff"] = old_value_diff
-            change["new_value_diff"] = new_value_diff
-            change["inline_diff"] = True
-
-        changes.append(change)
-
-    def _normalized_tag_names(data: dict) -> set[str]:
-        tag_names = set()
-        for tag in data.get("tags") or []:
-            if not isinstance(tag, dict):
-                continue
-            name = tag.get("name")
-            if not isinstance(name, str):
-                continue
-            normalized_name = name.strip()
-            if normalized_name:
-                tag_names.add(normalized_name)
-        return tag_names
-
-    # Compare title
-    _append_text_change("Title", from_data.get("title"), to_data.get("title"))
-
-    # Compare description
-    _append_text_change("Description", from_data.get("description"), to_data.get("description"))
-
-    # Compare summary
-    _append_text_change("Summary", from_data.get("summary"), to_data.get("summary"))
-
-    # Compare comments
-    _append_text_change("Comments", from_data.get("comments"), to_data.get("comments"))
-
-    # Compare tags
-    from_tags = _normalized_tag_names(from_data)
-    to_tags = _normalized_tag_names(to_data)
-
-    added_tags = to_tags - from_tags
-    removed_tags = from_tags - to_tags
-
-    if added_tags:
-        changes.append(
-            {
-                "field": "Tags Added",
-                "old_value": None,
-                "new_value": ", ".join(sorted(added_tags)),
-            }
-        )
-
-    if removed_tags:
-        changes.append(
-            {
-                "field": "Tags Removed",
-                "old_value": ", ".join(sorted(removed_tags)),
-                "new_value": None,
-            }
-        )
-
-    # Compare news items
-    from_news_items = {item.get("id") for item in from_data.get("news_items", [])}
-    to_news_items = {item.get("id") for item in to_data.get("news_items", [])}
-
-    added_items = to_news_items - from_news_items
-    removed_items = from_news_items - to_news_items
-
-    if added_items:
-        item_titles = [item.get("title", item.get("id")) for item in to_data.get("news_items", []) if item.get("id") in added_items]
-        changes.append(
-            {
-                "field": "News Items Added",
-                "old_value": None,
-                "new_value": ", ".join(item_titles[:5]) + (f" and {len(item_titles) - 5} more" if len(item_titles) > 5 else ""),
-            }
-        )
-
-    if removed_items:
-        item_titles = [item.get("title", item.get("id")) for item in from_data.get("news_items", []) if item.get("id") in removed_items]
-        changes.append(
-            {
-                "field": "News Items Removed",
-                "old_value": ", ".join(item_titles[:5]) + (f" and {len(item_titles) - 5} more" if len(item_titles) > 5 else ""),
-                "new_value": None,
-            }
-        )
-
-    # Compare attributes
-    from_attrs = {attr.get("key"): attr.get("value") for attr in from_data.get("attributes", [])}
-    to_attrs = {attr.get("key"): attr.get("value") for attr in to_data.get("attributes", [])}
-
-    # Find changed, added, and removed attributes
-    all_keys = set(from_attrs.keys()) | set(to_attrs.keys())
-    for key in sorted(all_keys):
-        from_val = from_attrs.get(key)
-        to_val = to_attrs.get(key)
-        if from_val != to_val:
-            changes.append(
-                {
-                    "field": f"Attribute: {key}",
-                    "old_value": from_val,
-                    "new_value": to_val,
-                }
-            )
-
-    return changes

--- a/src/frontend/tests/unit/views/test_report_view.py
+++ b/src/frontend/tests/unit/views/test_report_view.py
@@ -22,6 +22,108 @@ def test_report_view_renders_access_denied_page_when_core_returns_403(app, authe
     assert "403 - Access denied" in html
 
 
+def test_report_diff_view_renders_compare_payload(app, authenticated_client_basic, responses_mock):
+    report_id = "report-1"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items/{report_id}/revisions/1",
+        json={
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {
+                "title": "Report Draft",
+                "completed": False,
+                "stories": [{"id": "story-1", "title": "Story One"}],
+                "grouped_attributes": [
+                    {
+                        "title": "Summary",
+                        "attributes": [{"title": "Threat", "type": "STORY", "value": "story-1"}],
+                    }
+                ],
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items/{report_id}/revisions/2",
+        json={
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {
+                "title": "Report Final",
+                "completed": True,
+                "stories": [{"id": "story-2", "title": "Story Two"}],
+                "grouped_attributes": [
+                    {
+                        "title": "Summary",
+                        "attributes": [{"title": "Threat", "type": "STORY", "value": "story-2"}],
+                    }
+                ],
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
+
+    with app.test_request_context():
+        response = authenticated_client_basic.get(url_for("analyze.report_diff", report_id=report_id, from_rev=1, to_rev=2))
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Changes:" in html
+    assert "Report Final" in html
+    assert "Summary" in html
+    assert "bg-success/20 text-success" in html
+    assert "bg-error/20 text-error" in html
+
+
+def test_report_diff_view_shows_no_changes_state(app, authenticated_client_basic, responses_mock):
+    report_id = "report-1"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items/{report_id}/revisions/1",
+        json={
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {"title": "Report title", "completed": False, "stories": [], "grouped_attributes": []},
+        },
+        status=200,
+        content_type="application/json",
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/analyze/report-items/{report_id}/revisions/2",
+        json={
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {"title": "Report title", "completed": False, "stories": [], "grouped_attributes": []},
+        },
+        status=200,
+        content_type="application/json",
+    )
+
+    with app.test_request_context():
+        response = authenticated_client_basic.get(url_for("analyze.report_diff", report_id=report_id, from_rev=1, to_rev=2))
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "No changes detected between these revisions." in html
+
+
 def test_report_delete_actions_target_notification_bar_on_error(app):
     with app.test_request_context():
         delete_action = next(action for action in ReportItemView.get_report_actions() if action["label"] == "Delete")

--- a/src/frontend/tests/unit/views/test_story_view.py
+++ b/src/frontend/tests/unit/views/test_story_view.py
@@ -7,66 +7,126 @@ from models.assess import Story
 from werkzeug.exceptions import Forbidden
 
 from frontend.config import Config
-from frontend.views.story_views import StoryView, _calculate_story_diff, _normalize_story_import_payload
+from frontend.views.story_views import StoryView, _normalize_story_import_payload
 
 
 def expected_search_trigger(input_id: str) -> str:
     return f"input changed delay:500ms from:#{input_id}, search from:#{input_id}"
 
 
-def test_calculate_story_diff_ignores_empty_tag_changes():
-    from_data = {
-        "title": "Story title",
-        "tags": [{"name": None}],
-    }
-    to_data = {
-        "title": "Story title",
-        "tags": [{"name": ""}, {"name": "   "}],
-    }
+def test_story_diff_view_renders_compare_payload(app, authenticated_client, responses_mock):
+    story_id = "story-1"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}/revisions/1",
+        json={
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {
+                "title": "Kill Chain im Krieg verkurzt",
+                "description": "First draft",
+                "summary": "Summary A",
+                "comments": "Comment A",
+                "tags": [{"name": "old-tag"}],
+                "news_items": [{"id": "news-1", "title": "Old news"}],
+                "attributes": [{"key": "TLP", "value": "clear"}],
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}/revisions/2",
+        json={
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {
+                "title": "Kill Chain im Krieg deutlich verkurzt",
+                "description": "First draft",
+                "summary": "Summary B",
+                "comments": "Comment A",
+                "tags": [{"name": "new-tag"}],
+                "news_items": [{"id": "news-2", "title": "New news"}],
+                "attributes": [{"key": "TLP", "value": "amber"}],
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
 
-    changes = _calculate_story_diff(from_data, to_data)
+    with app.test_request_context():
+        response = authenticated_client.get(url_for("assess.story_diff", story_id=story_id, from_rev=1, to_rev=2))
 
-    assert changes == []
-
-
-def test_calculate_story_diff_keeps_real_tag_changes():
-    from_data = {
-        "title": "Story title",
-        "tags": [{"name": None}, {"name": "existing"}],
-    }
-    to_data = {
-        "title": "Story title",
-        "tags": [{"name": ""}, {"name": "existing"}, {"name": "new-tag"}],
-    }
-
-    changes = _calculate_story_diff(from_data, to_data)
-
-    assert {"field": "Tags Added", "old_value": None, "new_value": "new-tag"} in changes
+    assert response.status_code == 200
+    html_doc = response.get_data(as_text=True)
+    assert "Changes:" in html_doc
+    assert "Kill Chain im Krieg deutlich verkurzt" in html_doc
+    assert "old_segments" not in html_doc
+    assert "deutlich " in html_doc
+    assert "bg-success/20 text-success" in html_doc
+    assert "bg-error/20 text-error" in html_doc
 
 
-def test_calculate_story_diff_uses_inline_markup_for_text_changes():
-    from_data = {"title": "Kill Chain im Krieg verkurzt"}
-    to_data = {"title": "Kill Chain im Krieg deutlich verkurzt"}
+def test_story_diff_view_shows_no_changes_state(app, authenticated_client, responses_mock):
+    story_id = "story-1"
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}/revisions/1",
+        json={
+            "id": 1,
+            "revision": 1,
+            "created_at": "2026-03-12T10:00:00",
+            "created_by": "alice",
+            "created_by_id": 1,
+            "note": "created",
+            "data": {
+                "title": "Story title",
+                "tags": [],
+                "news_items": [],
+                "attributes": [],
+                "description": "",
+                "summary": "",
+                "comments": "",
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories/{story_id}/revisions/2",
+        json={
+            "id": 2,
+            "revision": 2,
+            "created_at": "2026-03-12T11:00:00",
+            "created_by": "bob",
+            "created_by_id": 2,
+            "note": "update",
+            "data": {
+                "title": "Story title",
+                "tags": [],
+                "news_items": [],
+                "attributes": [],
+                "description": "",
+                "summary": "",
+                "comments": "",
+            },
+        },
+        status=200,
+        content_type="application/json",
+    )
 
-    changes = _calculate_story_diff(from_data, to_data)
+    with app.test_request_context():
+        response = authenticated_client.get(url_for("assess.story_diff", story_id=story_id, from_rev=1, to_rev=2))
 
-    assert len(changes) == 1
-    assert changes[0]["field"] == "Title"
-    assert changes[0]["inline_diff"] is True
-    assert "bg-success/20" in str(changes[0]["new_value_diff"])
-    assert "deutlich " in str(changes[0]["new_value_diff"])
-    assert "deutlich " not in str(changes[0]["old_value_diff"])
-
-
-def test_calculate_story_diff_escapes_inline_markup_text():
-    from_data = {"title": "A <script>alert(1)</script> title"}
-    to_data = {"title": "A <script>alert(1)</script> new title"}
-
-    changes = _calculate_story_diff(from_data, to_data)
-
-    assert len(changes) == 1
-    assert "&lt;script&gt;" in str(changes[0]["new_value_diff"])
-    assert "<script>" not in str(changes[0]["new_value_diff"])
+    assert response.status_code == 200
+    html_doc = response.get_data(as_text=True)
+    assert "No changes detected between these revisions." in html_doc
 
 
 def test_normalize_story_import_payload_unwraps_export_items():

--- a/src/models/models/revision_diff.py
+++ b/src/models/models/revision_diff.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from typing import Any
+
+from pydantic import Field
+
+from models.base import TaranisBaseModel
+
+
+class RevisionDiffSegment(TaranisBaseModel):
+    text: str
+    highlighted: bool = False
+
+
+class RevisionDiffRevision(TaranisBaseModel):
+    id: int
+    revision: int
+    created_at: str | None = None
+    created_by: str | None = None
+    created_by_id: int | None = None
+    note: str | None = None
+
+
+class RevisionDiffResource(TaranisBaseModel):
+    id: str
+    title: str | None = None
+
+
+class RevisionDiffChange(TaranisBaseModel):
+    field: str
+    group: str | None = None
+    old_value: Any | None = None
+    new_value: Any | None = None
+    old_segments: list[RevisionDiffSegment] = Field(default_factory=list)
+    new_segments: list[RevisionDiffSegment] = Field(default_factory=list)
+
+
+class RevisionDiff(TaranisBaseModel):
+    resource: RevisionDiffResource
+    from_revision: RevisionDiffRevision
+    to_revision: RevisionDiffRevision
+    changes: list[RevisionDiffChange] = Field(default_factory=list)
+
+
+def _build_inline_segments(old_text: str, new_text: str) -> tuple[list[RevisionDiffSegment], list[RevisionDiffSegment]]:
+    old_segments: list[RevisionDiffSegment] = []
+    new_segments: list[RevisionDiffSegment] = []
+
+    matcher = SequenceMatcher(a=old_text, b=new_text)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        old_piece = old_text[i1:i2]
+        new_piece = new_text[j1:j2]
+
+        if tag == "equal":
+            if old_piece:
+                old_segments.append(RevisionDiffSegment(text=old_piece))
+            if new_piece:
+                new_segments.append(RevisionDiffSegment(text=new_piece))
+            continue
+
+        if tag in {"delete", "replace"} and old_piece:
+            old_segments.append(RevisionDiffSegment(text=old_piece, highlighted=True))
+
+        if tag in {"insert", "replace"} and new_piece:
+            new_segments.append(RevisionDiffSegment(text=new_piece, highlighted=True))
+
+    return old_segments, new_segments
+
+
+def _append_change(changes: list[RevisionDiffChange], field: str, old_value: Any, new_value: Any, group: str | None = None) -> None:
+    if old_value == new_value:
+        return
+
+    change = RevisionDiffChange(field=field, group=group, old_value=old_value, new_value=new_value)
+    if isinstance(old_value, str) and isinstance(new_value, str):
+        old_segments, new_segments = _build_inline_segments(old_value, new_value)
+        if old_segments or new_segments:
+            change.old_segments = old_segments
+            change.new_segments = new_segments
+
+    changes.append(change)
+
+
+def _format_joined_titles(titles: list[str], limit: int | None = None) -> str:
+    if limit is not None and len(titles) > limit:
+        return ", ".join(titles[:limit]) + f" and {len(titles) - limit} more"
+    return ", ".join(titles)
+
+
+def _normalized_tag_names(data: dict[str, Any]) -> set[str]:
+    tag_names = set()
+    for tag in data.get("tags") or []:
+        if not isinstance(tag, dict):
+            continue
+        name = tag.get("name")
+        if not isinstance(name, str):
+            continue
+        normalized_name = name.strip()
+        if normalized_name:
+            tag_names.add(normalized_name)
+    return tag_names
+
+
+def _story_title_map(stories: list[dict[str, Any]]) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    for story in stories:
+        story_id = story.get("id")
+        if isinstance(story_id, str) and story_id:
+            titles[story_id] = story.get("title") or story_id
+    return titles
+
+
+def _resolve_story_value(value: Any, story_map: dict[str, str]) -> Any:
+    if not isinstance(value, str) or not value.strip():
+        return value
+
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if len(parts) == 1:
+        part = parts[0]
+        return story_map.get(part, part)
+    return ", ".join(story_map.get(part, part) for part in parts)
+
+
+def _build_revision_diff(
+    resource_id: str,
+    resource_title: str | None,
+    from_revision: dict[str, Any],
+    to_revision: dict[str, Any],
+    changes: list[RevisionDiffChange],
+) -> RevisionDiff:
+    return RevisionDiff(
+        resource=RevisionDiffResource(id=resource_id, title=resource_title),
+        from_revision=RevisionDiffRevision(**{key: value for key, value in from_revision.items() if key != "data"}),
+        to_revision=RevisionDiffRevision(**{key: value for key, value in to_revision.items() if key != "data"}),
+        changes=changes,
+    )
+
+
+def build_story_revision_diff_payload(
+    story_id: str,
+    story_title: str | None,
+    from_revision: dict[str, Any],
+    to_revision: dict[str, Any],
+) -> RevisionDiff:
+    from_data = from_revision.get("data") or {}
+    to_data = to_revision.get("data") or {}
+    changes: list[RevisionDiffChange] = []
+
+    _append_change(changes, "Title", from_data.get("title"), to_data.get("title"))
+    _append_change(changes, "Description", from_data.get("description"), to_data.get("description"))
+    _append_change(changes, "Summary", from_data.get("summary"), to_data.get("summary"))
+    _append_change(changes, "Comments", from_data.get("comments"), to_data.get("comments"))
+
+    from_tags = _normalized_tag_names(from_data)
+    to_tags = _normalized_tag_names(to_data)
+
+    added_tags = sorted(to_tags - from_tags)
+    removed_tags = sorted(from_tags - to_tags)
+
+    if added_tags:
+        changes.append(RevisionDiffChange(field="Tags Added", old_value=None, new_value=_format_joined_titles(added_tags)))
+
+    if removed_tags:
+        changes.append(RevisionDiffChange(field="Tags Removed", old_value=_format_joined_titles(removed_tags), new_value=None))
+
+    from_news_items = [item for item in from_data.get("news_items", []) if isinstance(item, dict)]
+    to_news_items = [item for item in to_data.get("news_items", []) if isinstance(item, dict)]
+    from_news_ids = {item.get("id") for item in from_news_items}
+    to_news_ids = {item.get("id") for item in to_news_items}
+
+    added_items = to_news_ids - from_news_ids
+    removed_items = from_news_ids - to_news_ids
+
+    if added_items:
+        item_titles = [item.get("title") or item.get("id") for item in to_news_items if item.get("id") in added_items]
+        changes.append(
+            RevisionDiffChange(
+                field="News Items Added",
+                old_value=None,
+                new_value=_format_joined_titles([title for title in item_titles if isinstance(title, str)], limit=5),
+            )
+        )
+
+    if removed_items:
+        item_titles = [item.get("title") or item.get("id") for item in from_news_items if item.get("id") in removed_items]
+        changes.append(
+            RevisionDiffChange(
+                field="News Items Removed",
+                old_value=_format_joined_titles([title for title in item_titles if isinstance(title, str)], limit=5),
+                new_value=None,
+            )
+        )
+
+    from_attrs = {
+        attr.get("key"): attr.get("value") for attr in from_data.get("attributes", []) if isinstance(attr, dict) and attr.get("key")
+    }
+    to_attrs = {attr.get("key"): attr.get("value") for attr in to_data.get("attributes", []) if isinstance(attr, dict) and attr.get("key")}
+
+    for key in sorted(set(from_attrs) | set(to_attrs)):
+        _append_change(changes, key, from_attrs.get(key), to_attrs.get(key))
+
+    return _build_revision_diff(story_id, story_title, from_revision, to_revision, changes)
+
+
+def build_report_revision_diff_payload(
+    report_item_id: str,
+    report_title: str | None,
+    from_revision: dict[str, Any],
+    to_revision: dict[str, Any],
+) -> RevisionDiff:
+    from_data = from_revision.get("data") or {}
+    to_data = to_revision.get("data") or {}
+    changes: list[RevisionDiffChange] = []
+
+    _append_change(changes, "Title", from_data.get("title"), to_data.get("title"))
+    _append_change(changes, "Completed", from_data.get("completed"), to_data.get("completed"))
+
+    story_map = _story_title_map(
+        [story for story in from_data.get("stories", []) if isinstance(story, dict)]
+        + [story for story in to_data.get("stories", []) if isinstance(story, dict)]
+    )
+
+    from_groups = from_data.get("grouped_attributes", []) or []
+    to_groups = to_data.get("grouped_attributes", []) or []
+
+    from_attributes: dict[tuple[str, str], Any] = {}
+    from_attribute_types: dict[tuple[str, str], Any] = {}
+    for group in from_groups:
+        if not isinstance(group, dict):
+            continue
+        group_title = group.get("title") or ""
+        for attribute in group.get("attributes", []) or []:
+            if not isinstance(attribute, dict):
+                continue
+            key = (group_title, attribute.get("title") or "")
+            from_attributes[key] = attribute.get("value")
+            from_attribute_types[key] = attribute.get("type")
+
+    to_attributes: dict[tuple[str, str], Any] = {}
+    to_attribute_types: dict[tuple[str, str], Any] = {}
+    for group in to_groups:
+        if not isinstance(group, dict):
+            continue
+        group_title = group.get("title") or ""
+        for attribute in group.get("attributes", []) or []:
+            if not isinstance(attribute, dict):
+                continue
+            key = (group_title, attribute.get("title") or "")
+            to_attributes[key] = attribute.get("value")
+            to_attribute_types[key] = attribute.get("type")
+
+    for group_title, attribute_title in sorted(set(from_attributes) | set(to_attributes)):
+        from_value = from_attributes.get((group_title, attribute_title))
+        to_value = to_attributes.get((group_title, attribute_title))
+        if from_value == to_value:
+            continue
+
+        attribute_type = from_attribute_types.get((group_title, attribute_title)) or to_attribute_types.get((group_title, attribute_title))
+        if attribute_type == "STORY":
+            from_value = _resolve_story_value(from_value, story_map)
+            to_value = _resolve_story_value(to_value, story_map)
+
+        changes.append(RevisionDiffChange(field=attribute_title, group=group_title or None, old_value=from_value, new_value=to_value))
+
+    from_story_ids = {story.get("id") for story in from_data.get("stories", []) if isinstance(story, dict)}
+    to_story_ids = {story.get("id") for story in to_data.get("stories", []) if isinstance(story, dict)}
+
+    added_story_ids = to_story_ids - from_story_ids
+    removed_story_ids = from_story_ids - to_story_ids
+
+    if added_story_ids:
+        story_titles = [
+            story.get("title") or story.get("id")
+            for story in to_data.get("stories", [])
+            if isinstance(story, dict) and story.get("id") in added_story_ids
+        ]
+        changes.append(
+            RevisionDiffChange(
+                field="Stories Added", old_value=None, new_value=", ".join(title for title in story_titles if isinstance(title, str))
+            )
+        )
+
+    if removed_story_ids:
+        story_titles = [
+            story.get("title") or story.get("id")
+            for story in from_data.get("stories", [])
+            if isinstance(story, dict) and story.get("id") in removed_story_ids
+        ]
+        changes.append(
+            RevisionDiffChange(
+                field="Stories Removed", old_value=", ".join(title for title in story_titles if isinstance(title, str)), new_value=None
+            )
+        )
+
+    return _build_revision_diff(report_item_id, report_title, from_revision, to_revision, changes)


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared revision diff model and payload builders and refactor story/report revision diff views and templates to use it.

Enhancements:
- Unify story and report revision diff calculation into reusable builders that produce a structured RevisionDiff payload with inline text segments and collection changes.
- Replace inline diff-table rendering logic in story and report diff templates with shared macros for consistent highlighting and layout.
- Simplify story and report diff views to delegate diff construction to the new builders and remove legacy in-view diff computation.

Tests:
- Add unit tests for the new revision diff payload builders and for story and report diff views to cover inline highlighting, collection changes, and no-change states.