### PR TITLE
various small dev setup improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS Instructions
 
-This file contains project-specific instructions for coding agents working on the taranis.ai codebase.
+Project guidance for coding agents working on taranis.ai.
 
 ## Agent Persona
 
@@ -8,149 +8,12 @@ Name: jipitiii
 
 ## Project Overview
 
-taranis.ai - an OSINT application
+taranis.ai is an OSINT application. See [README.md](README.md) for product context.
 
-See [README.md](README.md) for more information.
+## Required Reading
 
-## Development Environment
+- Before editing application code or running validation, read [Development Workflow](docs/agents/development-workflow.md).
+- Before editing `src/core`, `src/frontend`, `src/worker`, models, API boundaries, queues, persistence, or datetime handling, also read [Architecture and Boundaries](docs/agents/architecture-and-boundaries.md).
+- For an application feature, workflow, route, model, template, or user-facing behavior, first inspect [Agent Memory](docs/agents/README.md) and read every matching memory before planning or editing.
 
-- this project uses [uv](https://docs.astral.sh/uv/) for managing python and packages (a fast Python package installer and resolver)
-- to set up the development environment, install uv and run `uv sync` to create the virtual environment
-- the python virtual environment needs to be activated with `source .venv/bin/activate` (or use `uv run` to run commands directly)
-- see pyproject.toml for the python packages used (and their versions)
-- uv.lock contains information about used libraries and their versions
-
-## Ask Developer Before Local Run Instructions
-
-- do not assume every developer uses tmux
-- before suggesting local startup steps, ask which workflow they want:
-  - `./dev/start_dev.sh` (automated)
-  - manual service startup without tmux (start support services with `docker compose -f dev/compose.yml up -d`, then run `./install_and_run_dev.sh` in `src/core`, `src/frontend`, and `src/worker` in separate terminals)
-  - manual tmux workflow from `dev/README.md`
-- if the developer does not specify a preference, propose `./dev/start_dev.sh` as default and mention alternatives briefly
-
-## Architecture
-
-- **core** (`src/core/`) - Flask REST API backend using SQLAlchemy ORM
-- **ingress** (`src/ingress/`) - Nginx entrypoint for routing requests to frontend and backend
-- **frontend** (`src/frontend/`) - Flask application with HTMX and DaisyUI, and Tailwind CSS for styling.
-- **worker** (`src/worker/`) - RQ workers for collectors, bots, presenters and publishers
-- **models** (`src/models/`) - Pydantic models for input/output validation
-
-### Task Queue System
-
-The application uses **RQ (Redis Queue)** with **Redis** as the message broker for background task processing:
-
-- **Queue Manager** (`src/core/core/managers/queue_manager.py`) - Manages job scheduling and enqueueing using RQ
-- **Task Functions** (`src/worker/worker/*/`) - Background jobs for data collection, analysis, and publishing
-- **Redis** - Message broker (port 6379) and job persistence
-- **Scheduling** - Uses RQ's built-in scheduler with cron expressions via `croniter>=6.0.0`
-
-Task modules:
-
-- `collector_tasks.py` - OSINT source data collection
-- `bot_tasks.py` - Automated analysis and processing
-- `presenter_tasks.py` - Report and product generation
-- `publisher_tasks.py` - Publishing to external systems
-- `connector_tasks.py` - Story sharing with MISP and other systems
-- `misc_tasks.py` - Maintenance tasks (token cleanup, wordlist updates)
-
-## Frontend/API Boundaries
-
-- user-facing frontend views must not import admin-domain models from `models.admin`
-- admin/config endpoints under `src/core/core/api/config.py` are for admin workflows; do not use them from user-facing views
-- when a user workflow needs product or publish-related reference data, expose it through a user-scoped endpoint in `src/core/core/api/publish.py`
-- declare matching user-facing model classes in `src/models/models/product.py` and import those from frontend publish views
-- frontend views should prefer `DataPersistenceLayer` over direct `CoreApi()` calls so cache behavior stays consistent; use `CoreApi()` directly only for raw response handling, downloads/streams, or endpoints that intentionally bypass cached model access
-
-## Agent Memory Files
-
-- feature and workflow context lives in `docs/agents/`
-- when a task mentions an application feature, workflow, route, model, template, or user-facing behavior, first inspect `docs/agents/README.md` for a matching memory file
-- read every matching memory file before planning or editing related code
-- memory files provide expected behavior, code paths, tests, and known pitfalls; the implementation remains the final source of truth
-- if a change updates behavior, code paths, cache behavior, validation, or test strategy covered by a memory file, update that memory file in the same task
-- if a task introduces a substantial feature or workflow that is likely to be revisited, add a new memory file and link it from `docs/agents/README.md`
-
-## Testing
-
-See .github/workflows for how tests are configured in CI.
-
-### Running Tests Locally
-
-**Setup:** In each src directory (`src/core`, `src/frontend`, `src/models`, `src/worker`), run:
-
-- `uv sync --all-extras --dev` to install all dependencies and dev extras.
-
-**Full Test Pipeline:** run this first when validating a branch or chasing a CI regression:
-
-- `cd src/core && uv run pytest`
-- `cd src/frontend && uv run pytest`
-- `cd src/frontend && uv run pytest --e2e-ci`
-
-Use narrower `pytest` targets only after the full pipeline reproduces or if you are isolating one failing area.
-
-**Linting:** In each component directory:
-
-- `uv run ruff check` - check for linting issues
-- `uv run ruff check --fix` - fix auto-fixable linting issues
-- `uv run ruff format` - format code
-
-**Important Notes:**
-
-- You must run commands separately in each src directory to ensure all dependencies are installed
-- Do not create migration files for new tables. New SQLAlchemy tables are created from model metadata during core startup through `src/core/core/managers/db_manager.py` (`db.init_app(app)` followed by metadata setup).
-- Create core migration files only when changing existing tables or deleting existing tables.
-- Before creating a migration, compare the affected schema and behavior with `master`; do not migrate a temporary change introduced only on the current unmerged branch.
-- For `src/core` migration work on existing tables, first launch core once so it bootstraps the current database state; only after that should you apply migrations
-- If the latest core migration was only marked as applied, undo or unmark that last migration first and then reapply it
-- Always execute test and lint commands from within the corresponding component directory (`cd src/<component>`), then run `uv run ...`
-- E2E tests require the application to be running (they start their own test server)
-- Tests are located in each component's `tests/` directory
-- If you run tests from VS Code / VSC and inherit `DEBUG=release` from the editor environment, override it to a boolean first (for example `DEBUG=true`) or unset it; frontend and core settings parse `DEBUG` as a boolean and `release` breaks test startup
-- E2E admin tests in master branch have many functions commented out to avoid flakiness - do not uncomment without ensuring they pass
-- Models package does not have unit tests
-- Worker package includes Playwright browser installation for web scraping tests
-- when adding tests in `src/core`, prefer reusing existing fixtures from the nearest `conftest.py`
-- if a fixture is broadly useful across the application suite, add it to `src/core/tests/application/conftest.py`
-- if a fixture is specific to one cluster such as admin configuration, keep it in that folder's local `conftest.py`
-- if a new payload/setup fixture is needed outside `tests/application/` as well, add it to `src/core/tests/conftest.py`
-- keep test data in fixtures or `src/core/tests/test_data/`; do not duplicate large inline payloads across test files
-- keep helper functions and builders in dedicated support modules under `src/core/tests/application/support/`, not inside the test files themselves
-- avoid inline fake classes or ad-hoc test doubles inside test functions; put shared fakes in the nearest `conftest.py` or a dedicated support module instead
-- avoid unit tests for orchestration methods whose collaborators are almost entirely monkeypatched or stubbed out; those tests tend to prove call wiring rather than behavior
-- for admin/frontend workflows that depend on cache invalidation, scheduling, seeding, or similar cross-component side effects, prefer frontend e2e coverage over heavily mocked unit tests
-- for e2e tests, prefer adding a `data-test-id` attribute as the selector when possible
-- do not use pytest autouse fixtures; request fixtures explicitly or use module/class-level `pytest.mark.usefixtures` when a whole module needs setup
-
-## Development Guidelines
-
-- The best code is no code.
-- Complexity is bad. Keep designs as simple as possible.
-- New WIP features must use one canonical field/API shape; do not introduce "legacy" aliases, migration validators, or compatibility payloads in the same branch unless the compatibility is for behavior already released to users.
-- For settings JSON, prefer simple flat keys and direct values; do not add nested metadata structures, constants, validators, or helper layers unless they are clearly needed now.
-- Mocking is also bad. Use it only when it is absolutely necessary.
-- DRY matters, but do not force reuse if it hurts readability.
-- When creating branches, use only `fix/`, `feature/`, or `chore/` prefixes.
-- never use `git add -A` or in general do not add "all" files lying around
-- use specific git add commands for the files you want to commit
-- don't commit how many tests passed (statistics in commit messages are not useful)
-- do not use `pip` for any package installations or management, always use `uv`
-- do not manually merge generated lockfiles such as `uv.lock` or `deno.lock`; regenerate them locally from the manifests/tools and commit the regenerated result
-- do not add `from __future__ import annotations` by default. Use it only in Python files that must run on Python 3.13 and need postponed annotation evaluation for forward references, circular type imports, or annotations guarded by `TYPE_CHECKING`; do not use it in Python 3.14-only code
-- do not create comments in code that say what was removed, added, changed and why it was done like this. this should be summarized in commit messages and/or PRs
-- run tests before committing code
-- write tests for new features and bug fixes
-- fix linting issues before committing code
-- after touching Python files, run `./dev/check_touched_pyright.sh` to catch Pylance/Pyright issues in changed files
-- don't write commit messages like "x tests are passing" or "resolves linting failures"
-- don't add comments like "Restore template files ..." directly in the code, when you add new codelines
-
-## Datetime Handling
-
-- in `src/core`, treat persisted naive datetimes as **UTC**, not local time
-- for incoming assess/story/news item payload timestamps, prefer normalization through `src/models/models/assess.py`
-- when storing timestamps in naive SQLAlchemy `DateTime` columns, store **UTC clock values** consistently
-- do not introduce new persistence code that uses local naive `datetime.now()` for values that are stored in the database; prefer UTC-based values
-- when serializing naive datetimes from `src/core`, preserve the convention that they represent UTC
-- do not leave trailing whitespace anywhere (especially on otherwise empty lines)
+Memory files provide expected behavior, code paths, tests, and known pitfalls; implementation remains the source of truth. Update a matching memory when behavior, code paths, cache behavior, validation, or test strategy changes. Add and index a memory for substantial recurring workflows.

--- a/dev/README.md
+++ b/dev/README.md
@@ -122,7 +122,11 @@ tmux new-window -t taranis:4 -n rq-dashboard -c src/worker
 tmux attach-session -t taranis
 ```
 
-Or simply run `./dev/start_tmux.sh` which sets up all windows automatically.
+Or run `./dev/start_tmux.sh` for the core, Tailwind, frontend, and worker windows. Set `WITH_CRON_RQ=1` to also start cron and rq-dashboard:
+
+```bash
+WITH_CRON_RQ=1 ./dev/start_tmux.sh
+```
 
 In Core Tab:
 
@@ -222,7 +226,7 @@ The development setup includes an **RQ Cron Scheduler** that automatically enque
 * Automatically enqueues collection and bot tasks at their scheduled times
 * Picks up definition changes from Redis on each poll cycle
 
-When using `./dev/start_tmux.sh`, the cron scheduler is automatically started in window 4.
+When using `WITH_CRON_RQ=1 ./dev/start_tmux.sh`, the cron scheduler is started in window 4.
 
 **Manual start:**
 ```bash
@@ -246,7 +250,7 @@ The development setup includes [rq-dashboard](https://github.com/Parallels/rq-da
 * Job details including arguments, results, and tracebacks
 * Ability to cancel jobs, requeue failed jobs, and empty queues
 
-When using `./dev/start_tmux.sh`, rq-dashboard is automatically started on port **9181** in window 5.
+When using `WITH_CRON_RQ=1 ./dev/start_tmux.sh`, rq-dashboard is started on port **9181** in window 5.
 
 Access it at: http://localhost:9181
 

--- a/dev/start_tmux.sh
+++ b/dev/start_tmux.sh
@@ -18,13 +18,12 @@ tmux send-keys -t taranis:frontend "./install_and_run_dev.sh" C-m
 tmux new-window -t taranis:3 -n worker -c src/worker
 tmux send-keys -t taranis:worker "./install_and_run_dev.sh" C-m
 
-# Create Cron Scheduler tab
-tmux new-window -t taranis:4 -n cron -c src/worker
-tmux send-keys -t taranis:cron "./install_and_run_cron.sh" C-m
-
-# Create RQ Dashboard tab
-tmux new-window -t taranis:5 -n rq-dashboard -c src/worker
-tmux send-keys -t taranis:rq-dashboard "./install_and_run_rq_dashboard.sh" C-m
+if [ -n "${WITH_CRON_RQ:-}" ]; then
+    tmux new-window -t taranis:4 -n cron -c src/worker
+    tmux send-keys -t taranis:cron "./install_and_run_cron.sh" C-m
+    tmux new-window -t taranis:5 -n rq-dashboard -c src/worker
+    tmux send-keys -t taranis:rq-dashboard "./install_and_run_rq_dashboard.sh" C-m
+fi
 
 
 # Attach to the session

--- a/dev/test_master_to_branch_migration.sh
+++ b/dev/test_master_to_branch_migration.sh
@@ -71,7 +71,7 @@ run_pytest_validation() {
       DEBUG=true \
       DISABLE_SCHEDULER=true \
       TARANIS_CORE_SENTRY_DSN= \
-      uv run --frozen pytest "$pytest_target"
+      uv run --frozen --extra dev pytest "$pytest_target"
   )
 }
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,10 +1,15 @@
 # Agent Memory
 
-This folder contains feature-level context for coding agents working on taranis.ai.
+This folder contains operational and feature context for coding agents working on taranis.ai.
 
 Use these files when a task mentions a related feature, workflow, route, model, template, or expected behavior. Read the matching memory before planning or editing code. Treat memory files as orientation and expected-behavior notes; code and tests remain the final source of truth.
 
-## Memories
+## Operational References
+
+- [Development Workflow](development-workflow.md) - environment setup, startup choices, validation commands, test conventions, and development rules. Read before application changes or validation.
+- [Architecture and Boundaries](architecture-and-boundaries.md) - component roles, RQ tasks, frontend/API boundaries, migrations, and UTC datetime handling. Read before component, API, persistence, queue, or datetime changes.
+
+## Feature Memories
 
 - [Assess Filters](assess-filters.md) - assess sidebar filters, filter-list loading, default filters, omnisearch filter handling, and related cache behavior.
 - [RBAC ACL Behavior](rbac-acl.md) - RoleBasedAccess ACL boundaries, ADMIN_OPERATIONS bypass, OSINT source-group inheritance, and config/admin ACL isolation.

--- a/docs/agents/architecture-and-boundaries.md
+++ b/docs/agents/architecture-and-boundaries.md
@@ -1,0 +1,40 @@
+# Architecture and Boundaries
+
+## When To Load
+
+Before changing application components, API boundaries, user-facing workflows, background jobs, persistence, migrations, or datetime handling.
+
+## Components
+
+- `src/core/`: Flask REST API using SQLAlchemy ORM
+- `src/ingress/`: Nginx routing to frontend and backend
+- `src/frontend/`: Flask, HTMX, DaisyUI, and Tailwind CSS
+- `src/worker/`: RQ workers for collectors, bots, presenters, and publishers
+- `src/models/`: Pydantic input/output models
+
+## Background Tasks
+
+RQ uses Redis on port 6379 for queueing and persistence. `src/core/core/managers/queue_manager.py` schedules and enqueues jobs with RQ's scheduler and cron expressions via `croniter>=6.0.0`.
+
+Worker task modules are `collector_tasks.py`, `bot_tasks.py`, `presenter_tasks.py`, `publisher_tasks.py`, `connector_tasks.py`, and `misc_tasks.py`.
+
+## Frontend and API Boundaries
+
+- User-facing frontend views must not import `models.admin`.
+- Do not use admin/config endpoints in `src/core/core/api/config.py` from user-facing views.
+- Expose user workflow product or publishing reference data through a user-scoped endpoint in `src/core/core/api/publish.py`, with matching models in `src/models/models/product.py`.
+- Prefer `DataPersistenceLayer` in frontend views. Use `CoreApi()` directly only for raw responses, downloads/streams, or deliberate cache bypasses.
+
+## Persistence and Migrations
+
+- Do not create migrations for new tables: core creates them from metadata in `src/core/core/managers/db_manager.py` after `db.init_app(app)` and metadata setup.
+- For existing-table changes or deletion, compare with `master` before adding a migration. Do not migrate a temporary, unmerged branch-only change.
+- Before a core migration, launch core once to bootstrap the current database. If the latest migration is only marked applied, undo or unmark it before reapplying.
+
+## Datetimes
+
+- Persisted naive datetimes in core represent UTC.
+- Normalize incoming assess/story/news timestamps through `src/models/models/assess.py` where applicable.
+- Store UTC clock values in naive SQLAlchemy `DateTime` columns. Do not persist local `datetime.now()` values.
+- Preserve the UTC convention when serializing naive core datetimes.
+- Do not leave trailing whitespace.

--- a/docs/agents/development-workflow.md
+++ b/docs/agents/development-workflow.md
@@ -1,0 +1,53 @@
+# Development Workflow
+
+## When To Load
+
+Before editing application code, running validation, changing development setup, or suggesting local startup steps.
+
+## Environment
+
+- This project uses [uv](https://docs.astral.sh/uv/) for Python packages. Do not use `pip`.
+- In each `src` component, run `uv sync --all-extras --dev` to install development dependencies. Use `uv run` for commands, or activate `.venv` with `source .venv/bin/activate` when needed.
+- See `pyproject.toml` for dependency versions. Regenerate lockfiles from manifests/tools; never manually merge `uv.lock` or `deno.lock`.
+
+## Local Startup
+
+Before suggesting local startup, ask which workflow the developer wants:
+
+- `./dev/start_dev.sh` (default when they have no preference; mention the alternatives)
+- Manual non-tmux startup: `docker compose -f dev/compose.yml up -d`, then run `./install_and_run_dev.sh` in `src/core`, `src/frontend`, and `src/worker` in separate terminals
+- Manual tmux workflow from `dev/README.md`
+
+Do not assume tmux.
+
+## Validation
+
+See `.github/workflows` for CI behavior. Run commands from the relevant component directory.
+
+- Full validation for a branch or CI regression: `cd src/core && uv run pytest`; `cd src/frontend && uv run pytest`; then `cd src/frontend && uv run pytest --e2e-ci`.
+- Use narrower pytest targets only after the full pipeline reproduces a failure or while isolating one.
+- Run test and lint commands from the relevant component directory. Tests live in each component's `tests/` directory.
+- Lint each changed component with `uv run ruff check`; use `uv run ruff check --fix` and `uv run ruff format` where appropriate.
+- After touching Python files, run `./dev/check_touched_pyright.sh`.
+- E2E tests require a running application. They start their own test server.
+- If VS Code supplies `DEBUG=release`, unset it or use a boolean value such as `DEBUG=true` before starting frontend or core tests.
+- Models has no unit tests. Worker browser-scraping tests install Playwright browsers.
+- E2E admin tests on `master` intentionally keep many functions commented out; do not uncomment them without proving they pass.
+
+## Test Conventions
+
+- Reuse the nearest existing `conftest.py` fixtures. Put broadly useful core fixtures in `src/core/tests/application/conftest.py`; cluster-specific fixtures in their local `conftest.py`; and cross-application payload/setup fixtures in `src/core/tests/conftest.py`.
+- Keep large test data in fixtures or `src/core/tests/test_data/`. Put shared builders and helpers in `src/core/tests/application/support/`.
+- Do not create inline fake classes or ad-hoc test doubles in test functions. Avoid unit tests that only prove mocked orchestration wiring.
+- For cache invalidation, scheduling, seeding, and similar cross-component effects, prefer frontend E2E coverage. Prefer `data-test-id` selectors for E2E tests.
+- Do not use pytest autouse fixtures. Request fixtures explicitly or use module/class-level `pytest.mark.usefixtures`.
+
+## Development Conventions
+
+- The best code is no code. Keep designs simple, use mocking only when necessary, and do not force DRY reuse that hurts readability.
+- Prefer the simplest correct implementation. Do not add WIP compatibility aliases, migration validators, or compatibility payloads for behavior not released to users.
+- Prefer flat settings JSON and direct values. Avoid unnecessary metadata, constants, validators, and helpers.
+- Keep changes focused. Use `fix/`, `feature/`, or `chore/` branch prefixes; never use `git add -A`; stage only intended files.
+- Run tests and fix lint before committing. Do not include test-pass counts in commit messages.
+- Do not add `from __future__ import annotations` unless Python 3.13 compatibility requires postponed annotation evaluation for forward references, circular imports, or `TYPE_CHECKING` annotations.
+- Do not add code comments that describe what changed or why; use commits and PRs for that history.

--- a/docs/agents/development-workflow.md
+++ b/docs/agents/development-workflow.md
@@ -29,7 +29,7 @@ See `.github/workflows` for CI behavior. Run commands from the relevant componen
 - Run test and lint commands from the relevant component directory. Tests live in each component's `tests/` directory.
 - Lint each changed component with `uv run ruff check`; use `uv run ruff check --fix` and `uv run ruff format` where appropriate.
 - After touching Python files, run `./dev/check_touched_pyright.sh`.
-- E2E tests require a running application. They start their own test server.
+- E2E tests start and stop a dedicated Docker/Podman Compose test stack automatically for the session; you mainly need Docker/Podman Compose available locally (see `src/frontend/tests/playwright/README.md`).
 - If VS Code supplies `DEBUG=release`, unset it or use a boolean value such as `DEBUG=true` before starting frontend or core tests.
 - Models has no unit tests. Worker browser-scraping tests install Playwright browsers.
 - E2E admin tests on `master` intentionally keep many functions commented out; do not uncomment them without proving they pass.

--- a/src/frontend/frontend/static/css/input.css
+++ b/src/frontend/frontend/static/css/input.css
@@ -122,11 +122,6 @@
       --choices-icon-cross: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEiIGhlaWdodD0iMjEiIHZpZXdCb3g9IjAgMCAyMSAyMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZyBmaWxsPSIjRkZGIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxwYXRoIGQ9Ik0yLjU5Mi4wNDRsMTguMzY0IDE4LjM2NC0yLjU0OCAyLjU0OEwuMDQ0IDIuNTkyeiIvPjxwYXRoIGQ9Ik0wIDE4LjM2NEwxOC4zNjQgMGwyLjU0OCAyLjU0OEwyLjU0OCAyMC45MTJ6Ii8+PC9nPjwvc3ZnPg==");
     }
   }
