### PR TITLE
Enqueue user-triggered jobs with priority (LIFO)

### DIFF
--- a/docs/agents/worker-task-notifications.md
+++ b/docs/agents/worker-task-notifications.md
@@ -21,3 +21,5 @@ Use `cd src/frontend && uv run pytest tests/unit/views/test_worker_task_notifica
 Do not change core queue endpoint status codes for this behavior. A missing or failed health check should keep the original task notification. The enqueue notification is still only about scheduling; failure visibility for admin/source/bot/render status comes from persisted task rows, not a second frontend polling path.
 
 Front-of-queue priority is local to each functional queue. Workers check enabled queues in this priority order: presenters, publishers, connectors, misc, bots, collectors. A dedicated collector worker is unaffected because it only subscribes to collectors. An already running job is never preempted.
+
+RQ promotes jobs created with `enqueue_at` when they become due without waiting for unfinished `depends_on` jobs. Scheduled user jobs retain front-of-queue promotion, but callers must not use scheduled dependencies to model execution ordering.

--- a/docs/agents/worker-task-notifications.md
+++ b/docs/agents/worker-task-notifications.md
@@ -6,14 +6,18 @@ Worker-backed frontend actions, task queue notifications, OSINT source collect, 
 ## Expected Behavior
 Worker-backed actions still report queue success when core accepts the job. If core health reports `workers: down`, the frontend shows a warning that the task was queued but may not be processed until a worker starts. Final task failures are not pushed into that enqueue notification, but persisted task/status views reflect actual RQ-level failures such as exceptions, timeouts, and killed workhorses. For user-triggered runs, the persisted task row also carries the authenticated `user_id`; scheduler-driven runs leave it empty.
 
+Jobs carrying an authenticated `user_id` are enqueued at the front of their functional RQ queue. User-triggered jobs therefore run in last-in, first-out order within that queue, while scheduler-driven and other background jobs retain normal first-in, first-out ordering. User attribution and front-of-queue priority propagate through deferred dependencies and post-collection bot scheduling.
+
 ## Code Paths
 Frontend notification handling lives in `frontend.views.base_view.BaseView.render_worker_task_notification`. Core health is read through `frontend.data_persistence.DataPersistenceLayer.get_core_health`.
 
 ## Data Flow
-The frontend posts the worker-backed action to core. On a successful response, it reads cached `/health`; only `services.workers == "down"` changes the notification from success to warning. Core includes the authenticated user in the queued job metadata for manual runs, and worker-side task persistence copies that onto the task row. Separately, core stores synthetic task failures from worker-level RQ hooks when a job dies before task code can call `save_task_result(...)`, and from the background reconciler when a run is missed or stalls before any worker-side persistence can happen.
+The frontend posts the worker-backed action to core. On a successful response, it reads cached `/health`; only `services.workers == "down"` changes the notification from success to warning. Core includes the authenticated user in the queued job metadata for manual runs, derives RQ's `at_front` option from that metadata, and worker-side task persistence copies the user onto the task row. Worker-triggered follow-up requests forward the current job's user metadata so downstream jobs retain the same behavior. Separately, core stores synthetic task failures from worker-level RQ hooks when a job dies before task code can call `save_task_result(...)`, and from the background reconciler when a run is missed or stalls before any worker-side persistence can happen.
 
 ## Testing
 Use `cd src/frontend && uv run pytest tests/unit/views/test_worker_task_notifications.py` for focused coverage.
 
 ## Pitfalls
 Do not change core queue endpoint status codes for this behavior. A missing or failed health check should keep the original task notification. The enqueue notification is still only about scheduling; failure visibility for admin/source/bot/render status comes from persisted task rows, not a second frontend polling path.
+
+Front-of-queue priority is local to each functional queue. Cross-queue execution remains determined by the worker's configured queue order, and an already running job is never preempted.

--- a/docs/agents/worker-task-notifications.md
+++ b/docs/agents/worker-task-notifications.md
@@ -20,4 +20,4 @@ Use `cd src/frontend && uv run pytest tests/unit/views/test_worker_task_notifica
 ## Pitfalls
 Do not change core queue endpoint status codes for this behavior. A missing or failed health check should keep the original task notification. The enqueue notification is still only about scheduling; failure visibility for admin/source/bot/render status comes from persisted task rows, not a second frontend polling path.
 
-Front-of-queue priority is local to each functional queue. Cross-queue execution remains determined by the worker's configured queue order, and an already running job is never preempted.
+Front-of-queue priority is local to each functional queue. Workers check enabled queues in this priority order: presenters, publishers, connectors, misc, bots, collectors. A dedicated collector worker is unaffected because it only subscribes to collectors. An already running job is never preempted.

--- a/src/core/core/api/assess.py
+++ b/src/core/core/api/assess.py
@@ -88,7 +88,7 @@ class NewsItemFetch(MethodView):
         if not self._is_supported_web_url(url):
             return {"error": "A valid http or https URL is required"}, 400
 
