### PR TITLE
fix(worker): suggest advertised RSS feed URLs

### DIFF
--- a/docs/agents/rss-source-health.md
+++ b/docs/agents/rss-source-health.md
@@ -6,7 +6,7 @@ RSS collectors, Atom feeds, feedparser validation, empty feeds, OSINT source sta
 
 ## Expected Behavior
 
-An RSS source fails immediately when feedparser cannot identify the response as RSS or Atom. A conditional 304 after that failure keeps the source failed because the unchanged response cannot prove that the feed became valid. A parseable feed with no entries is `NOT_MODIFIED` with the `rss_feed_empty` reason and a message explaining that the feed is valid but empty.
+An RSS source fails immediately when feedparser cannot identify the response as RSS or Atom. If the response is HTML and advertises an RSS or Atom feed through a standard `rel="alternate"` link, the failure message suggests the first advertised feed URL. A conditional 304 after that failure keeps the source failed because the unchanged response cannot prove that the feed became valid. A parseable feed with no entries is `NOT_MODIFIED` with the `rss_feed_empty` reason and a message explaining that the feed is valid but empty.
 
 Each state includes a user-facing message. Empty-feed results persist the current HTTP validators but do not count collection attempts or become failures.
 
@@ -19,7 +19,7 @@ Each state includes a user-facing message. Empty-feed results persist the curren
 
 ## Data Flow
 
-Core includes the latest persisted collector task in the worker's OSINT source payload. The RSS collector rejects responses without a detected feed version and reports parseable feeds that produce no items separately. The collector task records an empty feed as `NOT_MODIFIED` with the `rss_feed_empty` reason. A later 304 preserves that reason and message so the user continues to see that the unchanged feed is empty. A 304 also preserves a preceding failure instead of marking it successful.
+Core includes the latest persisted collector task in the worker's OSINT source payload. The RSS collector rejects responses without a detected feed version, adds the first advertised RSS or Atom URL to the user-facing failure message when available, and reports parseable feeds that produce no items separately. The collector task records an empty feed as `NOT_MODIFIED` with the `rss_feed_empty` reason. A later 304 preserves that reason and message so the user continues to see that the unchanged feed is empty. A 304 also preserves a preceding failure instead of marking it successful.
 
 ## Testing
 

--- a/src/worker/tests/collectors/conftest.py
+++ b/src/worker/tests/collectors/conftest.py
@@ -101,7 +101,12 @@ def rss_collector_mock(requests_mock, collectors_mock):
     requests_mock.get(rss_collector_fav_icon_url, json={})
     requests_mock.get(rss_collector_url, text=file_loader("test_rss_feed.xml"))
     requests_mock.get(rss_collector_url_not_modified, text="", status_code=304, headers={"Last-Modified": "Sat, 01 Jan 2022 00:00:00 GMT"})
-    requests_mock.get(rss_collector_url_no_content, text="", status_code=200)
+    requests_mock.get(
+        rss_collector_url_no_content,
+        text='<html><head><link rel="alternate" href="/feed.xml" type="application/rss+xml"></head></html>',
+        status_code=200,
+        headers={"Content-Type": "text/html"},
+    )
 
 
 @pytest.fixture

--- a/src/worker/tests/collectors/test_collector.py
+++ b/src/worker/tests/collectors/test_collector.py
@@ -76,8 +76,12 @@ def test_rss_collector_get_feed(rss_collector_mock, rss_collector):
         rss_collector.collect(rss_collector_source_data_not_modified)
     assert str(exception.value) == f"{rss_collector_url_not_modified} was not modified"
 
-    with pytest.raises(RSSCollectorError, match="No parseable RSS or Atom feed was detected"):
+    with pytest.raises(RSSCollectorError) as exception:
         rss_collector.collect(rss_collector_source_data_no_content)
+    assert str(exception.value) == (
+        f"No parseable RSS or Atom feed was detected at {rss_collector_source_data_no_content['parameters']['FEED_URL']}"
+        ". Suggested feed URL: https://rss.example.com/feed.xml"
+    )
 
 
 def test_rss_published_date_uses_first_parseable_value(rss_collector):

--- a/src/worker/worker/collectors/rss_collector.py
+++ b/src/worker/worker/collectors/rss_collector.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin, urlparse
 
 import feedparser
 import niquests as requests
