### PR TITLE
DB migration fix

### DIFF
--- a/src/core/core/managers/db_seed_manager.py
+++ b/src/core/core/managers/db_seed_manager.py
@@ -101,6 +101,7 @@ def pre_seed_update(db_engine: Engine):
             ReportItemType.add(r)
 
     for p in product_types:
+        p = _resolve_seed_product_type_report_types(p)
         pt = ProductType.filter_by_title(p["title"])
         if not pt:
             ProductType.add(p)
@@ -345,7 +346,7 @@ def pre_seed_workers():
         Bot.add(b)
 
     for p in product_types:
-        ProductType.add(p)
+        ProductType.add(_resolve_seed_product_type_report_types(p))
 
 
 def pre_seed_permissions():
@@ -437,6 +438,22 @@ def pre_seed_report_items():
     for report_type in report_types:
         if not ReportItemType.get_by_title(title=report_type["title"]):
             ReportItemType.add(report_type)
+
+
+def _resolve_seed_product_type_report_types(product_type: dict) -> dict:
+    from core.model.report_item_type import ReportItemType
+
+    product_type_data = deepcopy(product_type)
+    report_type_refs = product_type_data.get("report_types", [])
+    resolved_report_type_ids = []
+
+    for report_type_ref in report_type_refs:
+        report_type = ReportItemType.get_by_title(report_type_ref)
+        if report_type:
+            resolved_report_type_ids.append(report_type.id)
+
+    product_type_data["report_types"] = resolved_report_type_ids
+    return product_type_data
 
 
 def pre_seed_default_user():

