### PR TITLE
Custom RQ Job Timeout

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -48,6 +48,7 @@ Core owns frontend cache invalidation for write operations.
 - `CACHE_ENABLED=true|false` toggles frontend-cache invalidation support in core
 - `CACHE_REDIS_URL` optionally overrides the Redis URL used for frontend cache invalidation
 - `CACHE_REDIS_PASSWORD` optionally overrides the Redis password used for frontend cache invalidation
+- `RQ_DEFAULT_JOB_TIMEOUT` sets the default RQ job execution timeout in seconds for queues created by core
 - when the cache-specific settings are unset, core falls back to `REDIS_URL` and `REDIS_PASSWORD`
 - unit tests keep cache disabled by default through `build_config_overrides`
 - admin configuration writes under `/api/config/*` currently invalidate the full frontend cache by design

--- a/src/core/core/config.py
+++ b/src/core/core/config.py
@@ -78,8 +78,10 @@ class Settings(BaseSettings):
     @model_validator(mode="after")  # type: ignore
     def set_sqlalchemy_uri(self) -> "Settings":
         if not self.SQLALCHEMY_DATABASE_URI or len(self.SQLALCHEMY_DATABASE_URI) < 1:
-            self.SQLALCHEMY_DATABASE_URI = (
-                f"{self.SQLALCHEMY_SCHEMA}://{self.DB_USER}:{self.DB_PASSWORD.get_secret_value()}@{self.DB_URL}/{self.DB_DATABASE}"
+            object.__setattr__(
+                self,
+                "SQLALCHEMY_DATABASE_URI",
+                f"{self.SQLALCHEMY_SCHEMA}://{self.DB_USER}:{self.DB_PASSWORD.get_secret_value()}@{self.DB_URL}/{self.DB_DATABASE}",
             )
         if self.SQLALCHEMY_DATABASE_URI.startswith("sqlite:"):
             self.SQLALCHEMY_ENGINE_OPTIONS.update({"connect_args": {"timeout": self.SQLALCHEMY_CONNECT_TIMEOUT}})
@@ -97,7 +99,7 @@ class Settings(BaseSettings):
         if self.SQLALCHEMY_POOL_RECYCLE is not None:
             update_payload["pool_recycle"] = self.SQLALCHEMY_POOL_RECYCLE
         self.SQLALCHEMY_ENGINE_OPTIONS.update(update_payload)
-        self.SQLALCHEMY_DATABASE_URI_MASK = mask_db_uri(self.SQLALCHEMY_DATABASE_URI)
+        object.__setattr__(self, "SQLALCHEMY_DATABASE_URI_MASK", mask_db_uri(self.SQLALCHEMY_DATABASE_URI))
         return self
 
     TARANIS_AUTHENTICATOR: Literal["database", "openid", "external", "dev"] = "database"
@@ -115,6 +117,7 @@ class Settings(BaseSettings):
 
     REDIS_URL: str = "redis://localhost:6379"
     REDIS_PASSWORD: SecretStr | None = None
+    RQ_DEFAULT_JOB_TIMEOUT: int = 180
     CACHE_ENABLED: bool = CACHE_ENABLED_DEFAULT
     CACHE_DEFAULT_TIMEOUT: int = CACHE_DEFAULT_TIMEOUT_DEFAULT
     CACHE_KEY_PREFIX: str = CACHE_KEY_PREFIX_DEFAULT

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -32,6 +32,7 @@ import contextlib
 import hashlib
 import json
 import time
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -225,7 +226,11 @@ class QueueManager:
 
         # Create queue instances
         for queue_name in self.queue_names:
-            self._queues[queue_name] = Queue(queue_name, connection=self._redis)
+            self._queues[queue_name] = Queue(
+                queue_name,
+                connection=self._redis,
+                default_timeout=Config.RQ_DEFAULT_JOB_TIMEOUT,
+            )
 
         app.extensions["rq"] = self
         logger.info(f"QueueManager initialized with Redis: {self.redis_url}")
@@ -363,10 +368,14 @@ class QueueManager:
             with contextlib.suppress(Exception):
                 if hasattr(queue, "get_job_ids"):
                     queued_ids = list(queue.get_job_ids())
-                elif callable(getattr(queue, "job_ids", None)):
-                    queued_ids = list(queue.job_ids())
-                elif getattr(queue, "job_ids", None) is not None:
-                    queued_ids = list(queue.job_ids)
+                else:
+                    job_ids_attr: object | None = getattr(queue, "job_ids", None)
+                    if callable(job_ids_attr):
+                        job_ids_value = job_ids_attr()
+                        if isinstance(job_ids_value, Iterable):
+                            queued_ids = list(job_ids_value)
+                    elif isinstance(job_ids_attr, Iterable):
+                        queued_ids = list(job_ids_attr)
 
             for job_id in queued_ids:
                 if not matches(job_id) or job_id in removed_ids:

--- a/src/core/tests/unit/conftest.py
+++ b/src/core/tests/unit/conftest.py
@@ -1,0 +1,21 @@
+from collections.abc import Callable
+from typing import Any
+
+
+class FakeRedis:
+    def ping(self):
+        return True
+
+
+def fake_queue_factory(queue_calls: list[dict[str, object]]) -> Callable[..., object]:
+    class FakeQueue:
+        def __init__(self, name: str, connection: object | None = None, default_timeout: int | None = None, **kwargs: Any):
+            queue_calls.append(
+                {
+                    "name": name,
+                    "connection": connection,
+                    "default_timeout": default_timeout,
+                }
+            )
+
+    return FakeQueue

--- a/src/core/tests/unit/test_queue_manager_timeout.py
+++ b/src/core/tests/unit/test_queue_manager_timeout.py
@@ -1,36 +1,43 @@
 from flask import Flask
 
+from core.config import Config, Settings
 from core.managers.queue_manager import QueueManager
+from tests.unit.conftest import FakeRedis, fake_queue_factory
+
+
+def _build_queue_manager(monkeypatch, queue_calls: list[dict[str, object]], timeout: int | None = None):
+    redis_conn = FakeRedis()
+
+    monkeypatch.setattr("core.managers.queue_manager.Redis.from_url", lambda *args, **kwargs: redis_conn)
+    monkeypatch.setattr("core.managers.queue_manager.Queue", fake_queue_factory(queue_calls))
+    monkeypatch.setattr("core.managers.queue_manager.Config.REDIS_PASSWORD", None)
+    if timeout is not None:
+        monkeypatch.setattr("core.managers.queue_manager.Config.RQ_DEFAULT_JOB_TIMEOUT", timeout)
+
+    app = Flask(__name__)
+    queue_manager = QueueManager(app)
+    return queue_manager, redis_conn
 
 
 def test_queue_manager_initializes_queues_with_configured_default_timeout(monkeypatch):
     queue_calls: list[dict[str, object]] = []
-
-    class FakeRedis:
-        def ping(self):
-            return True
-
-    class FakeQueue:
-        def __init__(self, name, connection=None, default_timeout=None, **kwargs):
-            queue_calls.append(
-                {
-                    "name": name,
-                    "connection": connection,
-                    "default_timeout": default_timeout,
-                }
-            )
-
-    redis_conn = FakeRedis()
-
-    monkeypatch.setattr("core.managers.queue_manager.Redis.from_url", lambda *args, **kwargs: redis_conn)
-    monkeypatch.setattr("core.managers.queue_manager.Queue", FakeQueue)
-    monkeypatch.setattr("core.managers.queue_manager.Config.REDIS_PASSWORD", None)
-    monkeypatch.setattr("core.managers.queue_manager.Config.RQ_DEFAULT_JOB_TIMEOUT", 900)
-
-    app = Flask(__name__)
-    queue_manager = QueueManager(app)
+    queue_manager, redis_conn = _build_queue_manager(monkeypatch, queue_calls, timeout=900)
 
     assert queue_manager.error == ""
     assert [call["name"] for call in queue_calls] == queue_manager.queue_names
     assert all(call["connection"] is redis_conn for call in queue_calls)
     assert all(call["default_timeout"] == 900 for call in queue_calls)
+
+
+def test_queue_manager_initializes_queues_with_default_timeout(monkeypatch):
+    queue_calls: list[dict[str, object]] = []
+    queue_manager, redis_conn = _build_queue_manager(monkeypatch, queue_calls)
+
+    assert queue_manager.error == ""
+    assert [call["name"] for call in queue_calls] == queue_manager.queue_names
+    assert all(call["connection"] is redis_conn for call in queue_calls)
+    assert all(call["default_timeout"] == Config.RQ_DEFAULT_JOB_TIMEOUT for call in queue_calls)
+
+
+def test_core_settings_default_rq_timeout_is_180():
+    assert Settings.model_fields["RQ_DEFAULT_JOB_TIMEOUT"].default == 180

--- a/src/core/tests/unit/test_queue_manager_timeout.py
+++ b/src/core/tests/unit/test_queue_manager_timeout.py
@@ -31,11 +31,6 @@ def test_queue_manager_initializes_queues_with_configured_default_timeout(monkey
     queue_manager = QueueManager(app)
 
     assert queue_manager.error == ""
-    assert queue_calls == [
-        {"name": "misc", "connection": redis_conn, "default_timeout": 900},
-        {"name": "bots", "connection": redis_conn, "default_timeout": 900},
-        {"name": "collectors", "connection": redis_conn, "default_timeout": 900},
-        {"name": "presenters", "connection": redis_conn, "default_timeout": 900},
-        {"name": "publishers", "connection": redis_conn, "default_timeout": 900},
-        {"name": "connectors", "connection": redis_conn, "default_timeout": 900},
-    ]
+    assert [call["name"] for call in queue_calls] == queue_manager.queue_names
+    assert all(call["connection"] is redis_conn for call in queue_calls)
+    assert all(call["default_timeout"] == 900 for call in queue_calls)

--- a/src/core/tests/unit/test_queue_manager_timeout.py
+++ b/src/core/tests/unit/test_queue_manager_timeout.py
@@ -1,0 +1,41 @@
+from flask import Flask
+
+from core.managers.queue_manager import QueueManager
+
+
+def test_queue_manager_initializes_queues_with_configured_default_timeout(monkeypatch):
+    queue_calls: list[dict[str, object]] = []
+
+    class FakeRedis:
+        def ping(self):
+            return True
+
+    class FakeQueue:
+        def __init__(self, name, connection=None, default_timeout=None, **kwargs):
+            queue_calls.append(
+                {
+                    "name": name,
+                    "connection": connection,
+                    "default_timeout": default_timeout,
+                }
+            )
+
+    redis_conn = FakeRedis()
+
+    monkeypatch.setattr("core.managers.queue_manager.Redis.from_url", lambda *args, **kwargs: redis_conn)
+    monkeypatch.setattr("core.managers.queue_manager.Queue", FakeQueue)
+    monkeypatch.setattr("core.managers.queue_manager.Config.REDIS_PASSWORD", None)
+    monkeypatch.setattr("core.managers.queue_manager.Config.RQ_DEFAULT_JOB_TIMEOUT", 900)
+
+    app = Flask(__name__)
+    queue_manager = QueueManager(app)
+
+    assert queue_manager.error == ""
+    assert queue_calls == [
+        {"name": "misc", "connection": redis_conn, "default_timeout": 900},
+        {"name": "bots", "connection": redis_conn, "default_timeout": 900},
+        {"name": "collectors", "connection": redis_conn, "default_timeout": 900},
+        {"name": "presenters", "connection": redis_conn, "default_timeout": 900},
+        {"name": "publishers", "connection": redis_conn, "default_timeout": 900},
+        {"name": "connectors", "connection": redis_conn, "default_timeout": 900},
+    ]

--- a/src/frontend/frontend/templates/base.html
+++ b/src/frontend/frontend/templates/base.html
@@ -23,7 +23,7 @@
         data-confirm-delete="{{ _('Delete') }}"
         data-confirm-cancel="{{ _('Cancel') }}"
         hx-ext="response-targets"
-        x-data="{ sidebarOpen: {{ 'true' if _show_sidebar and templates and templates.get("sidebar_template") else 'false' }}, init() { if (window.self !== window.top) this.sidebarOpen = false } }">
+        x-data="{ sidebarOpen: {{ 'true' if _show_sidebar and templates and templates.get('sidebar_template') else 'false' }}, init() { if (window.self !== window.top) this.sidebarOpen = false } }">
     {% include "partials/viewport_notice.html" %}
     {% include "partials/sidebar.html" %}
 

--- a/src/worker/worker/config.py
+++ b/src/worker/worker/config.py
@@ -49,10 +49,10 @@ class Settings(BaseSettings):
         return f"/{v.strip('/')}/"
 
     @model_validator(mode="after")
-    def set_taranis_core(self):
+    def set_taranis_core(self) -> "Settings":
         if self.TARANIS_CORE_URL:
             return self
-        self.TARANIS_CORE_URL = f"http://{self.TARANIS_CORE_HOST}{self.TARANIS_BASE_PATH}api"
+        object.__setattr__(self, "TARANIS_CORE_URL", f"http://{self.TARANIS_CORE_HOST}{self.TARANIS_BASE_PATH}api")
         return self
 
 


### PR DESCRIPTION
Currently, RQ jobs run for max. 180s (which is RQ default)
For story-clustering e.g., jobs can easily take longer than that
Make the max job runtime customizable

## Details

- Add RQ_DEFAULT_JOB_TIMEOUT config to config.py
- override RQ timeout in queue_manager
- add test, update README