### PR TITLE
Integrate driver.js and add poc  tour functionality for Assess page

### DIFF
--- a/src/frontend/deno.json
+++ b/src/frontend/deno.json
@@ -5,6 +5,7 @@
     "alpinejs": "npm:alpinejs@^3.15.12",
     "choices.js": "npm:choices.js@^11.2.3",
     "daisyui": "npm:daisyui@^5.5.20",
+    "driver.js": "npm:driver.js@^1.4.0",
     "fuse.js": "npm:fuse.js@^7.3.0",
     "highlight-search-term": "npm:highlight-search-term@^1.0.3",
     "htmx-ext-response-targets": "npm:htmx-ext-response-targets@^2.0.4",

--- a/src/frontend/deno.lock
+++ b/src/frontend/deno.lock
@@ -5,16 +5,23 @@
     "npm:@codemirror/commands@^6.10.3": "6.10.3",
     "npm:@codemirror/language@*": "6.12.3",
     "npm:@codemirror/language@^6.12.3": "6.12.3",
+    "npm:@codemirror/legacy-modes@*": "6.5.3",
     "npm:@codemirror/legacy-modes@^6.5.3": "6.5.3",
     "npm:@codemirror/merge@^6.12.1": "6.12.1",
     "npm:@codemirror/state@*": "6.6.0",
     "npm:@codemirror/state@^6.6.0": "6.6.0",
+    "npm:@codemirror/view@*": "6.43.0",
     "npm:@codemirror/view@^6.43.0": "6.43.0",
+    "npm:@tailwindcss/cli@*": "4.3.0",
     "npm:@tailwindcss/cli@^4.3.0": "4.3.0",
+    "npm:alpinejs@*": "3.15.12",
     "npm:alpinejs@^3.15.12": "3.15.12",
+    "npm:choices.js@*": "11.2.3",
     "npm:choices.js@^11.2.3": "11.2.3",
     "npm:codemirror@^6.0.2": "6.0.2",
     "npm:daisyui@^5.5.20": "5.5.20",
+    "npm:driver.js@*": "1.4.0",
+    "npm:driver.js@^1.4.0": "1.4.0",
     "npm:fuse.js@*": "7.3.0",
     "npm:fuse.js@^7.3.0": "7.3.0",
     "npm:highlight-search-term@*": "1.0.3",