--- a/src/core/core/managers/pre_seed_data.py
+++ b/src/core/core/managers/pre_seed_data.py
@@ -625,7 +625,7 @@ product_types = [
             {"parameter": "CONVERT_FROM", "type": "text", "value": "md", "rules": "one_of:html|md"},
             {"parameter": "CONVERT_TO", "type": "text", "value": "odt", "rules": "one_of:docx|odt"},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "Default .html -> .docx Presenter",
@@ -636,7 +636,7 @@ product_types = [
             {"parameter": "CONVERT_FROM", "type": "text", "value": "html", "rules": "one_of:html|md"},
             {"parameter": "CONVERT_TO", "type": "text", "value": "docx", "rules": "one_of:docx|odt"},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "Default html tailwindcss Presenter",
@@ -648,7 +648,7 @@ product_types = [
             {"parameter": "CONVERT_TO", "type": "text", "value": "docx", "rules": "one_of:docx|odt"},
             {"parameter": "render_options", "type": "text", "value": ""},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "Default html chartjs Presenter",
@@ -660,7 +660,7 @@ product_types = [
             {"parameter": "CONVERT_TO", "type": "text", "value": "docx", "rules": "one_of:docx|odt"},
             {"parameter": "render_options", "type": "text", "value": ""},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "Default PDF Presenter",
@@ -669,7 +669,7 @@ product_types = [
         "parameters": [
             {"parameter": "TEMPLATE_PATH", "type": "text", "value": "pdf_template.html"},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "Default TEXT Presenter",
@@ -678,7 +678,7 @@ product_types = [
         "parameters": [
             {"parameter": "TEMPLATE_PATH", "type": "text", "value": "text_template.txt"},
         ],
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
     {
         "title": "CERT Daily Report",
@@ -688,13 +688,13 @@ product_types = [
             {"parameter": "TEMPLATE_PATH", "type": "text", "value": "cert_at_daily_report.html"},
             {"parameter": "render_options", "type": "text", "value": ""},
         ],
-        "report_types": [4],
+        "report_types": ["CERT Report"],
     },
     {
         "title": "STIXv2.1 Report Exporter",
         "description": "STIXv2.1 Report Exporter",
         "type": "STIX_PRESENTER",
-        "report_types": [1, 2, 3, 4],
+        "report_types": ["OSINT Report", "Disinformation", "Vulnerability Report", "CERT Report"],
     },
 ]
 

--- a/src/core/migrations/20260423_01_Va9mQ-move-news-item-tags-to-news-items.py
+++ b/src/core/migrations/20260423_01_Va9mQ-move-news-item-tags-to-news-items.py
@@ -21,8 +21,8 @@ steps = [
     ),
     step(
         """
-        INSERT INTO news_item_tag (name, tag_type, news_item_id)
-        SELECT DISTINCT tag.name, tag.tag_type, news_item.id
+        INSERT INTO news_item_tag (id, name, tag_type, news_item_id)
+        SELECT DISTINCT gen_random_uuid()::text, tag.name, tag.tag_type, news_item.id
         FROM news_item_tag tag
         JOIN news_item ON news_item.story_id = tag.story_id
         WHERE tag.news_item_id IS NULL
@@ -68,8 +68,8 @@ steps = [
 
         """,
         """
-        INSERT INTO news_item_tag (name, tag_type, story_id)
-        SELECT DISTINCT attr.value, attr.key, snia.story_id
+        INSERT INTO news_item_tag (id, name, tag_type, story_id)
+        SELECT DISTINCT gen_random_uuid()::text, attr.value, attr.key, snia.story_id
         FROM story_news_item_attribute snia
         JOIN news_item_attribute attr ON attr.id = snia.news_item_attribute_id
         WHERE attr.key ILIKE 'report_%'

--- a/src/core/migrations/20260423_01_Va9mQ-move-news-item-tags-to-news-items.py
+++ b/src/core/migrations/20260423_01_Va9mQ-move-news-item-tags-to-news-items.py
@@ -2,10 +2,82 @@
 move news item tags to news items
 """
 
+import uuid
+
 from yoyo import step
 
 
 __depends__ = {"20260416_01_Q7vKp-add-task-worker-metadata"}
+
+
+def _insert_news_item_tags_for_news_items(connection):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT DISTINCT tag.name, tag.tag_type, news_item.id
+            FROM news_item_tag tag
+            JOIN news_item ON news_item.story_id = tag.story_id
+            WHERE tag.news_item_id IS NULL
+              AND tag.tag_type NOT ILIKE 'report_%';
+            """
+        )
+        rows = cursor.fetchall()
+        cursor.executemany(
+            """
+            INSERT INTO news_item_tag (id, name, tag_type, news_item_id)
+            VALUES (%s, %s, %s, %s);
+            """,
+            [(str(uuid.uuid7()), name, tag_type, news_item_id) for name, tag_type, news_item_id in rows],
+        )
+
+
+def _restore_report_tags_to_news_item_tags(connection):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT DISTINCT attr.value, attr.key, snia.story_id
+            FROM story_news_item_attribute snia
+            JOIN news_item_attribute attr ON attr.id = snia.news_item_attribute_id
+            WHERE attr.key ILIKE 'report_%'
+              AND attr.id = md5('report-tag-attribute:' || snia.story_id || ':' || lower(attr.key))
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM news_item_tag tag
+                  WHERE tag.story_id = snia.story_id
+                    AND tag.tag_type = attr.key
+                    AND tag.name = attr.value
+              );
+            """
+        )
+        rows = cursor.fetchall()
+        cursor.executemany(
+            """
+            INSERT INTO news_item_tag (id, name, tag_type, story_id)
+            VALUES (%s, %s, %s, %s);
+            """,
+            [(str(uuid.uuid7()), name, tag_type, story_id) for name, tag_type, story_id in rows],
+        )
+        cursor.execute(
+            """
+            DELETE FROM story_news_item_attribute snia
+            USING news_item_attribute attr
+            WHERE attr.id = snia.news_item_attribute_id
+              AND attr.key ILIKE 'report_%'
+              AND attr.id = md5('report-tag-attribute:' || snia.story_id || ':' || lower(attr.key));
+
+            DELETE FROM news_item_attribute attr
+            WHERE attr.key ILIKE 'report_%'
+              AND EXISTS (
+                  SELECT 1 FROM story WHERE attr.id = md5('report-tag-attribute:' || story.id || ':' || lower(attr.key))
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM story_news_item_attribute snia WHERE snia.news_item_attribute_id = attr.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM news_item_news_item_attribute ninia WHERE ninia.news_item_attribute_id = attr.id
+              );
+            """
+        )
 
 
 steps = [
@@ -20,14 +92,7 @@ steps = [
         """,
     ),
     step(
-        """
-        INSERT INTO news_item_tag (id, name, tag_type, news_item_id)
-        SELECT DISTINCT gen_random_uuid()::text, tag.name, tag.tag_type, news_item.id
-        FROM news_item_tag tag
-        JOIN news_item ON news_item.story_id = tag.story_id
-        WHERE tag.news_item_id IS NULL
-          AND tag.tag_type NOT ILIKE 'report_%';
-        """,
+        _insert_news_item_tags_for_news_items,
         """
         """,
     ),
@@ -67,39 +132,7 @@ steps = [
         FROM report_tags;
 
         """,
-        """
-        INSERT INTO news_item_tag (id, name, tag_type, story_id)
-        SELECT DISTINCT gen_random_uuid()::text, attr.value, attr.key, snia.story_id
-        FROM story_news_item_attribute snia
-        JOIN news_item_attribute attr ON attr.id = snia.news_item_attribute_id
-        WHERE attr.key ILIKE 'report_%'
-          AND attr.id = md5('report-tag-attribute:' || snia.story_id || ':' || lower(attr.key))
-          AND NOT EXISTS (
-              SELECT 1
-              FROM news_item_tag tag
-              WHERE tag.story_id = snia.story_id
-                AND tag.tag_type = attr.key
-                AND tag.name = attr.value
-          );
-
-        DELETE FROM story_news_item_attribute snia
-        USING news_item_attribute attr
-        WHERE attr.id = snia.news_item_attribute_id
-          AND attr.key ILIKE 'report_%'
-          AND attr.id = md5('report-tag-attribute:' || snia.story_id || ':' || lower(attr.key));
-
-        DELETE FROM news_item_attribute attr
-        WHERE attr.key ILIKE 'report_%'
-          AND EXISTS (
-              SELECT 1 FROM story WHERE attr.id = md5('report-tag-attribute:' || story.id || ':' || lower(attr.key))
-          )
-          AND NOT EXISTS (
-              SELECT 1 FROM story_news_item_attribute snia WHERE snia.news_item_attribute_id = attr.id
-          )
-          AND NOT EXISTS (
-              SELECT 1 FROM news_item_news_item_attribute ninia WHERE ninia.news_item_attribute_id = attr.id
-          );
-        """,
+        _restore_report_tags_to_news_item_tags,
     ),
     step(
         """

--- a/src/core/tests/unit/test_uuidv7_primary_keys.py
+++ b/src/core/tests/unit/test_uuidv7_primary_keys.py
@@ -96,6 +96,21 @@ def test_representative_converted_seeded_models_use_string_ids(app):
         assert admin.roles[0].id == role.id
 
 
+def test_seeded_product_types_resolve_legacy_report_type_references(app):
+    with app.app_context():
+        product_type = ProductType.filter_by_title("Default PDF Presenter")
+
+        assert product_type is not None
+        assert len(product_type.report_types) == 4
+        assert {report_type.title for report_type in product_type.report_types} == {
+            "OSINT Report",
+            "Disinformation",
+            "Vulnerability Report",
+            "CERT Report",
+        }
+        assert all(isinstance(report_type.id, str) for report_type in product_type.report_types)
+
+
 def test_task_lookup_supports_preserved_legacy_job_id(app, session):
     with app.app_context():
         task = Task(id="legacy-job-for-uuid-test")


### PR DESCRIPTION
Two fixes:

1) In pre_seed_data.py, report_item_types were hard-coded as integers -> creation of product_types (that referenced these report_item_types by id was not possible)

2) Changed last migration to insert an additional id colum with a randomly generated uuid