### PR TITLE
add ordering parameter to templates endpoint

### DIFF
--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -332,7 +332,7 @@ class Templates(MethodView):
             return jsonify(build_template_response(template_path)), 200
 
         # List all templates
-        items = build_templates_list()
+        items = build_templates_list(request.args.get("order"))
         return jsonify({"items": items, "total_count": len(items)}), 200
 
     @auth_required("CONFIG_PRODUCT_TYPE_CREATE")

--- a/src/core/core/service/template_service.py
+++ b/src/core/core/service/template_service.py
@@ -152,6 +152,9 @@ def build_template_response(template_path: str) -> TemplateResponse:
     return _build_template_response(template_path, get_template_content(template_path))
 
 
-def build_templates_list() -> list[TemplateResponse]:
+def build_templates_list(order: str | None = None) -> list[TemplateResponse]:
     """Return API payloads for every stored presenter template."""
-    return [_build_template_response(template_id, get_template_content(template_id)) for template_id in list_templates()]
+    items = [_build_template_response(template_id, get_template_content(template_id)) for template_id in list_templates()]
+    if order in {"id_asc", "id_desc"}:
+        items.sort(key=lambda item: item["id"].casefold(), reverse=order == "id_desc")
+    return items

--- a/src/core/core/static/openapi3_1.yaml
+++ b/src/core/core/static/openapi3_1.yaml
@@ -4751,6 +4751,15 @@ paths:
       operationId: config.config_templates.get
       security:
       - UserAuth: []
+      parameters:
+      - name: order
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - id_asc
+          - id_desc
       responses:
         '200':
           description: success

--- a/src/core/tests/application/admin_console/configuration/test_template_service.py
+++ b/src/core/tests/application/admin_console/configuration/test_template_service.py
@@ -81,3 +81,21 @@ def test_build_templates_list_returns_api_payloads(monkeypatch):
             },
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("order", "expected_ids"),
+    [
+        ("id_asc", ["alpha.html", "Beta.html", "zulu.html"]),
+        ("id_desc", ["zulu.html", "Beta.html", "alpha.html"]),
+    ],
+)
+def test_templates_endpoint_orders_by_id(client, auth_header, monkeypatch, order, expected_ids):
+    templates = ["zulu.html", "alpha.html", "Beta.html"]
+    monkeypatch.setattr(template_service, "list_templates", lambda: templates)
+    monkeypatch.setattr(template_service, "get_template_content", lambda _: "Hello")
+
+    response = client.get("/api/config/templates", query_string={"order": order}, headers=auth_header)
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json["items"]] == expected_ids


### PR DESCRIPTION
Fixes: #1022 

This pull request adds support for ordering the list of presenter templates by their IDs in the API, allowing clients to specify ascending or descending order. The main changes include updating the API endpoint, service logic, documentation, and adding tests to cover the new ordering functionality.

API and service enhancements:

* The `GET /api/config/templates` endpoint now accepts an optional `order` query parameter (`id_asc` or `id_desc`) to control the sorting of template IDs. [[1]](diffhunk://#diff-e1a51744d292b7f772c88b71dc57e5b54c9ff8dcb1398009ddb1a38f729cde44L335-R335) [[2]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaR4754-R4762)
* The `build_templates_list` service function in `template_service.py` was updated to accept the `order` parameter and sort the returned templates accordingly, using case-insensitive ordering.

Documentation updates:

* The OpenAPI specification (`openapi3_1.yaml`) was updated to document the new `order` query parameter, including its allowed values.

Testing improvements:

* New parameterized tests were added to verify that the templates endpoint correctly orders templates by ID in both ascending and descending order.