-        response, status = StoryService.fetch_and_create_story(parameters)
+        response, status = StoryService.fetch_and_create_story(parameters, user_id=current_user.id)
         if 200 <= status < 300:
             sse_manager.news_items_updated()
             invalidate_frontend_cache_on_success(status, scopes=(SCOPE_ASSESS_VIEWS, SCOPE_STORY_REPORT_VIEWS))

--- a/src/core/core/api/worker.py
+++ b/src/core/core/api/worker.py
@@ -272,7 +272,7 @@ class PostCollectionBots(MethodView):
         if not (data := request.json):
             return {"error": "No data provided"}, 400
         if source_id := data.get("source_id", None):
-            return queue_manager.queue_manager.post_collection_bots(source_id=source_id)
+            return queue_manager.queue_manager.post_collection_bots(source_id=source_id, user_id=data.get("user_id"))
         return {"error": "No source_id provided"}, 400
 
 

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -47,7 +47,7 @@ from models.admin import CronSpec
 from redis import Redis
 from rq import Queue
 from rq.exceptions import NoSuchJobError
-from rq.job import Job
+from rq.job import Dependency, Job
 
 from core.config import Config
 from core.log import logger
@@ -447,6 +447,20 @@ class QueueManager:
         return self._queues.get(queue_name)
 
     @staticmethod
