### PR TITLE
Fix presenter id cast to int

### DIFF
--- a/src/worker/worker/core_api.py
+++ b/src/worker/worker/core_api.py
@@ -188,17 +188,17 @@ class CoreApi:
     def get_publisher(self, publisher_id: str) -> dict | None:
         return self.api_get(f"/worker/publishers/{publisher_id}")
 
-    def get_template(self, presenter: int) -> str | None:
-        url = f"{self.api_url}/worker/presenters/{presenter}"
+    def get_template(self, presenter_id: str) -> str | None:
+        url = f"{self.api_url}/worker/presenters/{presenter_id}"
         response = requests.get(url=url, headers=self.headers, verify=self.verify, timeout=self.timeout)
         return response.text if response.ok else None
 
-    def get_word_list(self, word_list_id: int) -> dict | None:
+    def get_word_list(self, word_list_id: str) -> dict | None:
         return self.api_get(
             url=f"/worker/word-list/{word_list_id}",
         )
 
-    def update_word_list(self, word_list_id: int, content: str | dict | list, content_type: str) -> dict | None:
+    def update_word_list(self, word_list_id: str, content: str | dict | list, content_type: str) -> dict | None:
         """Update a word list with new content.
 
         Args:

--- a/src/worker/worker/misc/misc_tasks.py
+++ b/src/worker/worker/misc/misc_tasks.py
@@ -83,7 +83,7 @@ def _reschedule_cleanup():
         logger.error(f"Failed to reschedule token cleanup: {e}")
 
 
-def gather_word_list(word_list_id: int):
+def gather_word_list(word_list_id: str):
     """Gather and update a word list.
 
     Args:

--- a/src/worker/worker/misc/wordlist_update.py
+++ b/src/worker/worker/misc/wordlist_update.py
@@ -4,7 +4,7 @@ from worker.core_api import CoreApi
 from worker.log import logger
 
 
-def update_wordlist(word_list_id: int):
+def update_wordlist(word_list_id: str):
     core_api = CoreApi()
 
     if not word_list_id:

--- a/src/worker/worker/presenters/presenter_tasks.py
+++ b/src/worker/worker/presenters/presenter_tasks.py
@@ -42,7 +42,7 @@ def presenter_task(product_id: str):
     worker_type = presenter.type
 
     # Get template if needed
-    type_id: int = int(product["type_id"])
+    type_id = str(product["type_id"])
     if "TEMPLATE_PATH" in product.get("parameters", {}):
         template = _get_template(core_api, type_id)
     else:
@@ -113,7 +113,7 @@ def _get_product(core_api: CoreApi, product_id: str) -> dict[str, Any]:
     return product
 
 
