### PR TITLE
Fix: Move assess-top-bar rule out of template

### DIFF
--- a/docs/agents/assess-filters.md
+++ b/docs/agents/assess-filters.md
@@ -8,6 +8,8 @@ Load this memory for tasks mentioning assess filters, the assess sidebar, story 
 
 Assess filters let users narrow stories and news items from the assess workspace by search text, read/important/relevant/in-report states, source, group, language, tags, date range, and sorting.
 
+The shared Assess selection bar is hidden when JavaScript is unavailable. Its `<noscript>` style belongs in `base.html`, not in HTMX-swappable fragments, so filtering cannot accidentally activate the fallback style.
+
 Filter option lists must reflect current user-visible database state. `/api/assess/filter-lists` builds those options on request and returns tags, sources, groups, and languages. The frontend may cache the response per user, so core writes that affect assess views must invalidate the relevant frontend cache scope.
 
 Saved assess default filters belong to the user profile. Applying defaults should preserve the same canonical query parameter shape used by normal sidebar filtering. Saving with an existing saved filter name updates that filter, duplicate filter criteria under another name are rejected, and managed filters can be updated from the current sidebar filters.
@@ -39,6 +41,7 @@ Saved assess default filters belong to the user profile. Applying defaults shoul
   - `filter_token_select.html`
   - `tri_state_filter.html`
   - `saved_filters_dialog.html`
+- No-JavaScript layout: `src/frontend/frontend/templates/base.html`
 - Shared saved filter template: `src/frontend/frontend/templates/assess/saved_filter_cards.html`
 
 ## Data Flow

