### PR TITLE
Hide empty sidebar

### DIFF
--- a/src/frontend/frontend/templates/base.html
+++ b/src/frontend/frontend/templates/base.html
@@ -23,7 +23,7 @@
         data-confirm-delete="{{ _('Delete') }}"
         data-confirm-cancel="{{ _('Cancel') }}"
         hx-ext="response-targets"
-        x-data="{ sidebarOpen: {{ 'true' if _show_sidebar else 'false' }}, init() { if (window.self !== window.top) this.sidebarOpen = false } }">
+        x-data="{ sidebarOpen: {{ 'true' if _show_sidebar and templates and templates.get("sidebar_template") else 'false' }}, init() { if (window.self !== window.top) this.sidebarOpen = false } }">
     {% include "partials/viewport_notice.html" %}
     {% include "partials/sidebar.html" %}
 

--- a/src/frontend/frontend/templates/partials/navbar.html
+++ b/src/frontend/frontend/templates/partials/navbar.html
@@ -1,7 +1,9 @@
 <div class="flex items-center space-x-4">
-  <button @click="sidebarOpen = !sidebarOpen" class="btn btn-ghost btn-square mr-4" aria-label="{{ _('Toggle sidebar') }}">
-    {{ heroicon_outline("bars-3") }}
-  </button>
+  {% if _show_sidebar and templates and templates.get('sidebar_template') %}
+    <button @click="sidebarOpen = !sidebarOpen" class="btn btn-ghost btn-square mr-4" aria-label="{{ _('Toggle sidebar') }}">
+      {{ heroicon_outline("bars-3") }}
+    </button>
+  {% endif %}
   <a href="{{ url_for('base.dashboard') }}" class="btn btn-ghost normal-case text-xl">
     <img src="{{ url_for('static', filename='assets/taranis-logo.svg') }}" alt="{{ _('Taranis AI Logo') }}" height="auto" width="auto" class="h-8">
   </a>

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -3,13 +3,14 @@ import json
 from datetime import datetime
 from io import BytesIO
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
 from flask import render_template
-from models.admin import OSINTSource
-from models.task import Task
+from models.admin import OSINTSource, ReportItemType
+from models.task import Task, TaskResultEnvelope
 from models.types import COLLECTOR_TYPES
 
 from frontend.cache import add_user_to_cache, cache
@@ -19,6 +20,8 @@ from frontend.views.admin_views.report_type_views import ReportItemTypeView
 from frontend.views.admin_views.source_views import SourceView
 from frontend.views.admin_views.word_list_views import WordListView
 from frontend.views.base_view import BaseView
+from frontend.views.product_views import ProductView
+from frontend.views.report_views import ReportItemView
 
 
 _VALID_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg=="
@@ -33,7 +36,7 @@ ADMIN_VIEWS = [(name, cls) for name, cls in VIEW_ITEMS if getattr(cls, "_is_admi
 ADMIN_IDS = [name for name, _ in ADMIN_VIEWS]
 
 
-def _json_request_body(call) -> dict:
+def _json_request_body(call: Any) -> dict[str, Any]:
     body = call.request.body
     if isinstance(body, bytes):
         body = body.decode("utf-8")
@@ -305,7 +308,12 @@ class TestSourceView:
         task_result = Task(
             id="source_preview_42",
             status="FAILURE",
-            result={"message": "Connection refused", "reason": "preview_failed", "retryable": False, "data": None},
+            result=TaskResultEnvelope(
+                message="Connection refused",
+                reason="preview_failed",
+                retryable=False,
+                data=None,
+            ),
         )
 
         with app.test_request_context("/"):
@@ -371,14 +379,15 @@ def test_report_item_type_submitted_form_model_uses_shared_normalization(app):
             "csrf_token": "secret",
         },
     ):
-        model = ReportItemTypeView._submitted_form_model()
+        model = cast(ReportItemType | None, ReportItemTypeView._submitted_form_model())
 
     assert model is not None
+    attribute_groups = model.attribute_groups or []
     assert model.title == "Incident Report"
-    assert len(model.attribute_groups or []) == 1
-    assert model.attribute_groups[0].title == "Indicators"
-    assert len(model.attribute_groups[0].attribute_group_items) == 1
-    assert model.attribute_groups[0].attribute_group_items[0].title == "Domain"
+    assert len(attribute_groups) == 1
+    assert attribute_groups[0].title == "Indicators"
+    assert len(attribute_groups[0].attribute_group_items) == 1
+    assert attribute_groups[0].attribute_group_items[0].title == "Domain"
 
 
 def test_osint_source_form_shows_current_icon_and_delete_option(app):
@@ -535,6 +544,45 @@ def test_admin_dashboard_renders_health_card(authenticated_client, auth_user, re
     assert "Pre-seeded" in html
     assert "Redis" in html
     assert "Workers" in html
+
+
+def test_analyze_page_hides_sidebar_toggle_when_no_sidebar(authenticated_client, mock_core_get_endpoints):
+    response = authenticated_client.get(ReportItemView.get_base_route())
+
+    assert response.status_code == 200
+    assert 'aria-label="Toggle sidebar"' not in response.get_data(as_text=True)
+
+
+def test_publish_page_hides_sidebar_toggle_when_no_sidebar(authenticated_client, mock_core_get_endpoints, responses_mock):
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/publish/product-types",
+        json={"items": [], "total_count": 0},
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/publish/publisher-presets",
+        json={"items": [], "total_count": 0},
+    )
+
+    response = authenticated_client.get(ProductView.get_base_route())
+
+    assert response.status_code == 200
+    assert 'aria-label="Toggle sidebar"' not in response.get_data(as_text=True)
+
+
+def test_assess_page_shows_sidebar_toggle_when_sidebar_exists(authenticated_client, responses_mock):
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/filter-lists",
+        json={"tags": [], "sources": [], "groups": [], "languages": []},
+    )
+    responses_mock.get(
+        f"{Config.TARANIS_CORE_URL}/assess/stories",
+        json={"items": [], "total_count": 0},
+    )
+
+    response = authenticated_client.get("/assess")
+
+    assert response.status_code == 200
+    assert 'aria-label="Toggle sidebar"' in response.get_data(as_text=True)
 
 
 def test_admin_dashboard_renders_frontend_release_info_when_core_build_info_fails(


### PR DESCRIPTION
Currently, you can toggle the sidebar even in views, where there is no sidebar template, e.g. in Analyze:

<img width="743" height="280" alt="image" src="https://github.com/user-attachments/assets/3f1efa7b-26ec-4e95-82ff-8bd73976f435" />

I propose to hide the toggle alltogether, in this case:

<img width="743" height="280" alt="image" src="https://github.com/user-attachments/assets/fadaa7b3-ce17-402e-b733-bc03484d773d" />

