### PR TITLE
refactor: improve error message for OSINT source deletion with related news items

### DIFF
--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -782,7 +782,7 @@ class OSINTSources(MethodView):
 
             if _NewsItemService.has_related_news_items(source_id):
                 return {
-                    "error": "OSINT Source has related News Items. To delete this item and all related News Items, set the 'force' flag."
+                    "error": "The OSINT source could not be deleted because related news items exist. Enable force deletion to delete the source and its related data."
                 }, 409
 
         response, status = osint_source.OSINTSource.delete(source_id, force=force)

--- a/src/core/tests/application/admin_console/configuration/test_config_api.py
+++ b/src/core/tests/application/admin_console/configuration/test_config_api.py
@@ -11,7 +11,12 @@ from werkzeug.datastructures import FileStorage
 
 from core.config import Config
 from tests.application.support.api_test_base import BaseTest
-from tests.application.support.builders import build_import_user_payload, delete_user_by_username
+from tests.application.support.builders import (
+    build_import_user_payload,
+    build_news_item_payload,
+    create_story,
+    delete_user_by_username,
+)
 
 
 _INVALID_IMAGE_BYTES = b"not-an-image"
@@ -445,6 +450,39 @@ class TestSourcesConfigApi(BaseTest):
         source_id = cleanup_sources["id"]
         response = self.assert_delete_ok(client, uri=f"osint-sources/{source_id}", auth_header=auth_header)
         assert response.json["message"] == "OSINT Source deleted"
+
+    def test_delete_source_with_related_news_items_requires_force(self, app, client, auth_header):
+        from core.model.osint_source import OSINTSource
+
+        source_id = str(uuid.uuid7())
+        source_data = {
+            "id": source_id,
+            "description": "Source with related news items",
+            "name": f"Source with data {source_id}",
+            "rank": 0,
+            "parameters": {"FEED_URL": "https://example.invalid/feed.xml"},
+            "type": "rss_collector",
+        }
+
+        with app.app_context():
+            OSINTSource.add(source_data)
+            create_story(news_items=[build_news_item_payload(source_id=source_id)])
+
+        try:
+            response = client.delete(self.concat_url(f"osint-sources/{source_id}"), headers=auth_header)
+
+            assert response.status_code == 409
+            assert response.json["error"] == (
+                "The OSINT source could not be deleted because related news items exist. "
+                "Enable force deletion to delete the source and its related data."
+            )
+
+            response = client.delete(self.concat_url(f"osint-sources/{source_id}?force=true"), headers=auth_header)
+            assert response.status_code == 200
+        finally:
+            with app.app_context():
+                if OSINTSource.get(source_id):
+                    OSINTSource.delete(source_id, force=True)
 
     def test_create_source_group(self, client, auth_header, cleanup_source_groups):
         response = self.assert_post_ok(client, uri="osint-source-groups", json_data=cleanup_source_groups, auth_header=auth_header)

--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -554,13 +554,25 @@ class BaseView(MethodView):
 
     @classmethod
     def delete_multiple_view(cls, object_ids: list[str], params: dict[str, str] | None = None) -> tuple[str, int]:
-        results = []
-        results.extend(DataPersistenceLayer().delete_object(cls.model, object_id, params=params) for object_id in object_ids)
-        if not all(r.ok for r in results):
-            return (
-                render_template("notification/index.html", notification={"message": "Failed to delete selected items", "error": True}),
-                500,
-            )
+        for deleted_count, object_id in enumerate(object_ids):
+            core_response = DataPersistenceLayer().delete_object(cls.model, object_id, params=params)
+            if not core_response.ok:
+                payload = cls._response_payload(core_response)
+                notification = (
+                    cls.get_notification_from_dict(payload)
+                    if isinstance(payload, dict)
+                    else {"message": "Failed to delete selected items", "error": True}
+                )
+                if deleted_count:
+                    item_label = "item was" if deleted_count == 1 else "items were"
+                    notification["message"] = (
+                        f"{deleted_count} selected {item_label} deleted before deletion stopped. {notification['message']}"
+                    )
+
+                cls._invalidate_model_cache()
+                response, status_code = cls.render_list()
+                response += render_template("notification/index.html", notification=notification)
+                return response, status_code
 
         cls._invalidate_model_cache()
 

