### PR TITLE
Configure Redis for frontend cache

### DIFF
--- a/deploy/helm/templates/deployments.yaml
+++ b/deploy/helm/templates/deployments.yaml
@@ -108,6 +108,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: taranis-config
+            - secretRef:
+                name: taranis-redis-credentials
           env:
             - name: TARANIS_CORE_URL
               value: http://core:8080/api

--- a/deploy/kubernetes/30-deployments-core.yaml
+++ b/deploy/kubernetes/30-deployments-core.yaml
@@ -116,6 +116,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: taranis-config
+            - secretRef:
+                name: taranis-redis-credentials
           env:
             - name: TARANIS_CORE_URL
               value: http://core:8080/api


### PR DESCRIPTION
## Summary

- expose `taranis-redis-credentials` to the frontend Kubernetes deployment
- apply the same Redis configuration to the Helm deployment template
- provide the frontend cache with `REDIS_URL` and `REDIS_PASSWORD`

## Why

Without the Redis Secret, the frontend falls back to `redis://localhost:6379`. Cache initialization fails with a connection refusal and the frontend continues with caching disabled.

## Validation

- `git diff --check`
- repository pre-commit hooks
- `kubectl kustomize deploy/kubernetes-optional-bots`
- `helm lint deploy/helm`
- `helm template taranis deploy/helm --output-dir <temporary-directory>`
- verified both rendered deployment formats expose `taranis-config` and `taranis-redis-credentials` to the frontend