### PR TITLE
Fix llm-bot healthcheck dependency

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -228,7 +228,7 @@ services:
         condition: always
     image: "${DOCKER_IMAGE_NAMESPACE}/taranis-llm-bot:${TARANIS_BOT_TAG:-stable}"
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import requests; requests.get('http://localhost:${LLM_BOT_PORT:-8000}/health', timeout=5).raise_for_status()\""]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:${LLM_BOT_PORT:-8000}/health', timeout=5).read()\""]
       interval: 1m30s
       timeout: 30s
       retries: 5


### PR DESCRIPTION
## Summary
- Replace the llm-bot healthcheck dependency on third-party `requests` with Python stdlib `urllib.request`
- Prevent the container from reporting unhealthy when the app health endpoint is actually available

## Verification
- Ran `docker compose -p taranis config` successfully
- Recreated `llm-bot` locally and verified Docker health changed to healthy
- Verified Taranis API responds with `{ "isalive": true }` at `http://127.0.0.1:8080/api`