--- a/src/frontend/frontend/views/base_view.py
+++ b/src/frontend/frontend/views/base_view.py
@@ -554,25 +554,10 @@ class BaseView(MethodView):
 
     @classmethod
     def delete_multiple_view(cls, object_ids: list[str], params: dict[str, str] | None = None) -> tuple[str, int]:
-        for deleted_count, object_id in enumerate(object_ids):
-            core_response = DataPersistenceLayer().delete_object(cls.model, object_id, params=params)
-            if not core_response.ok:
-                payload = cls._response_payload(core_response)
-                notification = (
-                    cls.get_notification_from_dict(payload)
-                    if isinstance(payload, dict)
-                    else {"message": "Failed to delete selected items", "error": True}
-                )
-                if deleted_count:
-                    item_label = "item was" if deleted_count == 1 else "items were"
-                    notification["message"] = (
-                        f"{deleted_count} selected {item_label} deleted before deletion stopped. {notification['message']}"
-                    )
-
-                cls._invalidate_model_cache()
-                response, status_code = cls.render_list()
-                response += render_template("notification/index.html", notification=notification)
-                return response, status_code
+        results = [DataPersistenceLayer().delete_object(cls.model, object_id, params=params) for object_id in object_ids]
+        failed_response = next((response for response in results if not response.ok), None)
+        if failed_response is not None:
+            return cls.get_notification_from_response(failed_response), failed_response.status_code or 500
 
         cls._invalidate_model_cache()
 

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -332,6 +332,62 @@ class TestSourceView:
 
         assert SourceView.get_admin_menu_badge() == 4
 
