### PR TITLE
Fix/osint source wordlist gathering

### DIFF
--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -692,7 +692,7 @@ class ConnectorsPull(MethodView):
 
 class OSINTSources(MethodView):
     @auth_required("CONFIG_OSINT_SOURCE_ACCESS")
-    @extract_args("search", "page", "limit", "sort", "order", "type", "fetch_all")
+    @extract_args("search", "page", "limit", "sort", "order", "type", "fetch_all", "filter_manual")
     def get(self, source_id: str | None = None, filter_args: dict[str, Any] | None = None):
         if source_id:
             return osint_source.OSINTSource.get_for_api(source_id)

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -460,7 +460,7 @@ class QueueManager:
         if self.error:
             return {"error": "QueueManager not initialized"}, 500
 
-        word_lists = WordList.get_all_for_collector() or []
+        word_lists = WordList.get_all_for_gathering() or []
         for word_list in word_lists:
             self.enqueue_task("misc", "gather_word_list", word_list.id, job_id=f"gather_word_list_{word_list.id}")
         return {"message": "Gathering for all WordLists scheduled"}, 200

--- a/src/core/core/model/osint_source.py
+++ b/src/core/core/model/osint_source.py
@@ -169,6 +169,7 @@ class OSINTSource(BaseModel):
     @classmethod
     def get_all_for_api(cls, filter_args: dict[str, Any] | None, with_count: bool = False, user=None) -> tuple[dict[str, Any], int]:
         filter_args = dict(filter_args or {})
+        filter_args["filter_manual"] = cls._filter_manual_enabled(filter_args.get("filter_manual", True))
 
         response, status_code = super().get_all_for_api(filter_args=filter_args, with_count=with_count, user=user)
         items = response.get("items", [])
@@ -205,7 +206,7 @@ class OSINTSource(BaseModel):
         if enabled := filter_args.get("enabled"):
             query = query.where(cls.enabled.is_(enabled))
 
-        if cls._filter_manual_enabled(filter_args.get("filter_manual", True)):
+        if filter_args.get("filter_manual"):
             query = query.where(cls.type != COLLECTOR_TYPES.MANUAL_COLLECTOR)
 
         return query

--- a/src/core/core/model/osint_source.py
+++ b/src/core/core/model/osint_source.py
@@ -169,7 +169,6 @@ class OSINTSource(BaseModel):
     @classmethod
     def get_all_for_api(cls, filter_args: dict[str, Any] | None, with_count: bool = False, user=None) -> tuple[dict[str, Any], int]:
         filter_args = dict(filter_args or {})
-        filter_args["filter_manual"] = filter_args.get("filter_manual", True)
 
         response, status_code = super().get_all_for_api(filter_args=filter_args, with_count=with_count, user=user)
         items = response.get("items", [])
@@ -179,6 +178,10 @@ class OSINTSource(BaseModel):
             items.sort(key=lambda item: (item.get("status") or {}).get("status", ""), reverse=True)
 
         return response, status_code
+
+    @staticmethod
+    def _filter_manual_enabled(value: Any) -> bool:
+        return str(value).strip().lower() not in {"", "false", "0", "off", "no"}
 
     @classmethod
     def get_filter_query_with_acl(cls, filter_args: dict, user) -> Select:
@@ -202,7 +205,7 @@ class OSINTSource(BaseModel):
         if enabled := filter_args.get("enabled"):
             query = query.where(cls.enabled.is_(enabled))
 
-        if filter_args.get("filter_manual"):
+        if cls._filter_manual_enabled(filter_args.get("filter_manual", True)):
             query = query.where(cls.type != COLLECTOR_TYPES.MANUAL_COLLECTOR)
 
         return query
@@ -426,6 +429,7 @@ class OSINTSource(BaseModel):
     @classmethod
     def delete(cls, source_id: str, force: bool = False) -> tuple[dict, int]:
         from core.managers import queue_manager
+        from core.service.story import StoryService
 
         if source_id == "manual":
             return {"error": "The manual source cannot be deleted"}, 400
@@ -443,6 +447,7 @@ class OSINTSource(BaseModel):
                 news_item_table = db.metadata.tables.get("news_item")
                 if news_item_table is not None:
                     db.session.execute(news_item_table.delete().where(news_item_table.c.osint_source_id == source_id))
+                StoryService.delete_stories_with_no_items()
             db.session.delete(source)
             db.session.commit()
             return {"message": f"OSINT Source {source.name} deleted", "id": f"{source_id}"}, 200

--- a/src/core/core/model/word_list.py
+++ b/src/core/core/model/word_list.py
@@ -2,6 +2,7 @@ import csv
 import json
 from enum import IntEnum
 from typing import Any
+from urllib.parse import urlparse
 
 from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy.sql import Select
@@ -86,7 +87,17 @@ class WordList(BaseModel):
 
     @classmethod
     def get_all_empty(cls):
