### PR TITLE
Add build date to container metadata and scripts

### DIFF
--- a/.github/workflows/build_core.yaml
+++ b/.github/workflows/build_core.yaml
@@ -121,6 +121,7 @@ jobs:
         run: |
           echo "GIT_INFO=$(./docker/git_info.sh)" >>${GITHUB_ENV}
           echo "BUILD_VERSION=$(./docker/git_info.sh build-version)" >>${GITHUB_ENV}
+          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>${GITHUB_ENV}
 
       - name: Set metadata for container build
         id: meta
@@ -144,6 +145,7 @@ jobs:
           build-args: |
             git_info=${{ env.GIT_INFO }}
             build_version=${{ env.BUILD_VERSION }}
+            build_date=${{ env.BUILD_DATE }}
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ matrix.arch }}:latest
           cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ matrix.arch }}:latest,mode=max
           outputs: type=image,"name=${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true,compression=zstd

--- a/.github/workflows/build_frontend.yaml
+++ b/.github/workflows/build_frontend.yaml
@@ -121,6 +121,7 @@ jobs:
         run: |
           echo "GIT_INFO=$(./docker/git_info.sh)" >>${GITHUB_ENV}
           echo "BUILD_VERSION=$(./docker/git_info.sh build-version)" >>${GITHUB_ENV}
+          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>${GITHUB_ENV}
 
       - name: Set metadata for container build
         id: meta
@@ -144,6 +145,7 @@ jobs:
           build-args: |
             git_info=${{ env.GIT_INFO }}
             build_version=${{ env.BUILD_VERSION }}
+            build_date=${{ env.BUILD_DATE }}
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ matrix.arch }}:latest
           cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}-cache-${{ matrix.arch }}:latest,mode=max
           outputs: type=image,"name=${{ env.GHCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true,compression=zstd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,7 @@ jobs:
           images=("taranis-core" "taranis-worker" "taranis-ingress" "taranis-frontend")
           short_sha=$(printf '%.7s' "${GITHUB_SHA}")
           git_info=$(printf '{"branch":"master","HEAD":"%s","tag":"%s"}' "${short_sha}" "${TAG}")
+          build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           for image in "${images[@]}"; do
             case "${image}" in
@@ -65,6 +66,7 @@ jobs:
                 build_args=(
                   --build-arg "git_info=${git_info}"
                   --build-arg "build_version=${TAG}"
+                  --build-arg "build_date=${build_date}"
                 )
                 ;;
               taranis-worker)
@@ -85,6 +87,7 @@ jobs:
                 build_args=(
                   --build-arg "git_info=${git_info}"
                   --build-arg "build_version=${TAG}"
+                  --build-arg "build_date=${build_date}"
                 )
                 ;;
             esac

--- a/docker/Containerfile.core
+++ b/docker/Containerfile.core
@@ -47,6 +47,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --from=builder --chown=user:user /app/.venv /app/.venv
 COPY --chown=user:user ./src/core/. /app/
 
+ARG build_date
+RUN printf 'BUILD_DATE=%s\n' "${build_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" > /app/.env && \
+    chown user:user /app/.env
+
 USER user
 
 ENV PYTHONOPTIMIZE=1

--- a/docker/Containerfile.frontend
+++ b/docker/Containerfile.frontend
@@ -50,6 +50,10 @@ COPY --from=builder --chown=user:user /app/.venv /app/.venv
 COPY --chown=user:user ./src/frontend/app.py /app/app.py
 COPY --from=builder --chown=user:user /app/frontend /app/frontend
 
+ARG build_date
+RUN printf 'BUILD_DATE=%s\n' "${build_date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" > /app/.env && \
+    chown user:user /app/.env
+
 USER user
 
 ENV PYTHONOPTIMIZE=1

--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -9,14 +9,16 @@ REPO_NAMESPACE=${GITHUB_REPOSITORY_OWNER:-"taranis-ai"}
 REPO="${IMAGE_REGISTRY}/${REPO_NAMESPACE}"
 GIT_INFO=$(./docker/git_info.sh)
 BUILD_VERSION=${BUILD_VERSION:-$(./docker/git_info.sh build-version)}
+BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9_.-]/_/g')
 
-echo "Building containers for branch ${CURRENT_BRANCH} on ${REPO} with git info ${GIT_INFO} and build version ${BUILD_VERSION}"
+echo "Building containers for branch ${CURRENT_BRANCH} on ${REPO} with git info ${GIT_INFO}, build version ${BUILD_VERSION}, and build date ${BUILD_DATE}"
 
 build_core() {
   docker buildx build --file docker/Containerfile.core \
     --build-arg "git_info=${GIT_INFO}" \
     --build-arg "build_version=${BUILD_VERSION}" \
+    --build-arg "build_date=${BUILD_DATE}" \
     --tag "${REPO}/taranis-core:latest" \
     --tag "${REPO}/taranis-core:${CURRENT_BRANCH}" \
     --load .
@@ -43,6 +45,7 @@ build_frontend() {
   docker buildx build --file docker/Containerfile.frontend \
     --build-arg "git_info=${GIT_INFO}" \
     --build-arg "build_version=${BUILD_VERSION}" \
+    --build-arg "build_date=${BUILD_DATE}" \
     --tag "${REPO}/taranis-frontend:latest" \
     --tag "${REPO}/taranis-frontend:${CURRENT_BRANCH}" \
     --load .


### PR DESCRIPTION
Fixes #1001 

This pull request introduces a standardized approach to embedding the build date into both the backend and frontend Docker containers. The build date is now consistently captured during CI/CD workflows and passed as a build argument to the Docker build process, ensuring that each image contains metadata about when it was built.

**Build metadata improvements:**

* Added a `BUILD_DATE` environment variable in the GitHub Actions workflows (`build_core.yaml`, `build_frontend.yaml`, `release.yaml`) to capture the UTC build timestamp and pass it as a build argument to Docker builds. [[1]](diffhunk://#diff-2441cf7b5b40f2568cccaca9869605e3093294e200d14c16ce6e403903685c3bR124) [[2]](diffhunk://#diff-2441cf7b5b40f2568cccaca9869605e3093294e200d14c16ce6e403903685c3bR148) [[3]](diffhunk://#diff-50b1caecf2a37a9b7d1f55d80c26d41e30b963fe52b6421a5732b1d1116aef19R124) [[4]](diffhunk://#diff-50b1caecf2a37a9b7d1f55d80c26d41e30b963fe52b6421a5732b1d1116aef19R148) [[5]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR60) [[6]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR69) [[7]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR90)

* Updated `docker/build_container.sh` to set and use the `BUILD_DATE` variable, passing it as a build argument to both the core and frontend container builds and including it in the build log output. [[1]](diffhunk://#diff-f053ec63fdfab34b347dfc386e8805079df7d938ae42628946e017511a48c41fR12-R21) [[2]](diffhunk://#diff-f053ec63fdfab34b347dfc386e8805079df7d938ae42628946e017511a48c41fR48)

**Docker image enhancements:**

* Modified `docker/Containerfile.core` and `docker/Containerfile.frontend` to accept the `build_date` build argument, write it to an `.env` file inside the container, and set proper ownership, making the build date available at runtime. [[1]](diffhunk://#diff-e278e0724ed444fc8e5a54ab712f4a1d958c7f396ce744ecf45d3d7321a4e3e8R50-R53) [[2]](diffhunk://#diff-c93bdacd595913fd7f3788c175df21290ae507d6a5c723c5a8a12e6430f3cc74R53-R56)