### PR TITLE
Fix Add to report (Shift + R) hotkey in Story Edit Mode

### DIFF
--- a/src/frontend/frontend/templates/assess/story_edit_content.html
+++ b/src/frontend/frontend/templates/assess/story_edit_content.html
@@ -63,7 +63,7 @@
           </a>
           <button type="button"
                   class="btn btn-outline btn-sm"
-                  hx-trigger="click, keyup[shiftKey && code == 'R' && canUseAssessShortcut(event)] from:body"
+                  hx-trigger="click, keydown[canUseAssessShortcut(event, 'r')] from:body"
                   hx-get="{{ url_for('assess.report_story') }}"
                   hx-target="body"
                   hx-swap="beforeend"

--- a/src/frontend/tests/unit/views/test_story_view.py
+++ b/src/frontend/tests/unit/views/test_story_view.py
@@ -407,6 +407,7 @@ def test_story_edit_renders_news_item_tag_editor(authenticated_client, responses
 
     assert tree.xpath('//*[@data-testid="edit-newsitem-tags"]')
     assert tree.xpath('//*[@data-testid="news-item-tag-name-input"]')
+    assert "keydown[canUseAssessShortcut(event, 'r')]" in response.text
     assert "resetTags(); tagEditorOpen = false" in response.text
     assert not tree.xpath('//*[@data-testid="tag-name-input"]')
     assert not tree.xpath('//*[@data-testid="tag-value-input"]')


### PR DESCRIPTION
The canUseAssessShortcut signature changed; need to use it in story_edit_content.html to not block the Shift + R hotkey
Use keydown instead of keyup, because it feels more responsive