--- a/docs/agents/story-bookmarks.md
+++ b/docs/agents/story-bookmarks.md
@@ -23,6 +23,8 @@ Bookmark detail views reuse Assess story cards, but hide the per-story `Bookmark
 
 Bookmark detail views also reuse the Assess selection hotkey bar except for `Shift+B`. Bookmark actions re-render the bookmark detail instead of navigating back to Assess, Read/Important actions stay at the top level alongside Remove selected, and story cards expose Read, Important, and In Reports state even when the user's compact-card preference is enabled. The clustering dialog still offers `Cluster and Open`; choosing it intentionally navigates to the resulting primary story.
 
+Without JavaScript, bookmark detail views hide the shared selection bar through the base template's global `<noscript>` rule.
+
 Selecting a Bookmark story card checks its native `story_ids` input and updates both the selection count and the card's selected styling (`aria-selected`, primary background/border, and shadow). Bookmark actions submit those checked inputs directly; JavaScript only adapts the HTML-backed selection to the shared Assess toolbar interface. Assess and Bookmark use the same card-state synchronizer so their selected cards cannot diverge visually.
 
 Per-card Ungroup requests carry the bookmark ID and re-render the current collection for both success and error responses. Core rejects ungrouping stories assigned to reports, so Bookmark must show that error without redirecting to Assess.
@@ -52,7 +54,7 @@ When an eligible bookmarked story is ungrouped, core replaces its bookmark relat
 - Frontend views: `src/frontend/frontend/views/story_bookmark_views.py`, `src/frontend/frontend/views/story_views.py`
 - Frontend selection adapter: `src/frontend/frontend/templates/bookmarks/bookmark_detail.html`
 - Frontend routes: `src/frontend/frontend/router/assess.py`
-- Templates: `src/frontend/frontend/templates/bookmarks/`, `src/frontend/frontend/templates/assess/bookmarks_bar.html`, `src/frontend/frontend/templates/assess/story_actions.html`
+- Templates: `src/frontend/frontend/templates/base.html`, `src/frontend/frontend/templates/bookmarks/`, `src/frontend/frontend/templates/assess/bookmarks_bar.html`, `src/frontend/frontend/templates/assess/story_actions.html`
 - Tests:
   - `src/core/tests/application/user_workspace/assessment/test_story_bookmarks.py`
   - `src/frontend/tests/unit/views/test_story_bookmark_view.py`

--- a/src/frontend/frontend/templates/assess/assess_top_bar.html
+++ b/src/frontend/frontend/templates/assess/assess_top_bar.html
@@ -30,13 +30,6 @@
   </button>
 {% endmacro %}
 
-<noscript>
-  <style>
-    #assess-top-bar {
-      display: none;
-    }
-  </style>
-</noscript>
 {% set bookmark_mode = bookmark is defined and bookmark %}
 <div id="assess-top-bar"
      class="sticky z-10 mb-4"

--- a/src/frontend/frontend/templates/base.html
+++ b/src/frontend/frontend/templates/base.html
@@ -27,9 +27,9 @@
         x-data="{ sidebarOpen: {{ 'true' if _show_sidebar and templates and templates.get('sidebar_template') else 'false' }}, init() { if (window.self !== window.top) this.sidebarOpen = false } }">
     {% include "partials/viewport_notice.html" %}
     {% include "partials/sidebar.html" %}
-    {% if _show_sidebar and templates and templates.get('sidebar_template') %}
-      <noscript>
-        <style>
+    <noscript>
+      <style>
+        {% if _show_sidebar and templates and templates.get('sidebar_template') %}
           #sidebar {
             width: 16rem;
           }
@@ -38,12 +38,12 @@
             margin-left: 16rem;
             max-width: calc(100vw - 16rem);
           }
-          #assess-top-bar {
-            display: none;
-          }
-        </style>
-      </noscript>
-    {% endif %}
+        {% endif %}
+        #assess-top-bar {
+          display: none;
+        }
+      </style>
+    </noscript>
 
     <header id="navbar"
             class="fixed left-0 right-0 h-16 bg-base-200 flex items-center justify-between px-4 z-30 navbar"

--- a/src/frontend/frontend/templates/base.html
+++ b/src/frontend/frontend/templates/base.html
@@ -38,6 +38,9 @@
             margin-left: 16rem;
             max-width: calc(100vw - 16rem);
           }
+          #assess-top-bar {
+            display: none;
+          }
         </style>
       </noscript>
     {% endif %}

--- a/src/frontend/tests/playwright/test_no_javascript.py
+++ b/src/frontend/tests/playwright/test_no_javascript.py
@@ -63,6 +63,18 @@ class TestNoJavaScriptLayout:
             story_card.get_by_test_id("toggle-read").click()
             page.wait_for_url("**/story/**", wait_until="domcontentloaded")
             expect(page.get_by_test_id(f"story-card-{story_id}")).to_have_attribute("data-story-read", "true")
+
+            page.goto(url_for("assess.assess", _external=True))
+            story_card = page.get_by_test_id(f"story-card-{story_id}")
+            story_card.get_by_test_id("story-actions-menu").click()
+            story_card.get_by_test_id("bookmark-story").click()
+            page.wait_for_url("**/story/**", wait_until="domcontentloaded")
+
+            page.goto(url_for("assess.bookmarks", _external=True))
+            page.locator('[data-testid^="open-bookmark-"]').first.click()
+            page.wait_for_url("**/bookmarks/**", wait_until="domcontentloaded")
+            expect(page.get_by_test_id("bookmark-detail")).to_be_visible()
+            expect(page.locator("#assess-top-bar")).to_be_hidden()
         finally:
             page.close()
             context.close()

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -661,7 +661,8 @@ def test_analyze_page_hides_sidebar_toggle_when_no_sidebar(authenticated_client,
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert 'aria-label="Toggle sidebar"' not in html
-    assert "<noscript>" not in html
+    assert "#sidebar {" not in html
+    assert "#sidebar ~ main {" not in html
 
 
 def test_publish_page_hides_sidebar_toggle_when_no_sidebar(authenticated_client, mock_core_get_endpoints, responses_mock):


### PR DESCRIPTION
The style rule for top-assess-bar is activated by the browser, even if js is enabled when the template is rendered with xhr. (the `<noscript>` tag is ignored)

Moving the style rule outside of the rendered template fixes the disappearing top nav bar.

Fixes #1014 