-        return cls.get_filtered(db.select(cls).filter_by(entries=None).order_by(db.asc(WordList.name)))
+        word_lists = cls.get_filtered(db.select(cls).filter_by(entries=None).order_by(db.asc(WordList.name))) or []
+        return [word_list for word_list in word_lists if word_list.has_valid_link()]
+
+    @classmethod
+    def get_all_for_gathering(cls) -> list["WordList"]:
+        word_lists = cls.get_filtered(db.select(cls).order_by(db.asc(WordList.name))) or []
+        return [word_list for word_list in word_lists if word_list.has_valid_link()]
+
+    def has_valid_link(self) -> bool:
+        parsed_link = urlparse(self.link or "")
+        return parsed_link.scheme in {"http", "https"} and bool(parsed_link.netloc)
 
     @classmethod
     def get_filter_query_with_acl(cls, filter_args: dict, user: User) -> Select:

--- a/src/core/tests/application/admin_console/configuration/test_config_api.py
+++ b/src/core/tests/application/admin_console/configuration/test_config_api.py
@@ -257,6 +257,49 @@ class TestSourcesConfigApi(BaseTest):
                 if OSINTSource.get(manual_source_id):
                     OSINTSource.delete(manual_source_id)
 
+    def test_get_sources_can_include_manual_collectors(self, client, auth_header, app):
+        from core.model.osint_source import OSINTSource
+
+        unique_suffix = uuid.uuid4().hex
+        rss_source_id = f"rss-{unique_suffix}"
+        manual_source_id = f"manual-{unique_suffix}"
+
+        rss_source = {
+            "id": rss_source_id,
+            "name": f"Visible Source {unique_suffix}",
+            "description": "Collector that should remain visible",
+            "parameters": {"FEED_URL": "https://example.invalid/feed.xml"},
+            "type": "rss_collector",
+        }
+        manual_source = {
+            "id": manual_source_id,
+            "name": f"Visible Source {unique_suffix}",
+            "description": "Collector that should be shown when requested",
+            "parameters": {},
+            "type": "manual_collector",
+        }
+
+        with app.app_context():
+            OSINTSource.add(rss_source)
+            OSINTSource.add(manual_source)
+
+        try:
+            response = self.assert_get_ok(
+                client,
+                uri=f"osint-sources?search={unique_suffix}&fetch_all=true&filter_manual=false",
+                auth_header=auth_header,
+            )
+            payload = response.get_json()
+
+            assert payload["total_count"] == 2
+            assert {item["id"] for item in payload["items"]} == {rss_source_id, manual_source_id}
+        finally:
+            with app.app_context():
+                if OSINTSource.get(rss_source_id):
+                    OSINTSource.delete(rss_source_id)
+                if OSINTSource.get(manual_source_id):
+                    OSINTSource.delete(manual_source_id)
+
     def test_get_sources_orders_by_status(self, client, auth_header, app):
         from core.model.osint_source import OSINTSource
         from core.model.task import Task

--- a/src/frontend/frontend/templates/osint_source/osint_sources_table.html
+++ b/src/frontend/frontend/templates/osint_source/osint_sources_table.html
@@ -9,6 +9,7 @@
 {% set data = model_plural_name | get_var %}
 {% set table_container = model_name + '-table-container' %}
 {% set actions = actions | default([]) %}
+{% set filter_manual = request.args.get("filter_manual", "true") %}
 
 <div id="{{ table_container }}" class="table-container" x-data="{ selectedItems: [], exportUrl: '{{ url_for("admin.export_osint_sources") }}' }">
   {% call table_decoration(name, model_name, table_container, routes=routes) %}
@@ -26,6 +27,36 @@
           Export
         </a>
       </div>
+    </div>
+    <div class="grow-0">
+      <form class="inline-flex flex-col items-center gap-1"
+            hx-get="{{ routes.base_route }}"
+            hx-target="#{{ table_container }}"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-trigger="change">
+        {% for key in request.args %}
+          {% for value in request.args.getlist(key) %}
+            {% if key != "filter_manual" %}<input type="hidden" name="{{ key }}" value="{{ value }}">{% endif %}
+          {% endfor %}
+        {% endfor %}
+        <div class="join" role="radiogroup" aria-label="Manual sources">
+          <input class="join-item btn btn-sm"
+                 type="radio"
+                 name="filter_manual"
+                 value="false"
+                 aria-label="Show"
+                 {% if filter_manual == "false" %}checked{% endif %} />
+          <input class="join-item btn btn-sm"
+                 type="radio"
+                 name="filter_manual"
+                 value="true"
+                 aria-label="Hide"
+                 {% if filter_manual != "false" %}checked{% endif %} />
+        </div>
+        <span class="label-text text-sm">Manual sources</span>
+
+      </form>
     </div>
   {% endcall %}
   {% if data and data | length > 0 %}


### PR DESCRIPTION
## Summary by Sourcery

Allow manual OSINT sources to be optionally included in listings and ensure wordlist gathering only processes lists with valid links.

New Features:
- Add UI and API support to toggle inclusion of manual OSINT sources when listing OSINT collectors.

Bug Fixes:
- Ensure wordlist gathering only schedules tasks for wordlists with valid HTTP(S) links.
- Prevent OSINT source deletion from leaving orphaned stories without associated items.

Enhancements:
- Filter out manual OSINT sources by default based on more robust interpretation of the filter flag value.
- Extend tests to cover inclusion of manual OSINT sources via the configuration API.

Tests:
- Add coverage for listing OSINT sources with manual collectors included.