### PR TITLE
Simplify default seed organizations to single entry

### DIFF
--- a/src/core/core/managers/db_seed_manager.py
+++ b/src/core/core/managers/db_seed_manager.py
@@ -452,9 +452,9 @@ def pre_seed_default_user():
     if not admin_organization:
         Organization.add(
             {
-                "name": "The Earth",
-                "description": "Earth is the third planet from the Sun and the only astronomical object known to harbor life.",
-                "address": {"street": "29 Arlington Avenue", "city": "Islington, London", "zip": "N1 7BE", "country": "United Kingdom"},
+                "id": 1,
+                "name": "Default Organization",
+                "description": "Default organization for initial users.",
             }
         )
 
@@ -470,20 +470,6 @@ def pre_seed_default_user():
                 }
             )
 
-    if not Organization.get(2):
-        Organization.add(
-            {
-                "name": "The Clacks",
-                "description": "A network infrastructure of Semaphore Towers, that operate in a similar fashion to telegraph.",
-                "address": {
-                    "street": "Cherry Tree Rd",
-                    "city": "Beaconsfield, Buckinghamshire",
-                    "zip": "HP9 1BH",
-                    "country": "United Kingdom",
-                },
-            }
-        )
-
     if not User.find_by_name(username="user"):
         user_role = Role.filter_by_name("User").id  # type: ignore
         User.add(
@@ -491,7 +477,7 @@ def pre_seed_default_user():
                 "username": "user",
                 "name": "Terry Pratchett",
                 "roles": [user_role],
-                "organization": {"id": 2},
+                "organization": {"id": 1},
                 "password": Config.PRE_SEED_PASSWORD_USER,
             }
         )

--- a/src/frontend/tests/unit/views/conftest.py
+++ b/src/frontend/tests/unit/views/conftest.py
@@ -448,7 +448,7 @@ def users_get_mock(responses_mock, organizations_get_mock, roles_get_mock):
             {
                 "id": 6,
                 "name": "ccc",
-                "organization": 2,
+                "organization": 1,
                 "permissions": [
                     "PUBLISH_DELETE",
                     "ASSESS_UPDATE",
@@ -482,24 +482,13 @@ def organizations_get_mock(responses_mock):
     mock_data = {
         "items": [
             {
-                "address": {
-                    "city": "Beaconsfield, Buckinghamshire",
-                    "country": "United Kingdom",
-                    "street": "Cherry Tree Rd",
-                    "zip": "HP9 1BH",
-                },
-                "description": "A network infrastructure of Semaphore Towers, that operate in a similar fashion to telegraph.",
-                "id": 2,
-                "name": "The Clacks",
-            },
-            {
-                "address": {"city": "Islington, London", "country": "United Kingdom", "street": "29 Arlington Avenue", "zip": "N1 7BE"},
-                "description": "Earth is the third planet from the Sun and the only astronomical object known to harbor life.",
+                "address": {},
+                "description": "Default organization for initial users.",
                 "id": 1,
-                "name": "The Earth",
+                "name": "Default Organization",
             },
         ],
-        "total_count": 2,
+        "total_count": 1,
     }
 
     responses_mock.get(f"{Config.TARANIS_CORE_URL}/config/organizations", json=mock_data)


### PR DESCRIPTION
Replace the two fictional seed organizations ("The Earth" and "The Clacks") with a single "Default Organization", and assign both default users to it.

## Summary by Sourcery

Simplify default seed data to use a single default organization shared by initial users and update tests accordingly.

Enhancements:
- Replace multiple fictional seed organizations with a single Default Organization assigned a fixed ID.
- Align default user seeding so both initial users belong to the same default organization.

Tests:
- Update frontend unit test fixtures to reflect the single default organization and adjusted organization counts.