### PR TITLE
fix broken production CI

### DIFF
--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -22,27 +22,6 @@ env:
   UV_FROZEN: true
 
 jobs:
-  schema_change:
-    name: detect schema changes
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - id: changes
-        run: |
-          if git diff --quiet "${{ github.event.before }}" "${{ github.sha }}" -- \
-            src/core/core/model \
-            src/core/migrations \
-            src/models; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
   test:
     name: pytest
     defaults:
@@ -240,23 +219,3 @@ jobs:
           subject-name: ${{ env.GHCR_IMAGE }}
           subject-digest: ${{ env.MERGED_DIGEST }}
           push-to-registry: true
-
-
-  migration_upgrade:
-    name: migrate released database to master
-    needs: schema_change
-    if: needs.schema_change.outputs.changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Migrate the latest released database
-        env:
-          CONTAINER_CLI: docker
-        run: |
-          BASE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')"
-          BASE_REF="$BASE_REF" ./dev/test_master_to_branch_migration.sh

--- a/.github/workflows/test_schema_migrate.yaml
+++ b/.github/workflows/test_schema_migrate.yaml
@@ -1,0 +1,38 @@
+name: Test schema migration
+
+on:
+  push:
+    paths:
+      - 'src/core/core/model/**'
+      - 'src/core/migrations/**'
+      - 'src/models/**'
+      - '.github/workflows/test_schema_migrate.yaml'
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  migration_upgrade:
+    name: migrate released database to master
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          prune-cache: false
+
+      - name: Migrate the latest released database
+        env:
+          CONTAINER_CLI: docker
+        run: |
+          BASE_REF="$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')"
+          BASE_REF="$BASE_REF" ./dev/test_master_to_branch_migration.sh


### PR DESCRIPTION
This pull request refactors how schema migration tests are triggered in CI. The main change is moving the migration test logic from the main build workflow (`build_core.yaml`) into a dedicated workflow file (`test_schema_migrate.yaml`). This makes schema migration testing more modular and ensures it only runs when relevant files change on the `master` branch.

**CI/CD workflow refactoring:**

* Removed the `schema_change` job and the conditional `migration_upgrade` job from `.github/workflows/build_core.yaml`, simplifying the main build workflow and decoupling schema migration logic from other jobs. [[1]](diffhunk://#diff-2441cf7b5b40f2568cccaca9869605e3093294e200d14c16ce6e403903685c3bL25-L45) [[2]](diffhunk://#diff-2441cf7b5b40f2568cccaca9869605e3093294e200d14c16ce6e403903685c3bL243-L262)
* Added a new workflow file `.github/workflows/test_schema_migrate.yaml` that runs the migration test (`migration_upgrade` job) only when there are changes to schema-related files or the workflow itself, and only on the `master` branch.