-
-  .highlight::highlight(search) {
-    background-color: rgba(251, 191, 36, 0.45);
-    color: inherit;
-  }
 }
 
 @layer utilities {

--- a/src/frontend/frontend/templates/assess/index.html
+++ b/src/frontend/frontend/templates/assess/index.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% block head %}
+  <style>
+    ::highlight(search) {
+      background-color: rgba(251, 191, 36, 0.45);
+      color: inherit;
+    }
+  </style>
+{% endblock head %}
+
 {% block content %}
   {% include "assess/story_table.html" %}
 {% endblock content %}


### PR DESCRIPTION
This pull request improves project documentation for coding agents, refines the development workflow, and clarifies local development setup. It restructures agent instructions into more focused operational and feature memory files, splits out architecture and development workflow guidance, and makes the `./dev/start_tmux.sh` script and docs more flexible by supporting optional cron and RQ dashboard startup. Additionally, it moves a CSS rule from the global stylesheet to a template-scoped style block for better encapsulation.

**Documentation and Workflow Restructuring**

* The agent instructions in `AGENTS.md` are streamlined and reorganized, with detailed environment, architecture, and test guidance moved into new operational memory files. The file now points to [Development Workflow](docs/agents/development-workflow.md) and [Architecture and Boundaries](docs/agents/architecture-and-boundaries.md) for in-depth guidance.
* The `docs/agents/README.md` now distinguishes between operational references and feature memories, linking to the new workflow and architecture docs.
* New files `docs/agents/development-workflow.md` and `docs/agents/architecture-and-boundaries.md` provide clear, modular guidance on environment setup, validation, migrations, API boundaries, and datetime handling. [[1]](diffhunk://#diff-43afc9b5c16e33b29431833b560e75d18371f1dc5739f556ac78d8d6d4b34442R1-R53) [[2]](diffhunk://#diff-18a58759d8dc43b0ae99472404214f75e7fd67fab790a4f0a0acac12afa8276dR1-R40)

**Development Environment Improvements**

* The `./dev/start_tmux.sh` script now only starts the cron scheduler and RQ dashboard tabs if the `WITH_CRON_RQ=1` environment variable is set, making tmux setup more flexible for developers.
* The `dev/README.md` is updated to clarify the new `WITH_CRON_RQ=1` option and document its effect on tmux window startup for cron and RQ dashboard. [[1]](diffhunk://#diff-e14025c0fa40d4857e4b40fc96ea5ee995afe300014626b68cb55a479fa5b8fcL125-R129) [[2]](diffhunk://#diff-e14025c0fa40d4857e4b40fc96ea5ee995afe300014626b68cb55a479fa5b8fcL225-R229) [[3]](diffhunk://#diff-e14025c0fa40d4857e4b40fc96ea5ee995afe300014626b68cb55a479fa5b8fcL249-R253)

**Frontend Style Encapsulation**

* The CSS rule for the `::highlight(search)` pseudo-element is moved from the global stylesheet (`src/frontend/frontend/static/css/input.css`) into a `<style>` block within the `assess/index.html` template, ensuring the highlight style only applies where needed. [[1]](diffhunk://#diff-71958c299631c29d7b564d619d63907ab3d2cad500b1af4360a53afe5d0f4cd5L125-L129) [[2]](diffhunk://#diff-e70aa839d9d69762fe5a5badca109b1ee5abc847ac22b89913028fb37b05f5bdR3-R11)