@@ -384,6 +391,9 @@
     "detect-libc@2.1.2": {
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
+    "driver.js@1.4.0": {
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew=="
+    },
     "enhanced-resolve@5.21.3": {
       "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
       "dependencies": [
@@ -549,6 +559,7 @@
       "npm:choices.js@^11.2.3",
       "npm:codemirror@^6.0.2",
       "npm:daisyui@^5.5.20",
+      "npm:driver.js@^1.4.0",
       "npm:fuse.js@^7.3.0",
       "npm:highlight-search-term@^1.0.3",
       "npm:htmx-ext-response-targets@^2.0.4",

--- a/src/frontend/frontend/static/css/input.css
+++ b/src/frontend/frontend/static/css/input.css
@@ -48,6 +48,55 @@
     background-color: var(--color-primary) !important;
     color: var(--color-primary-content) !important;
   }
+
+  .driver-popover.taranis-driver-popover {
+    background-color: var(--color-base-100);
+    border: 1px solid color-mix(in oklab, var(--color-base-content) 15%, transparent);
+    border-radius: var(--radius-box);
+    box-shadow: 0 18px 48px color-mix(in oklab, var(--color-base-content) 16%, transparent);
+    color: var(--color-base-content);
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-title,
+  .driver-popover.taranis-driver-popover .driver-popover-description,
+  .driver-popover.taranis-driver-popover .driver-popover-progress-text,
+  .driver-popover.taranis-driver-popover .driver-popover-close-btn {
+    color: var(--color-base-content);
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-close-btn:hover {
+    color: color-mix(in oklab, var(--color-base-content) 80%, var(--color-primary));
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-prev-btn,
+  .driver-popover.taranis-driver-popover .driver-popover-next-btn {
+    background: var(--color-primary);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-field);
+    color: var(--color-primary-content);
+    text-shadow: none;
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-prev-btn:hover,
+  .driver-popover.taranis-driver-popover .driver-popover-next-btn:hover {
+    background: color-mix(in oklab, var(--color-primary) 88%, var(--color-base-100));
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-arrow-side-left.driver-popover-arrow {
+    border-left-color: var(--color-base-100);
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-arrow-side-right.driver-popover-arrow {
+    border-right-color: var(--color-base-100);
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-arrow-side-top.driver-popover-arrow {
+    border-top-color: var(--color-base-100);
+  }
+
+  .driver-popover.taranis-driver-popover .driver-popover-arrow-side-bottom.driver-popover-arrow {
+    border-bottom-color: var(--color-base-100);
+  }
 }
 
 @layer base {

--- a/src/frontend/frontend/static/js/main.js
+++ b/src/frontend/frontend/static/js/main.js
@@ -5,6 +5,63 @@ function getCSRFToken() {
     ?.split("=")[1];
 }
 
+const defaultTourConfig = {
+  allowClose: true,
+  popoverClass: "taranis-driver-popover",
+  showProgress: true,
+  smoothScroll: true,
+};
+
+function resolveTourElement(element) {
+  if (!element) {
+    return null;
+  }
+
+  if (typeof element === "string") {
+    return document.querySelector(element);
+  }
+
+  if (typeof element === "function") {
+    const resolved = element();
+    return resolved instanceof Element ? resolved : null;
+  }
+
+  return element instanceof Element ? element : null;
+}
+
+function filterTourSteps(steps) {
+  if (!Array.isArray(steps)) {
+    return steps;
+  }
+
+  return steps.filter((step) => {
+    if (!step || !("element" in step) || step.element == null) {
+      return true;
+    }
+
+    return resolveTourElement(step.element) !== null;
+  });
+}
+
+function createTour(config = {}) {
+  if (typeof driver !== "function") {
+    throw new Error("Driver.js is not available in the current bundle.");
+  }
+
+  const resolvedConfig = {
+    ...defaultTourConfig,
+    ...config,
+    steps: filterTourSteps(config.steps),
+  };
+
+  return driver(resolvedConfig);
+}
+
+window.createTour = createTour;
+window.taranisTour = {
+  create: createTour,
+};
+
 function getConfirmOptions(el, question) {
   const title = el.getAttribute("data-confirm-title") || question;
   const confirmButtonText = el.getAttribute("data-confirm-confirm") || (el.hasAttribute("hx-delete") ? "Delete" : "OK");

--- a/src/frontend/frontend/templates/assess/sidebar/sidebar.html
+++ b/src/frontend/frontend/templates/assess/sidebar/sidebar.html
@@ -84,6 +84,83 @@ document.addEventListener('htmx:afterSwap', function (event) {
   }
 });
 
+function getAssessTourSteps() {
+  return [
+    {
+      element: "#assess-search-form",
+      popover: {
+        title: "Search stories",
+        description: "Start with a keyword search. Ctrl+K focuses this field from anywhere on the Assess page.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: "#tag_search",
+      popover: {
+        title: "Filter by tags",
+        description: "Search tags here and add them to the selected tag list to narrow the story set.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: "#source-filter",
+      popover: {
+        title: "Scope by source",
+        description: "Choose individual OSINT sources or source groups to restrict the feed.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: "#assess-sidebar [aria-label='Time presets']",
+      popover: {
+        title: "Use time filters",
+        description: "Use quick presets or the From and To fields to focus on the period you care about.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: "[data-testid='assess_story_count']",
+      popover: {
+        title: "Track the result set",
+        description: "This counter shows how many stories are currently visible compared to the total matching set.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: "[data-testid='assess-select-all-button']",
+      popover: {
+        title: "Take bulk actions",
+        description: "Select visible stories here, then cluster them, add them to a report, or mark them in bulk.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+  ];
+}
+
+function startAssessTour() {
+  if (window.assessSidebarTour && typeof window.assessSidebarTour.destroy === "function") {
+    window.assessSidebarTour.destroy();
+  }
+
+  const tour = createTour({
+    nextBtnText: "Next",
+    prevBtnText: "Back",
+    doneBtnText: "Done",
+    steps: getAssessTourSteps(),
+  });
+
+  window.assessSidebarTour = tour;
+  tour.drive();
+}
+
+window.startAssessTour = startAssessTour;
+
 </script>
 
 <div class="p-4 space-y-4">
@@ -295,6 +372,10 @@ document.addEventListener('htmx:afterSwap', function (event) {
     {{ heroicon_outline('pencil-square', class='h-4 w-4') }}
     Create new item
   </a>
+  <button type="button" class="btn btn-accent btn-sm w-full" data-testid="assess-tour-button" onclick="startAssessTour()">
+    {{ heroicon_outline('sparkles', class='h-4 w-4') }}
+    Show Assess tour
+  </button>
 </div>
 
 {% include "partials/keyboard_hint.html" %}

--- a/src/frontend/tests/playwright/test_e2e_user.py
+++ b/src/frontend/tests/playwright/test_e2e_user.py
@@ -59,6 +59,8 @@ class TestEndToEndUser(BaseE2ETest):
 
         def test_dashboard_edit_settings(page: Page) -> None:
             expect(page.get_by_role("link", name="Taranis AI Logo")).to_be_visible()
+            assert page.evaluate("typeof window.driver === 'function'")
+            assert page.evaluate("typeof window.createTour === 'function'")
 
             page.locator("#dashboard").get_by_role("link", name="Assess").click()
             expect(page.get_by_test_id("assess_story_count")).to_be_visible()
@@ -263,6 +265,10 @@ class TestEndToEndUser(BaseE2ETest):
             expect(page.get_by_test_id("assess_story_count")).to_be_visible(timeout=30000)
             visible_count, total_count = self._get_assess_story_counts(page)
             assert total_count >= visible_count > 0
+            page.get_by_test_id("assess-tour-button").click()
+            expect(page.locator(".driver-popover")).to_be_visible()
+            expect(page.locator(".driver-popover-title")).to_contain_text("Search stories")
+            page.locator(".driver-popover-close-btn").click()
             page.screenshot(path="./tests/playwright/screenshots/user_assess.png")
             return total_count
 

--- a/src/frontend/vendor.js
+++ b/src/frontend/vendor.js
@@ -3,11 +3,13 @@ import Alpine from "npm:alpinejs";
 
 import Sortable from "npm:sortablejs";
 import Choices from "npm:choices.js";
+import { driver } from "npm:driver.js";
 import Fuse from "npm:fuse.js";
 import Swal from "npm:sweetalert2";
 import { highlightSearchTerm } from "npm:highlight-search-term";
 
 import "npm:choices.js/public/assets/styles/choices.min.css";
+import "npm:driver.js/dist/driver.css";
 import "npm:htmx-ext-response-targets";
 import "npm:sweetalert2/dist/sweetalert2.min.css";
 
@@ -16,6 +18,7 @@ window.Alpine = Alpine;
 
 window.Sortable = Sortable;
 window.Choices = Choices;
+window.driver = driver;
 window.Fuse = Fuse;
 window.Swal = Swal;
 window.highlightSearchTerm = highlightSearchTerm;


### PR DESCRIPTION
🚨Please review the [guidelines for contributing](https://github.com/taranis-ai/.github/blob/master/CONTRIBUTING.md) to this repository.

## Summary by Sourcery

Integrate a reusable Driver.js-based guided tour system and add an initial Assess page sidebar tour, including styling and tests.

New Features:
- Add a generic tour creation helper backed by Driver.js and expose it on the global window object.
- Add an Assess page sidebar guided tour with steps covering key search and bulk-action controls, accessible via a new UI button.

Enhancements:
- Style Driver.js popovers to match the Taranis theme and improve visual integration with the app UI.

Build:
- Add Driver.js as a frontend dependency and wire it into the shared vendor bundle.

Tests:
- Extend Playwright end-to-end tests to verify Driver.js availability, tour creation, and the Assess tour popover content.