### PR TITLE
improve creation and update time for asses import

### DIFF
--- a/src/core/core/model/story.py
+++ b/src/core/core/model/story.py
@@ -79,6 +79,7 @@ class Story(BaseModel):
         tags: list[dict[str, Any]] | None = None,
         news_items: list[dict[str, Any]] | list[str] | list[NewsItem] | None = None,
         last_change: str | None = None,
+        updated: datetime | str | None = None,
     ):
         self.id = id or str(uuid.uuid4())
         self.likes = likes
@@ -86,7 +87,6 @@ class Story(BaseModel):
         self.relevance = 0
         self.title = title
         self.description = description
-        self.created = self.get_creation_date(created)
         self.read = read
         self.important = important
         self.summary = summary
@@ -99,6 +99,7 @@ class Story(BaseModel):
             self.attributes = NewsItemAttribute.load_multiple(attributes)
         if tags:
             self.tags = NewsItemTag.load_multiple(tags)
+        self.created, self.updated = self.get_story_dates(created, updated)
         self.recompute_relevance(in_reports_count=0)
 
     @classmethod
@@ -221,9 +222,23 @@ class Story(BaseModel):
     def from_dict(cls, data: dict[str, Any]) -> "Story":
         return cls(**StoryPayload.model_validate(data).to_core_dict())
 
-    def get_creation_date(self, created: datetime | str | None):
-        payload = StoryPayload.model_validate({"created": created})
-        return payload.created or self.utcnow()
+    def get_story_dates(self, created: datetime | str | None, updated: datetime | str | None) -> tuple[datetime, datetime]:
+        payload = StoryPayload.model_validate({"created": created, "updated": updated})
+        if payload.created:
+            created_date = payload.created
+            return created_date, payload.updated or created_date
+
+        published_dates = self._published_dates()
+        if not published_dates:
+            created_date = self.utcnow()
+            return created_date, payload.updated or created_date
+
+        created_date = min(published_dates, key=self._comparison_timestamp)
+        updated_date = payload.updated or max(published_dates, key=self._comparison_timestamp)
+        return created_date, updated_date
+
+    def _published_dates(self) -> list[datetime]:
+        return [news_item.published for news_item in self.news_items if news_item.published]
 
     def load_news_items(self, news_items) -> list["NewsItem"]:
         if not news_items:
@@ -694,7 +709,7 @@ class Story(BaseModel):
                     news_item.last_change = actor
             db.session.add(story)
             db.session.flush()
-            story.update_status(change=resolved_actor)
+            story.update_status(change=resolved_actor, refresh_timestamps=False)
             story.record_revision(note="created")
             db.session.commit()
 
@@ -1315,7 +1330,7 @@ class Story(BaseModel):
         db.session.add(new_story)
         db.session.flush()
 
-        new_story.update_status(change=change)
+        new_story.update_status(change=change, refresh_timestamps=False)
         new_story.record_revision(note="created")
         if commit:
             db.session.commit()
@@ -1359,10 +1374,11 @@ class Story(BaseModel):
             return True
         return False
 
-    def update_status(self, change: str | None = None):
+    def update_status(self, change: str | None = None, refresh_timestamps: bool = True):
         if self.remove_empty_story():
             return
-        self.update_timestamps()
+        if refresh_timestamps:
+            self.update_timestamps()
         self.update_status_attributes()
         self.recompute_relevance()
         if change is not None:

--- a/src/core/tests/application/admin_console/operations/test_admin_api.py
+++ b/src/core/tests/application/admin_console/operations/test_admin_api.py
@@ -58,7 +58,7 @@ def test_export_stories_and_metadata(client, full_story, api_header, auth_header
     assert data[0]["id"] == story_id
     assert data[0]["news_items"][0].get("author") is None
 
-    expected_created = min(datetime.fromisoformat(item["published"]) for item in full_story[0]["news_items"]).isoformat()
+    expected_created = datetime.fromisoformat(full_story[0]["created"]).isoformat()
     assert data[0]["created"] == expected_created
 
     exported_news_item_ids = {ni["id"] for ni in data[0].get("news_items", [])}

--- a/src/core/tests/conftest.py
+++ b/src/core/tests/conftest.py
@@ -226,6 +226,7 @@ def mixed_timezone_story_payload():
 
     return {
         "expected_created": datetime.fromisoformat("2023-12-31T22:30:00"),
+        "expected_updated": datetime.fromisoformat("2024-01-01T00:00:00"),
         "payload": {
             "title": f"Story {uuid.uuid4()}",
             "news_items": [

--- a/src/core/tests/test_revision_tracking.py
+++ b/src/core/tests/test_revision_tracking.py
@@ -279,13 +279,16 @@ def test_story_creation_creates_created_revision():
 @pytest.mark.usefixtures("session")
 def test_story_creation_handles_mixed_timezone_published_dates(mixed_timezone_story_payload):
     expected_created = mixed_timezone_story_payload["expected_created"]
+    expected_updated = mixed_timezone_story_payload["expected_updated"]
     result, status = Story.add(mixed_timezone_story_payload["payload"])
 
     assert status == 200
     story = Story.get(result["story_id"])
     assert story is not None
     assert story.created == expected_created
+    assert story.updated == expected_updated
     assert story.to_dict()["created"] == "2023-12-31T22:30:00+00:00"
+    assert story.to_dict()["updated"] == "2024-01-01T00:00:00+00:00"
     assert any(news_item.published == expected_created for news_item in story.news_items)
 
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust story timestamp handling to derive created and updated times more accurately and avoid unnecessary timestamp refreshes on initial creation.

Bug Fixes:
- Fix story created and updated timestamps to be derived consistently from provided values or associated news item published dates, handling mixed time zones correctly.

Enhancements:
- Introduce a unified method to compute story created and updated dates, including fallback to news item publish times and a helper for collecting published dates.
- Allow skipping automatic timestamp refresh when updating story status during initial creation flows to preserve import-specified times.

Tests:
- Extend story creation tests to cover updated timestamps alongside created timestamps, including mixed timezone scenarios, and adjust admin export tests to assert exported created times from the story payload.