+    def test_bulk_delete_stops_on_related_news_items_and_renders_current_table(self, authenticated_client, responses_mock, htmx_header):
+        core_url = f"{Config.TARANIS_CORE_URL}/config/osint-sources"
+        related_data_error = (
+            "The OSINT source could not be deleted because related news items exist. "
+            "Enable force deletion to delete the source and its related data."
+        )
+        remaining_sources = [
+            {
+                "id": source_id,
+                "name": name,
+                "description": "",
+                "rank": 0,
+                "type": "rss_collector",
+                "parameters": {},
+            }
+            for source_id, name in [("source-blocked", "Blocked source"), ("source-pending", "Pending source")]
+        ]
+
+        responses_mock.delete(f"{core_url}/source-deleted", json={"message": "OSINT Source deleted"})
+        responses_mock.delete(f"{core_url}/source-blocked", json={"error": related_data_error}, status=409)
+        responses_mock.delete(f"{core_url}/source-pending", json={"message": "OSINT Source deleted"})
+        responses_mock.post(f"{Config.TARANIS_CORE_URL}/admin/cache/invalidate", json={"message": "Cache invalidated"})
+        responses_mock.get(core_url, json={"items": remaining_sources, "total_count": len(remaining_sources)})
+
+        response = authenticated_client.delete(
+            SourceView.get_base_route(),
+            data={"ids": ["source-deleted", "source-blocked", "source-pending"]},
+            headers=htmx_header,
+        )
+
+        assert response.status_code == 200
+        response_text = response.get_data(as_text=True)
+        assert f"1 selected item was deleted before deletion stopped. {related_data_error}" in response_text
+        assert "Blocked source" in response_text
+        assert "Pending source" in response_text
+        delete_paths = [urlparse(call.request.url).path for call in responses_mock.calls if call.request.method == "DELETE"]
+        assert delete_paths == ["/api/config/osint-sources/source-deleted", "/api/config/osint-sources/source-blocked"]
+
+    def test_bulk_force_delete_forwards_force_to_every_source(self, authenticated_client, responses_mock, htmx_header):
+        core_url = f"{Config.TARANIS_CORE_URL}/config/osint-sources"
+        for source_id in ["source-one", "source-two"]:
+            responses_mock.delete(f"{core_url}/{source_id}", json={"message": "OSINT Source deleted"})
+        responses_mock.post(f"{Config.TARANIS_CORE_URL}/admin/cache/invalidate", json={"message": "Cache invalidated"})
+        responses_mock.get(core_url, json={"items": [], "total_count": 0})
+
+        response = authenticated_client.delete(
+            SourceView.get_base_route(),
+            data={"ids": ["source-one", "source-two"], "force": "true"},
+            headers=htmx_header,
+        )
+
+        assert response.status_code == 200
+        delete_calls = [call for call in responses_mock.calls if call.request.method == "DELETE"]
+        assert len(delete_calls) == 2
+        assert all(parse_qs(urlparse(call.request.url).query) == {"force": ["true"]} for call in delete_calls)
+
     def test_import_post_view(self, authenticated_client, responses_mock):
         """
         Test that the import_post_view method correctly extracts the "sources" key

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -332,61 +332,22 @@ class TestSourceView:
 
         assert SourceView.get_admin_menu_badge() == 4
 
-    def test_bulk_delete_stops_on_related_news_items_and_renders_current_table(self, authenticated_client, responses_mock, htmx_header):
+    def test_bulk_delete_renders_related_news_items_error(self, authenticated_client, responses_mock, htmx_header):
         core_url = f"{Config.TARANIS_CORE_URL}/config/osint-sources"
         related_data_error = (
             "The OSINT source could not be deleted because related news items exist. "
             "Enable force deletion to delete the source and its related data."
         )
-        remaining_sources = [
-            {
-                "id": source_id,
-                "name": name,
-                "description": "",
-                "rank": 0,
-                "type": "rss_collector",
-                "parameters": {},
-            }
-            for source_id, name in [("source-blocked", "Blocked source"), ("source-pending", "Pending source")]
-        ]
-
-        responses_mock.delete(f"{core_url}/source-deleted", json={"message": "OSINT Source deleted"})
         responses_mock.delete(f"{core_url}/source-blocked", json={"error": related_data_error}, status=409)
-        responses_mock.delete(f"{core_url}/source-pending", json={"message": "OSINT Source deleted"})
-        responses_mock.post(f"{Config.TARANIS_CORE_URL}/admin/cache/invalidate", json={"message": "Cache invalidated"})
-        responses_mock.get(core_url, json={"items": remaining_sources, "total_count": len(remaining_sources)})
 
         response = authenticated_client.delete(
             SourceView.get_base_route(),
-            data={"ids": ["source-deleted", "source-blocked", "source-pending"]},
+            data={"ids": ["source-blocked"]},
             headers=htmx_header,
         )
 
-        assert response.status_code == 200
-        response_text = response.get_data(as_text=True)
-        assert f"1 selected item was deleted before deletion stopped. {related_data_error}" in response_text
-        assert "Blocked source" in response_text
-        assert "Pending source" in response_text
-        delete_paths = [urlparse(call.request.url).path for call in responses_mock.calls if call.request.method == "DELETE"]
-        assert delete_paths == ["/api/config/osint-sources/source-deleted", "/api/config/osint-sources/source-blocked"]
-
-    def test_bulk_force_delete_forwards_force_to_every_source(self, authenticated_client, responses_mock, htmx_header):
-        core_url = f"{Config.TARANIS_CORE_URL}/config/osint-sources"
-        for source_id in ["source-one", "source-two"]:
-            responses_mock.delete(f"{core_url}/{source_id}", json={"message": "OSINT Source deleted"})
-        responses_mock.post(f"{Config.TARANIS_CORE_URL}/admin/cache/invalidate", json={"message": "Cache invalidated"})
-        responses_mock.get(core_url, json={"items": [], "total_count": 0})
-
-        response = authenticated_client.delete(
-            SourceView.get_base_route(),
-            data={"ids": ["source-one", "source-two"], "force": "true"},
-            headers=htmx_header,
-        )
-
-        assert response.status_code == 200
-        delete_calls = [call for call in responses_mock.calls if call.request.method == "DELETE"]
-        assert len(delete_calls) == 2
-        assert all(parse_qs(urlparse(call.request.url).query) == {"force": ["true"]} for call in delete_calls)
+        assert response.status_code == 409
+        assert related_data_error in response.get_data(as_text=True)
 
     def test_import_post_view(self, authenticated_client, responses_mock):
         """


### PR DESCRIPTION
Frontend swallowed cores reply about "deletion failed because of related news items" and just put out "Failed to delete selected items". This has changed.

On only partially succeeding deletion the bulk process stops and the UI stays in sync of the current status.

test_e2e_admin.py now proves that "force=true" is necessary