+from bs4 import BeautifulSoup
 from models.assess import NewsItem
 
 from worker.collectors.base_web_collector import BaseWebCollector, parse_datetime
@@ -262,11 +263,30 @@ class RSSCollector(BaseWebCollector):
 
         self.feed_content = self.send_get_request(self.feed_url)
 
-        feed = feedparser.parse(self.feed_content.content)
+        feed_content = self.feed_content.content
+        feed = feedparser.parse(feed_content)
         if not feed.get("version"):
-            parser_error = feed.get("bozo_exception")
-            error_detail = f": {parser_error}" if parser_error else ""
-            raise RSSCollectorError(f"No parseable RSS or Atom feed was detected at {self.feed_url}{error_detail}")
+            logger.info(f"Could not parse RSS or Atom feed: {feed.get('bozo_exception')}")
+            suggestion = ""
+            if feed_content and "html" in self.feed_content.headers.get("content-type", "").lower():
+                html = BeautifulSoup(feed_content, "html.parser")
+                for link in html.find_all("link", rel="alternate"):
+                    feed_type = link.get("type")
+                    href = link.get("href")
+                    if (
+                        isinstance(feed_type, str)
+                        and feed_type.strip().lower()
+                        in {
+                            "application/rss+xml",
+                            "application/atom+xml",
+                        }
+                        and isinstance(href, str)
+                        and href.strip()
+                    ):
+                        base_url = str(self.feed_content.url or self.feed_url)
+                        suggestion = f". Suggested feed URL: {urljoin(base_url, href.strip())}"
+                        break
+            raise RSSCollectorError(f"No parseable RSS or Atom feed was detected at {self.feed_url}{suggestion}")
         return feed
 
     def preview_collector(self, source: dict):


### PR DESCRIPTION
## Summary

- suggest the first standard RSS or Atom alternate link when an HTML page is configured as a feed
- keep feedparser diagnostics in worker logs instead of user-facing errors
- adapt the existing invalid-feed fixture and assertion
- document RSS feed discovery behavior

## Validation

- live collector check against `https://kurier.at` suggested `https://kurier.at/xml/rss`

This pull request enhances the RSS collector to provide better feedback when a requested URL returns HTML that advertises an RSS or Atom feed but does not itself contain a parseable feed. Now, when such a situation is detected, the collector suggests the first advertised feed URL in the error message. The documentation and tests have been updated accordingly.

**Improvements to RSS feed detection and error messaging:**

* [`src/worker/worker/collectors/rss_collector.py`](diffhunk://#diff-31b4f15d2cda06e925327719a51329ef9220d1a30601a6c6fbcc3504970c941aL265-R289): When a response is HTML and includes a `rel="alternate"` link to an RSS or Atom feed, the collector now suggests the first advertised feed URL in the failure message. This is implemented using BeautifulSoup to parse the HTML and extract the feed link.
* [`src/worker/worker/collectors/rss_collector.py`](diffhunk://#diff-31b4f15d2cda06e925327719a51329ef9220d1a30601a6c6fbcc3504970c941aR7): Added import for BeautifulSoup to support HTML parsing.

**Documentation updates:**

* [`docs/agents/rss-source-health.md`](diffhunk://#diff-ea31cfc3e2213da5548f9fba99c8699bf41897e0234adaeaf7bcd60767ebf78aL9-R9): Updated expected behavior and data flow sections to describe the new suggestion feature in failure messages when an advertised feed URL is detected in HTML responses. [[1]](diffhunk://#diff-ea31cfc3e2213da5548f9fba99c8699bf41897e0234adaeaf7bcd60767ebf78aL9-R9) [[2]](diffhunk://#diff-ea31cfc3e2213da5548f9fba99c8699bf41897e0234adaeaf7bcd60767ebf78aL22-R22)

**Testing improvements:**

* [`src/worker/tests/collectors/conftest.py`](diffhunk://#diff-53a49686370e4360a86fe588fffea44e5e45e6164a02fce23627c02e9dee2e71L104-R109): Modified the mock for a no-content RSS response to return an HTML page advertising an RSS feed, ensuring the new suggestion logic is tested.
* [`src/worker/tests/collectors/test_collector.py`](diffhunk://#diff-f082c0af9b7f6e1bdb0585f83835f172975fdb4ee9d8236a7f08d89ce56929b9L79-R84): Updated the test to assert that the error message includes the suggested feed URL when a non-parseable HTML page advertises a feed.