-def _get_template(core_api: CoreApi, presenter_id: int) -> str:
+def _get_template(core_api: CoreApi, presenter_id: str) -> str:
     """Fetch template from core API.
 
     Args:

--- a/src/worker/worker/tests/presenters/presenters_test_data.py
+++ b/src/worker/worker/tests/presenters/presenters_test_data.py
@@ -25,7 +25,7 @@ test_product = {
     "mime_type": "text/plain",
     "title": "A Test Report",
     "type": "text_presenter",
-    "type_id": 2,
+    "type_id": "0a428364-3af6-7a35-95fe-9c6f1f9df201",
     "report_items": [
         {
             "title": "The very best report you have ever seen",
@@ -160,7 +160,7 @@ test_stix_product = {
             "created": "2025-09-26T14:31:51.329753+02:00",
             "id": "09e63054-309a-459e-9dca-7544749e86dc",
             "last_updated": "2025-09-26T14:31:51.329758+02:00",
-            "report_item_type_id": 3,
+            "report_item_type_id": "0a428364-3af6-7a35-95fe-9c6f1f9df202",
             "stories": [
                 {
                     "attributes": {"TLP": {"key": "TLP", "value": "clear"}},
@@ -206,5 +206,5 @@ test_stix_product = {
     ],
     "title": "Stix product",
     "type": "stix_presenter",
-    "type_id": 6,
+    "type_id": "0a428364-3af6-7a35-95fe-9c6f1f9df203",
 }

--- a/src/worker/worker/tests/publishers/publishers_data.py
+++ b/src/worker/worker/tests/publishers/publishers_data.py
@@ -26,10 +26,10 @@ email_publisher_admin_input_no_smtp_address = {
 
 
 product_text = {
-    "id": 1,
+    "id": "0a428364-3af6-7a35-95fe-9c6f1f9df204",
     "title": "Test_Text_Product",
     "type": "text_presenter",
-    "type_id": 3,
+    "type_id": "0a428364-3af6-7a35-95fe-9c6f1f9df205",
     "mime_type": "text/plain",
     "report_items": [{"title": "test title"}],
 }

--- a/src/worker/worker/tests/testdata.py
+++ b/src/worker/worker/tests/testdata.py
@@ -161,7 +161,7 @@ news_items = [
 
 include_list = [
     {
-        "id": 1,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df206",
         "name": "includelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -176,7 +176,7 @@ include_list = [
 
 exclude_list = [
     {
-        "id": 2,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df207",
         "name": "excludelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -190,7 +190,7 @@ exclude_list = [
 
 include_exclude_list = [
     {
-        "id": 1,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df208",
         "name": "includelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -202,7 +202,7 @@ include_exclude_list = [
         ],
     },
     {
-        "id": 2,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df209",
         "name": "excludelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -216,7 +216,7 @@ include_exclude_list = [
 
 multiple_include_exclude_list = [
     {
-        "id": 1,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20a",
         "name": "includelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -224,7 +224,7 @@ multiple_include_exclude_list = [
         "entries": [{"value": "Azure Data Explorer", "category": "CVE_PRODUCT", "description": ""}],
     },
     {
-        "id": 2,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20b",
         "name": "includelist2",
         "description": "dummy test data 2",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -232,7 +232,7 @@ multiple_include_exclude_list = [
         "entries": [{"value": "Bing", "category": "MISC", "description": ""}],
     },
     {
-        "id": 3,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20c",
         "name": "excludelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -240,7 +240,7 @@ multiple_include_exclude_list = [
         "entries": [{"value": "iPhone-Event", "category": "MISC", "description": ""}],
     },
     {
-        "id": 4,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20d",
         "name": "excludelist2",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -251,7 +251,7 @@ multiple_include_exclude_list = [
 
 include_multiple_list = [
     {
-        "id": 1,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20e",
         "name": "includelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -259,7 +259,7 @@ include_multiple_list = [
         "entries": [{"value": "Azure Data Explorer", "category": "CVE_PRODUCT", "description": ""}],
     },
     {
-        "id": 2,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df20f",
         "name": "includelist2",
         "description": "dummy test data 2",
         "usage": ["COLLECTOR_INCLUDELIST", "TAGGING_BOT"],
@@ -270,7 +270,7 @@ include_multiple_list = [
 
 exclude_multiple_list = [
     {
-        "id": 1,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df210",
         "name": "excludelist",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -278,7 +278,7 @@ exclude_multiple_list = [
         "entries": [{"value": "iPhone-Event", "category": "MISC", "description": ""}],
     },
     {
-        "id": 2,
+        "id": "0a428364-3af6-7a35-95fe-9c6f1f9df211",
         "name": "excludelist2",
         "description": "dummy test data",
         "usage": ["COLLECTOR_EXCLUDELIST", "TAGGING_BOT"],
@@ -291,15 +291,15 @@ web_collector_url = "https://raw.example.com/testweb.html"
 web_collector_ref_url = "https://raw.example.com/test/url/index.html"
 web_collector_result_content = "In an era where digital security is paramount, the role of National Computer Emergency Response Teams (CERTs) has never been more critical."
 web_collector_fav_icon_url = "https://raw.example.com/favicon.ico"
-web_collector_source_data = {"id": 1, "parameters": {"WEB_URL": "https://raw.example.com/testweb.html"}}
+web_collector_source_data = {"id": "0a428364-3af6-7a35-95fe-9c6f1f9df212", "parameters": {"WEB_URL": "https://raw.example.com/testweb.html"}}
 web_collector_source_xpath = "/html/body/div/div[3]"
 web_collector_result_title = "National CERT Importance"
 
 rss_collector_url = "https://rss.example.com/en/category/security-news/feed/"
-rss_collector_source_data = {"id": 1, "parameters": {"FEED_URL": f"{rss_collector_url}"}}
+rss_collector_source_data = {"id": "0a428364-3af6-7a35-95fe-9c6f1f9df213", "parameters": {"FEED_URL": f"{rss_collector_url}"}}
 rss_collector_source_data_complex = {
     "description": "",
-    "id": "1",
+    "id": "0a428364-3af6-7a35-95fe-9c6f1f9df214",
     "last_attempted": "2000-01-01T00:00:00.000000",
     "last_collected": "2000-01-01T00:00:00.000000",
     "last_error_message": None,
@@ -314,10 +314,16 @@ rss_collector_source_data_complex = {
     "word_lists": [],
 }
 rss_collector_url_not_modified = "https://rss.example.com/en/archive/feed/"
-rss_collector_source_data_not_modified = {"id": 1, "parameters": {"FEED_URL": f"{rss_collector_url_not_modified}"}}
+rss_collector_source_data_not_modified = {
+    "id": "0a428364-3af6-7a35-95fe-9c6f1f9df215",
+    "parameters": {"FEED_URL": f"{rss_collector_url_not_modified}"},
+}
 
 rss_collector_url_no_content = "https://rss.example.com/en/wrong-feed"
-rss_collector_source_data_no_content = {"id": 1, "parameters": {"FEED_URL": f"{rss_collector_url_no_content}"}}
+rss_collector_source_data_no_content = {
+    "id": "0a428364-3af6-7a35-95fe-9c6f1f9df216",
+    "parameters": {"FEED_URL": f"{rss_collector_url_no_content}"},
+}
 
 rss_collector_fav_icon_url = "https://rss.example.com/favicon.ico"
 rss_collector_targets = [


### PR DESCRIPTION
In presenter_tasks.py, the product_type id was still cast to int.
This caused no problems on migrated database, because you can cast a str that was formerly an int, to int
But on fresh dbs, this throws, because you cant cast a uuid to int

Also adapted some type-hints and test data

## Summary by Sourcery

Adapt worker presenter and word list handling to use string UUID identifiers instead of integers.

Bug Fixes:
- Fix presenter template retrieval by avoiding casting UUID product_type identifiers to integers, preventing crashes on fresh databases.

Enhancements:
- Update CoreApi methods and misc tasks to accept string IDs for presenters and word lists for consistency with backend data types.

Tests:
- Adjust test fixtures and presenter/publisher test data to use UUID string IDs instead of integer IDs.