+    def _is_user_triggered(meta: dict[str, Any] | None) -> bool:
+        return bool(meta and meta.get("user_id"))
+
+    @staticmethod
+    def _prioritize_dependencies(depends_on: Any) -> Dependency:
+        if isinstance(depends_on, Dependency):
+            return Dependency(
+                depends_on.dependencies,
+                allow_failure=depends_on.allow_failure,
+                enqueue_at_front=True,
+            )
+        return Dependency(depends_on, enqueue_at_front=True)
+
+    @staticmethod
     def _build_task_meta(
         task: str,
         *,
@@ -571,12 +585,11 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
-            user_triggered = bool(meta and meta.get("user_id"))
-            job = queue.enqueue(task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
-            if user_triggered and getattr(job, "is_deferred", False):
-                job.enqueue_at_front = True
-                job.save()
-            return job
+            user_triggered = self._is_user_triggered(meta)
+            if user_triggered and (depends_on := kwargs.get("depends_on")) is not None:
+                kwargs["depends_on"] = self._prioritize_dependencies(depends_on)
+
+            return queue.enqueue(task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
         except Exception as e:
             logger.error(f"Failed to enqueue task {task_name}: {e}")
             return False
@@ -621,7 +634,7 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
-            user_triggered = bool(meta and meta.get("user_id"))
+            user_triggered = self._is_user_triggered(meta)
             logger.info(
                 f"enqueue_at: queue={queue_name}, func={task_func}, scheduled_time={scheduled_time}, job_id={job_id}, args={args}, kwargs={kwargs}"
             )

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -571,7 +571,12 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
-            return queue.enqueue(task_func, *args, job_id=job_id, **kwargs)
+            user_triggered = bool(meta and meta.get("user_id"))
+            job = queue.enqueue(task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
+            if user_triggered and getattr(job, "is_deferred", False):
+                job.enqueue_at_front = True
+                job.save()
+            return job
         except Exception as e:
             logger.error(f"Failed to enqueue task {task_name}: {e}")
             return False
@@ -616,10 +621,11 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
+            user_triggered = bool(meta and meta.get("user_id"))
             logger.info(
                 f"enqueue_at: queue={queue_name}, func={task_func}, scheduled_time={scheduled_time}, job_id={job_id}, args={args}, kwargs={kwargs}"
             )
-            job = queue.enqueue_at(scheduled_time, task_func, *args, job_id=job_id, **kwargs)
+            job = queue.enqueue_at(scheduled_time, task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
             logger.info(f"enqueue_at: created job {job.id} scheduled for {scheduled_time}")
             return job
         except Exception as e:
@@ -790,7 +796,7 @@ class QueueManager:
         payload_hash = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
         return f"fetch_single_news_item_{payload_hash}"
 
-    def fetch_single_news_item(self, parameters: dict[str, Any]):
+    def fetch_single_news_item(self, parameters: dict[str, Any], user_id: str | None = None):
         url = get_simple_web_collector_url(parameters)
         job = self.enqueue_task(
             "collectors",
@@ -799,7 +805,7 @@ class QueueManager:
             job_id=self._get_single_fetch_job_id(parameters),
             meta=self._build_task_meta(
                 "collector_task",
-                user_id=None,
+                user_id=user_id,
                 worker_id=self._get_single_fetch_url(parameters),
                 worker_type="simple_web_collector",
             ),

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -34,6 +34,7 @@ import json
 import re
 import time
 from collections.abc import Callable, Iterable
+from copy import copy
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
@@ -453,12 +454,17 @@ class QueueManager:
     @staticmethod
     def _prioritize_dependencies(depends_on: Any) -> Dependency:
         if isinstance(depends_on, Dependency):
-            return Dependency(
-                depends_on.dependencies,
-                allow_failure=depends_on.allow_failure,
-                enqueue_at_front=True,
-            )
+            prioritized = copy(depends_on)
+            prioritized.enqueue_at_front = True
+            return prioritized
         return Dependency(depends_on, enqueue_at_front=True)
+
+    @classmethod
+    def _prepare_user_priority(cls, meta: dict[str, Any] | None, kwargs: dict[str, Any]) -> bool:
+        user_triggered = cls._is_user_triggered(meta)
+        if user_triggered and (depends_on := kwargs.get("depends_on")) is not None:
+            kwargs["depends_on"] = cls._prioritize_dependencies(depends_on)
+        return user_triggered
 
     @staticmethod
     def _build_task_meta(
@@ -585,10 +591,7 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
-            user_triggered = self._is_user_triggered(meta)
-            if user_triggered and (depends_on := kwargs.get("depends_on")) is not None:
-                kwargs["depends_on"] = self._prioritize_dependencies(depends_on)
-
+            user_triggered = self._prepare_user_priority(meta, kwargs)
             return queue.enqueue(task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
         except Exception as e:
             logger.error(f"Failed to enqueue task {task_name}: {e}")
@@ -616,7 +619,10 @@ class QueueManager:
         meta: dict[str, Any] | None = None,
         **kwargs,
     ):
-        """Enqueue a task to run at a specific time"""
+        """Enqueue a task to run at a specific time.
+
+        RQ promotes scheduled jobs at their due time without waiting for unfinished dependencies.
+        """
         if self.error:
             return False
 
@@ -634,7 +640,7 @@ class QueueManager:
             if meta:
                 kwargs["meta"] = dict(meta)
 
-            user_triggered = self._is_user_triggered(meta)
+            user_triggered = self._prepare_user_priority(meta, kwargs)
             logger.info(
                 f"enqueue_at: queue={queue_name}, func={task_func}, scheduled_time={scheduled_time}, job_id={job_id}, args={args}, kwargs={kwargs}"
             )

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -641,9 +641,7 @@ class QueueManager:
                 kwargs["meta"] = dict(meta)
 
             user_triggered = self._prepare_user_priority(meta, kwargs)
-            logger.info(
-                f"enqueue_at: queue={queue_name}, func={task_func}, scheduled_time={scheduled_time}, job_id={job_id}, args={args}, kwargs={kwargs}"
-            )
+            logger.info(f"enqueue_at: queue={queue_name}, func={task_func}, scheduled_time={scheduled_time}, job_id={job_id}")
             job = queue.enqueue_at(scheduled_time, task_func, *args, job_id=job_id, at_front=user_triggered, **kwargs)
             logger.info(f"enqueue_at: created job {job.id} scheduled for {scheduled_time}")
             return job

--- a/src/core/core/service/story.py
+++ b/src/core/core/service/story.py
@@ -166,8 +166,8 @@ class StoryService:
         story.remove_attributes([f"report_{report_id}"])
 
     @staticmethod
-    def fetch_and_create_story(parameters: dict[str, Any]) -> tuple[dict[str, Any], int]:
-        result = queue_manager.queue_manager.fetch_single_news_item(parameters=parameters)
+    def fetch_and_create_story(parameters: dict[str, Any], user_id: str | None = None) -> tuple[dict[str, Any], int]:
+        result = queue_manager.queue_manager.fetch_single_news_item(parameters=parameters, user_id=user_id)
         if isinstance(result, tuple):
             return result
         if isinstance(result, list):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -451,9 +451,101 @@ def test_enqueue_task_passes_meta_to_rq_queue(monkeypatch):
             "task_func": "worker.collectors.collector_tasks.collector_task",
             "args": ("source-1", True),
             "job_id": "collect_rss_collector_source-1",
-            "kwargs": {"meta": {"task": "collector_task", "user_id": None, "worker_id": "source-1", "worker_type": "rss_collector"}},
+            "kwargs": {
+                "at_front": False,
+                "meta": {"task": "collector_task", "user_id": None, "worker_id": "source-1", "worker_type": "rss_collector"},
+            },
         }
     ]
+
+
+def test_enqueue_task_places_user_triggered_job_at_front(monkeypatch):
+    queue_calls = []
+
+    class FakeJob:
+        is_deferred = False
+
+    class FakeQueue:
+        def enqueue(self, task_func, *args, job_id=None, **kwargs):
+            queue_calls.append({"task_func": task_func, "args": args, "job_id": job_id, "kwargs": kwargs})
+            return FakeJob()
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
+
+    qm.enqueue_task(
+        "presenters",
+        "presenter_task",
+        "product-1",
+        job_id="presenter_task_product-1",
+        meta={"task": "presenter_task", "user_id": "user-1", "worker_id": "product-1", "worker_type": "presenter_task"},
+    )
+
+    assert queue_calls[0]["kwargs"]["at_front"] is True
+
+
+def test_enqueue_task_preserves_user_priority_for_deferred_job(monkeypatch):
+    class FakeJob:
+        is_deferred = True
+        enqueue_at_front = False
+        saved = False
+
+        def save(self):
+            self.saved = True
+
+    job = FakeJob()
+
+    class FakeQueue:
+        def enqueue(self, *_args, **_kwargs):
+            return job
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
+
+    result = qm.enqueue_task(
+        "publishers",
+        "publisher_task",
+        "product-1",
+        "publisher-1",
+        depends_on=object(),
+        meta={"task": "publisher_task", "user_id": "user-1", "worker_id": "publisher-1", "worker_type": "publisher_task"},
+    )
+
+    assert result is job
+    assert job.enqueue_at_front is True
+    assert job.saved is True
+
+
+def test_enqueue_at_preserves_user_priority(monkeypatch):
+    queue_calls = []
+
+    class FakeQueue:
+        def enqueue_at(self, scheduled_time, task_func, *args, job_id=None, **kwargs):
+            queue_calls.append(
+                {
+                    "scheduled_time": scheduled_time,
+                    "task_func": task_func,
+                    "args": args,
+                    "job_id": job_id,
+                    "kwargs": kwargs,
+                }
+            )
+            return object()
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
+    scheduled_time = datetime(2026, 7, 23, tzinfo=timezone.utc)
+
+    qm.enqueue_at(
+        "presenters",
+        "presenter_task",
+        scheduled_time,
+        "product-1",
+        job_id="presenter_task_product-1",
+        meta={"task": "presenter_task", "user_id": "user-1", "worker_id": "product-1", "worker_type": "presenter_task"},
+    )
+
+    assert queue_calls[0]["kwargs"]["at_front"] is True
 
 
 def test_autopublish_product_returns_error_when_presenter_enqueue_fails(monkeypatch):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -519,6 +519,7 @@ def test_enqueue_task_preserves_existing_dependency_options(monkeypatch):
     qm = _make_queue_manager()
     monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
     existing_dependency = qm_module.Dependency("presenter-job", allow_failure=True)
+    existing_dependency.custom_config = {"timeout": 120}
 
     qm.enqueue_task(
         "publishers",
@@ -531,9 +532,12 @@ def test_enqueue_task_preserves_existing_dependency_options(monkeypatch):
 
     dependency = queue_calls[0]["kwargs"]["depends_on"]
     assert isinstance(dependency, qm_module.Dependency)
+    assert dependency is not existing_dependency
     assert dependency.dependencies == ["presenter-job"]
     assert dependency.allow_failure is True
     assert dependency.enqueue_at_front is True
+    assert dependency.custom_config == {"timeout": 120}
+    assert existing_dependency.enqueue_at_front is False
 
 
 def test_enqueue_at_preserves_user_priority(monkeypatch):
@@ -562,10 +566,49 @@ def test_enqueue_at_preserves_user_priority(monkeypatch):
         scheduled_time,
         "product-1",
         job_id="presenter_task_product-1",
+        depends_on="collector-job",
         meta={"task": "presenter_task", "user_id": "user-1", "worker_id": "product-1", "worker_type": "presenter_task"},
     )
 
     assert queue_calls[0]["kwargs"]["at_front"] is True
+    dependency = queue_calls[0]["kwargs"]["depends_on"]
+    assert isinstance(dependency, qm_module.Dependency)
+    assert dependency.dependencies == ["collector-job"]
+    assert dependency.enqueue_at_front is True
+
+
+def test_enqueue_at_keeps_background_job_at_normal_priority(monkeypatch):
+    queue_calls = []
+
+    class FakeQueue:
+        def enqueue_at(self, scheduled_time, task_func, *args, job_id=None, **kwargs):
+            queue_calls.append(
+                {
+                    "scheduled_time": scheduled_time,
+                    "task_func": task_func,
+                    "args": args,
+                    "job_id": job_id,
+                    "kwargs": kwargs,
+                }
+            )
+            return object()
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
+    scheduled_time = datetime(2026, 7, 23, tzinfo=timezone.utc)
+
+    qm.enqueue_at(
+        "presenters",
+        "presenter_task",
+        scheduled_time,
+        "product-1",
+        job_id="presenter_task_product-1",
+        depends_on="collector-job",
+        meta={"task": "presenter_task", "user_id": None, "worker_id": "product-1", "worker_type": "presenter_task"},
+    )
+
+    assert queue_calls[0]["kwargs"]["at_front"] is False
+    assert queue_calls[0]["kwargs"]["depends_on"] == "collector-job"
 
 
 def test_autopublish_product_returns_error_when_presenter_enqueue_fails(monkeypatch):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -462,13 +462,10 @@ def test_enqueue_task_passes_meta_to_rq_queue(monkeypatch):
 def test_enqueue_task_places_user_triggered_job_at_front(monkeypatch):
     queue_calls = []
 
-    class FakeJob:
-        is_deferred = False
-
     class FakeQueue:
         def enqueue(self, task_func, *args, job_id=None, **kwargs):
             queue_calls.append({"task_func": task_func, "args": args, "job_id": job_id, "kwargs": kwargs})
-            return FakeJob()
+            return object()
 
     qm = _make_queue_manager()
     monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
@@ -484,36 +481,59 @@ def test_enqueue_task_places_user_triggered_job_at_front(monkeypatch):
     assert queue_calls[0]["kwargs"]["at_front"] is True
 
 
-def test_enqueue_task_preserves_user_priority_for_deferred_job(monkeypatch):
-    class FakeJob:
-        is_deferred = True
-        enqueue_at_front = False
-        saved = False
-
-        def save(self):
-            self.saved = True
-
-    job = FakeJob()
+def test_enqueue_task_prioritizes_dependencies_for_user_triggered_job(monkeypatch):
+    queue_calls = []
 
     class FakeQueue:
-        def enqueue(self, *_args, **_kwargs):
-            return job
+        def enqueue(self, task_func, *args, job_id=None, **kwargs):
+            queue_calls.append({"task_func": task_func, "args": args, "job_id": job_id, "kwargs": kwargs})
+            return object()
 
     qm = _make_queue_manager()
     monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
 
-    result = qm.enqueue_task(
+    qm.enqueue_task(
         "publishers",
         "publisher_task",
         "product-1",
         "publisher-1",
-        depends_on=object(),
+        depends_on=["presenter-job-1", "presenter-job-2"],
         meta={"task": "publisher_task", "user_id": "user-1", "worker_id": "publisher-1", "worker_type": "publisher_task"},
     )
 
-    assert result is job
-    assert job.enqueue_at_front is True
-    assert job.saved is True
+    dependency = queue_calls[0]["kwargs"]["depends_on"]
+    assert isinstance(dependency, qm_module.Dependency)
+    assert dependency.dependencies == ["presenter-job-1", "presenter-job-2"]
+    assert dependency.allow_failure is False
+    assert dependency.enqueue_at_front is True
+
+
+def test_enqueue_task_preserves_existing_dependency_options(monkeypatch):
+    queue_calls = []
+
+    class FakeQueue:
+        def enqueue(self, task_func, *args, job_id=None, **kwargs):
+            queue_calls.append({"task_func": task_func, "args": args, "job_id": job_id, "kwargs": kwargs})
+            return object()
+
+    qm = _make_queue_manager()
+    monkeypatch.setattr(qm, "get_queue", lambda _queue_name: FakeQueue())
+    existing_dependency = qm_module.Dependency("presenter-job", allow_failure=True)
+
+    qm.enqueue_task(
+        "publishers",
+        "publisher_task",
+        "product-1",
+        "publisher-1",
+        depends_on=existing_dependency,
+        meta={"task": "publisher_task", "user_id": "user-1", "worker_id": "publisher-1", "worker_type": "publisher_task"},
+    )
+
+    dependency = queue_calls[0]["kwargs"]["depends_on"]
+    assert isinstance(dependency, qm_module.Dependency)
+    assert dependency.dependencies == ["presenter-job"]
+    assert dependency.allow_failure is True
+    assert dependency.enqueue_at_front is True
 
 
 def test_enqueue_at_preserves_user_priority(monkeypatch):

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -2,7 +2,9 @@
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import fakeredis
 import rq.registry as rq_registry
+from rq import Queue
 
 from core.managers import queue_manager as qm_module
 from core.managers.queue_manager import QueueManager
@@ -479,6 +481,36 @@ def test_enqueue_task_places_user_triggered_job_at_front(monkeypatch):
     )
 
     assert queue_calls[0]["kwargs"]["at_front"] is True
+
+
+def test_user_triggered_jobs_run_lifo_ahead_of_background_jobs():
+    queue = Queue("presenters", connection=fakeredis.FakeRedis())
+    qm = _make_queue_manager()
+    qm._queues = {"presenters": queue}
+
+    qm.enqueue_task(
+        "presenters",
+        "presenter_task",
+        "background-product",
+        job_id="background-job",
+        meta={"task": "presenter_task", "user_id": None, "worker_id": "background-product", "worker_type": "presenter_task"},
+    )
+    qm.enqueue_task(
+        "presenters",
+        "presenter_task",
+        "first-user-product",
+        job_id="first-user-job",
+        meta={"task": "presenter_task", "user_id": "user-1", "worker_id": "first-user-product", "worker_type": "presenter_task"},
+    )
+    qm.enqueue_task(
+        "presenters",
+        "presenter_task",
+        "second-user-product",
+        job_id="second-user-job",
+        meta={"task": "presenter_task", "user_id": "user-2", "worker_id": "second-user-product", "worker_type": "presenter_task"},
+    )
+
+    assert queue.job_ids == ["second-user-job", "first-user-job", "background-job"]
 
 
 def test_enqueue_task_prioritizes_dependencies_for_user_triggered_job(monkeypatch):

--- a/src/core/tests/application/user_workspace/assessment/test_assess_api.py
+++ b/src/core/tests/application/user_workspace/assessment/test_assess_api.py
@@ -169,7 +169,7 @@ class TestAssessNewsItems(BaseTest):
         story_response = self.assert_get_ok(client, f"story/{story_id}", auth_header)
         assert story_response.get_json()["relevance"] == 0
 
-    def test_post_news_item_fetch_uses_simple_web_collector_payload(self, client, auth_header, monkeypatch):
+    def test_post_news_item_fetch_uses_simple_web_collector_payload(self, client, auth_header, admin_user, monkeypatch):
         captured = {}
 
         def fake_fetch_and_create_story(parameters, user_id=None):
@@ -190,7 +190,7 @@ class TestAssessNewsItems(BaseTest):
         assert response.status_code == 200
         assert response.get_json()["story_ids"] == ["story-1"]
         assert captured["parameters"] == payload
-        assert captured["user_id"]
+        assert captured["user_id"] == admin_user.id
 
     def test_post_news_item_fetch_rejects_non_object_parameters(self, client, auth_header):
         response = client.post(

--- a/src/core/tests/application/user_workspace/assessment/test_assess_api.py
+++ b/src/core/tests/application/user_workspace/assessment/test_assess_api.py
@@ -172,8 +172,9 @@ class TestAssessNewsItems(BaseTest):
     def test_post_news_item_fetch_uses_simple_web_collector_payload(self, client, auth_header, monkeypatch):
         captured = {}
 
-        def fake_fetch_and_create_story(parameters):
+        def fake_fetch_and_create_story(parameters, user_id=None):
             captured["parameters"] = parameters
+            captured["user_id"] = user_id
             return {"story_ids": ["story-1"], "news_item_ids": ["news-1"], "message": "1 News items added successfully"}, 200
 
         monkeypatch.setattr("core.api.assess.StoryService.fetch_and_create_story", fake_fetch_and_create_story)
@@ -189,6 +190,7 @@ class TestAssessNewsItems(BaseTest):
         assert response.status_code == 200
         assert response.get_json()["story_ids"] == ["story-1"]
         assert captured["parameters"] == payload
+        assert captured["user_id"]
 
     def test_post_news_item_fetch_rejects_non_object_parameters(self, client, auth_header):
         response = client.post(

--- a/src/core/tests/application/worker_pipeline/test_worker_api.py
+++ b/src/core/tests/application/worker_pipeline/test_worker_api.py
@@ -21,6 +21,25 @@ def _expected_story_tag_names(story: dict) -> set[str]:
 class TestWorkerApi:
     base_uri = "/api/worker"
 
+    def test_post_collection_bots_forwards_user_id(self, client, api_header, monkeypatch):
+        captured = {}
+
+        def fake_post_collection_bots(source_id, user_id=None):
+            captured["source_id"] = source_id
+            captured["user_id"] = user_id
+            return {"message": "scheduled"}, 200
+
+        monkeypatch.setattr("core.api.worker.queue_manager.queue_manager.post_collection_bots", fake_post_collection_bots)
+
+        response = client.put(
+            f"{self.base_uri}/post-collection-bots",
+            json={"source_id": "source-1", "user_id": "user-1"},
+            headers=api_header,
+        )
+
+        assert response.status_code == 200
+        assert captured == {"source_id": "source-1", "user_id": "user-1"}
+
     @pytest.mark.parametrize(
         "result_payload",
         [

--- a/src/worker/tests/unit/test_core_api.py
+++ b/src/worker/tests/unit/test_core_api.py
@@ -15,3 +15,13 @@ def test_update_osint_source_icon_sends_multipart_file(requests_mock):
 
     assert result == {"message": "Icon uploaded"}
     assert requests_mock.request_history[0].headers["Content-Type"].startswith("multipart/form-data")
+
+
+def test_run_post_collection_bots_forwards_current_job_user(requests_mock, monkeypatch):
+    requests_mock.put(f"{Config.TARANIS_CORE_URL}/worker/post-collection-bots", json={"message": "scheduled"})
+    monkeypatch.setattr(CoreApi, "_get_current_job_user_id", staticmethod(lambda: "user-1"))
+
+    result = CoreApi().run_post_collection_bots("source-1")
+
+    assert result == {"message": "scheduled"}
+    assert requests_mock.request_history[0].json() == {"source_id": "source-1", "user_id": "user-1"}

--- a/src/worker/tests/unit/test_healthcheck.py
+++ b/src/worker/tests/unit/test_healthcheck.py
@@ -47,12 +47,6 @@ def test_check_worker_health_passes_when_expected_queue_exists(monkeypatch):
     assert redis_connection.hgetall_keys == ["rq:worker:worker-a"]
 
 
-def test_expected_worker_queues_use_lowercase_worker_types(monkeypatch):
-    monkeypatch.setattr(healthcheck.Config, "WORKER_TYPES", ["Presenters", "Collectors"])
-
-    assert healthcheck._expected_worker_queues() == {"presenters", "collectors"}
-
-
 def test_check_worker_health_fails_when_expected_queue_missing(monkeypatch):
     monkeypatch.setattr(healthcheck.Config, "WORKER_TYPES", ["Collectors"])
     redis_connection = FakeRedis(workers={"rq:worker:worker-b": {"queues": "bots"}})

--- a/src/worker/tests/unit/test_healthcheck.py
+++ b/src/worker/tests/unit/test_healthcheck.py
@@ -47,6 +47,12 @@ def test_check_worker_health_passes_when_expected_queue_exists(monkeypatch):
     assert redis_connection.hgetall_keys == ["rq:worker:worker-a"]
 
 
+def test_expected_worker_queues_use_lowercase_worker_types(monkeypatch):
+    monkeypatch.setattr(healthcheck.Config, "WORKER_TYPES", ["Presenters", "Collectors"])
+
+    assert healthcheck._expected_worker_queues() == {"presenters", "collectors"}
+
+
 def test_check_worker_health_fails_when_expected_queue_missing(monkeypatch):
     monkeypatch.setattr(healthcheck.Config, "WORKER_TYPES", ["Collectors"])
     redis_connection = FakeRedis(workers={"rq:worker:worker-b": {"queues": "bots"}})

--- a/src/worker/tests/unit/test_worker_queue_order.py
+++ b/src/worker/tests/unit/test_worker_queue_order.py
@@ -1,4 +1,17 @@
+import pytest
+from pydantic import ValidationError
+
 import worker
+from worker.config import WORKER_TYPE_PRIORITIES, Settings
+
+
+def test_worker_types_default_to_priority_order():
+    assert Settings.model_fields["WORKER_TYPES"].default == list(WORKER_TYPE_PRIORITIES)
+
+
+def test_worker_types_reject_unknown_values():
+    with pytest.raises(ValidationError, match="Unknown worker types: Unknown"):
+        Settings(WORKER_TYPES=["Unknown"])
 
 
 def test_get_queues_uses_default_priority_order(monkeypatch):

--- a/src/worker/tests/unit/test_worker_queue_order.py
+++ b/src/worker/tests/unit/test_worker_queue_order.py
@@ -1,0 +1,17 @@
+import worker
+
+
+def test_get_queues_uses_default_priority_order(monkeypatch):
+    monkeypatch.setattr(
+        worker.Config,
+        "WORKER_TYPES",
+        ["Collectors", "Bots", "Misc", "Connectors", "Publishers", "Presenters"],
+    )
+
+    assert worker.get_queues() == ["presenters", "publishers", "connectors", "misc", "bots", "collectors"]
+
+
+def test_get_queues_only_includes_enabled_worker_types(monkeypatch):
+    monkeypatch.setattr(worker.Config, "WORKER_TYPES", ["Collectors"])
+
+    assert worker.get_queues() == ["collectors"]

--- a/src/worker/tests/unit/test_worker_queue_order.py
+++ b/src/worker/tests/unit/test_worker_queue_order.py
@@ -22,9 +22,3 @@ def test_get_queues_uses_default_priority_order(monkeypatch):
     )
 
     assert worker.get_queues() == ["presenters", "publishers", "connectors", "misc", "bots", "collectors"]
-
-
-def test_get_queues_only_includes_enabled_worker_types(monkeypatch):
-    monkeypatch.setattr(worker.Config, "WORKER_TYPES", ["Collectors"])
-
-    assert worker.get_queues() == ["collectors"]

--- a/src/worker/worker/__init__.py
+++ b/src/worker/worker/__init__.py
@@ -8,7 +8,7 @@ This module sets up RQ workers for different job types:
 - connectors: Handle external integrations
 
 Usage:
-    rq worker collectors bots presenters publishers connectors
+    rq worker presenters publishers connectors misc bots collectors
 """
 
 import sys
@@ -36,24 +36,10 @@ def get_redis_connection(*, spawn_safe: bool = False):
 
 
 def get_queues():
-    """Get list of queue names based on configured worker types."""
-    queue_names = []
+    """Get enabled queue names in dequeue-priority order."""
     worker_types = Config.WORKER_TYPES
-
-    if "Collectors" in worker_types:
-        queue_names.append("collectors")
-    if "Bots" in worker_types:
-        queue_names.append("bots")
-    if "Presenters" in worker_types:
-        queue_names.append("presenters")
-    if "Publishers" in worker_types:
-        queue_names.append("publishers")
-    if "Connectors" in worker_types:
-        queue_names.append("connectors")
-    if "Misc" in worker_types:
-        queue_names.append("misc")
-
-    return queue_names
+    worker_type_priorities = ("Presenters", "Publishers", "Connectors", "Misc", "Bots", "Collectors")
+    return [worker_type.lower() for worker_type in worker_type_priorities if worker_type in worker_types]
 
 
 def register_task_modules():

--- a/src/worker/worker/__init__.py
+++ b/src/worker/worker/__init__.py
@@ -17,7 +17,7 @@ from typing import Any
 import redis
 from rq import Queue, SpawnWorker, Worker
 
-from worker.config import Config
+from worker.config import WORKER_TYPE_PRIORITIES, Config
 from worker.core_api import CoreApi
 from worker.log import logger
 from worker.rq_failure_bridge import rq_failure_exception_handler, rq_work_horse_killed_handler
@@ -38,8 +38,7 @@ def get_redis_connection(*, spawn_safe: bool = False):
 def get_queues():
     """Get enabled queue names in dequeue-priority order."""
     worker_types = Config.WORKER_TYPES
-    worker_type_priorities = ("Presenters", "Publishers", "Connectors", "Misc", "Bots", "Collectors")
-    return [worker_type.lower() for worker_type in worker_type_priorities if worker_type in worker_types]
+    return [worker_type.lower() for worker_type in WORKER_TYPE_PRIORITIES if worker_type in worker_types]
 
 
 def register_task_modules():

--- a/src/worker/worker/config.py
+++ b/src/worker/worker/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     SSL_VERIFICATION: bool = False
     DISABLE_HTTP3: bool = False
     REQUESTS_TIMEOUT: int = 60
-    # This defines the execution order of worker types. RQ will process queues in the order they are defined here.
+    # This selects which task types the worker handles. The worker defines their dequeue-priority order.
     WORKER_TYPES: list[Literal["Bots", "Collectors", "Presenters", "Publishers", "Connectors", "Misc"]] = [
         "Bots",
         "Collectors",

--- a/src/worker/worker/config.py
+++ b/src/worker/worker/config.py
@@ -4,6 +4,9 @@ from pydantic import ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
 
+WORKER_TYPE_PRIORITIES = ("Presenters", "Publishers", "Connectors", "Misc", "Bots", "Collectors")
+
+
 class Settings(BaseSettings):
     class Config:
         env_file = ".env"
@@ -22,14 +25,7 @@ class Settings(BaseSettings):
     DISABLE_HTTP3: bool = False
     REQUESTS_TIMEOUT: int = 60
     # This selects which task types the worker handles. The worker defines their dequeue-priority order.
-    WORKER_TYPES: list[Literal["Bots", "Collectors", "Presenters", "Publishers", "Connectors", "Misc"]] = [
-        "Bots",
-        "Collectors",
-        "Presenters",
-        "Publishers",
-        "Connectors",
-        "Misc",
-    ]
+    WORKER_TYPES: list[str] = list(WORKER_TYPE_PRIORITIES)
     REDIS_URL: str = "redis://localhost:6379"
     REDIS_PASSWORD: str | None = None
     RQ_WORKER_CLASS: Literal["auto", "fork", "spawn"] = "auto"
@@ -48,6 +44,13 @@ class Settings(BaseSettings):
             return "/"
 
         return f"/{v.strip('/')}/"
+
+    @field_validator("WORKER_TYPES")
+    @classmethod
+    def ensure_known_worker_types(cls, worker_types: list[str]) -> list[str]:
+        if unknown_worker_types := set(worker_types) - set(WORKER_TYPE_PRIORITIES):
+            raise ValueError(f"Unknown worker types: {', '.join(sorted(unknown_worker_types))}")
+        return worker_types
 
     @model_validator(mode="after")
     def set_taranis_core(self) -> Self:

--- a/src/worker/worker/core_api.py
+++ b/src/worker/worker/core_api.py
@@ -413,7 +413,10 @@ class CoreApi:
 
     def run_post_collection_bots(self, source_id) -> dict | None:
         try:
-            return self.api_put("/worker/post-collection-bots", json_data={"source_id": source_id})
+            return self.api_put(
+                "/worker/post-collection-bots",
+                json_data={"source_id": source_id, "user_id": self._get_current_job_user_id()},
+            )
         except Exception:
             logger.exception("Can't run Post Collection Bots")
             return None

--- a/src/worker/worker/healthcheck.py
+++ b/src/worker/worker/healthcheck.py
@@ -7,14 +7,6 @@ from worker.config import Config
 
 
 CRON_LEADER_KEY = "rq:cron:leader"
-WORKER_QUEUE_NAMES = {
-    "Bots": "bots",
-    "Collectors": "collectors",
-    "Presenters": "presenters",
-    "Publishers": "publishers",
-    "Connectors": "connectors",
-    "Misc": "misc",
-}
 
 
 def _redis_connection() -> Redis:
@@ -26,7 +18,7 @@ def _redis_connection() -> Redis:
 
 
 def _expected_worker_queues() -> set[str]:
-    return {WORKER_QUEUE_NAMES[worker_type] for worker_type in Config.WORKER_TYPES if worker_type in WORKER_QUEUE_NAMES}
+    return {worker_type.lower() for worker_type in Config.WORKER_TYPES}
 
 
 def check_worker_health(redis_connection: Any, hostname: str | None = None) -> None:


### PR DESCRIPTION
This is a "minimal" solution without any additional priority queues.

RQ's option `at_front` is used to set a user triggered job in front of a queue.

About deferred: This is passed through the jobs with `is_deferred` to accomplish priority in the full chain of multiple jobs, where the first one was triggered by a user.

RQ sets it indirectly. `is_deferred` is a read-only property:

```python
@property
def is_deferred(self) -> bool:
    return self.get_status() == JobStatus.DEFERRED
```

Currently taranis does not call bots after a collector with `depends_on`. 
But the `at_front` option is forwarded to the scheduling post-collection bots.

Additionally the order of the queues is changed here https://github.com/taranis-ai/taranis-ai/blob/868-enqueue-user-triggered-jobs-with-proper-priorities/src/worker/worker/__init__.py#L41
