### PR TITLE
prune retired cron jobs and update related tests

### DIFF
--- a/docs/agents/scheduler-dashboard.md
+++ b/docs/agents/scheduler-dashboard.md
@@ -57,4 +57,5 @@ Load this memory when working on the scheduler dashboard, scheduled jobs, active
 - Do not carry `search`, `page`, `limit`, or `order` from one scheduler tab into another.
 - Auto-refresh must not reset an active search, sort, page, or page-size selection.
 - Runtime RQ registry data is not SQL-backed, so scheduler list filtering, ordering, and pagination are applied after collecting and annotating the registry entries.
+- Core owns the `rq:cron:def` Redis hash. Startup reconciliation treats the current source, bot, and housekeeping specifications as an allowlist and removes every other persisted definition and its artifacts.
 - Execution-history totals and per-worker statistics describe the full matching dataset, not only the visible page.

--- a/src/core/core/managers/queue_manager.py
+++ b/src/core/core/managers/queue_manager.py
@@ -290,11 +290,7 @@ class QueueManager:
             managed_specs = self._get_managed_cron_specs()
             desired_ids = set(managed_specs)
             current_ids = self._get_registered_cron_job_ids()
-            housekeeping_ids = set(self._get_housekeeping_cron_specs())
-            managed_current_ids = {
-                job_id for job_id in current_ids if job_id.startswith(("osint_source_", "bot_")) or job_id in housekeeping_ids
-            }
-            stale_ids = sorted(managed_current_ids - desired_ids)
+            stale_ids = sorted(current_ids - desired_ids)
 
             registered = 0
             source_count = 0

--- a/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
+++ b/src/core/tests/application/admin_console/configuration/test_queue_manager_scheduler_extended.py
@@ -960,12 +960,14 @@ def test_reschedule_all_prunes_stale_managed_cron_jobs(monkeypatch):
     qm._redis.hashes["rq:cron:def"] = {  # type: ignore[attr-defined]
         "osint_source_stale": b'{"cron":"0 * * * *"}',
         "bot_stale": b'{"cron":"0 * * * *"}',
-        "custom_keep": b'{"cron":"0 * * * *"}',
+        "reconcile_task_failures": b'{"cron":"*/5 * * * *"}',
+        "unconfigured_job": b'{"cron":"0 * * * *"}',
     }
     qm._redis.zsets["rq:cron:next"] = {  # type: ignore[attr-defined]
         "osint_source_stale": 1234.0,
         "bot_stale": 1234.0,
-        "custom_keep": 1234.0,
+        "reconcile_task_failures": 1234.0,
+        "unconfigured_job": 1234.0,
     }
 
     purged_calls: list[tuple[set[str], list[str]]] = []
@@ -986,7 +988,14 @@ def test_reschedule_all_prunes_stale_managed_cron_jobs(monkeypatch):
     assert "cleanup_task_history" in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
     assert "osint_source_stale" not in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
     assert "bot_stale" not in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
-    assert "custom_keep" in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
+    assert "reconcile_task_failures" not in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
+    assert "reconcile_task_failures" not in qm._redis.zsets["rq:cron:next"]  # type: ignore[index,attr-defined]
+    assert "unconfigured_job" not in qm._redis.hashes["rq:cron:def"]  # type: ignore[index,attr-defined]
     assert len(purged_calls) == 1
     assert purged_calls[0][0] == set()
-    assert set(purged_calls[0][1]) == {"cron_osint_source_stale_", "cron_bot_stale_"}
+    assert set(purged_calls[0][1]) == {
+        "cron_osint_source_stale_",
+        "cron_bot_stale_",
+        "cron_reconcile_task_failures_",
+        "cron_unconfigured_job_",
+    }


### PR DESCRIPTION
Remove stale cron registration in Redis.

841d648b introduced a housekeeping task, a0e6a2c3 removed it.

But current reconciliation only removes stale source jobs, bot jobs, and currently known housekeeping IDs.

The cron process consequently continues enqueing it.

I confirmed this in a dev instance with 

```
redis-cli HGET rq:cron:def reconcile_task_failures
redis-cli ZSCORE rq:cron:next reconcile_task_failures
```

and removed it manually prior this bugfix-PR with

```
redis-cli HDEL rq:cron:def reconcile_task_failures
redis-cli ZREM rq:cron:next reconcile_task_failures
redis-cli XADD rq:cron:events '*' op delete job_id reconcile_task_failures
```
