### PR TITLE
Scroll to tag editor when clicking "Manage tags"

### DIFF
--- a/src/frontend/frontend/templates/assess/news_item_card.html
+++ b/src/frontend/frontend/templates/assess/news_item_card.html
@@ -2,7 +2,7 @@
   {% set news_item_tags = (news_item.tags.values() if news_item.tags is mapping else (news_item.tags or [])) | list %}
   <article id="news-item-card-{{ news_item.id }}"
            class="rounded-lg border border-base-200 bg-base-100 p-2 shadow-sm"
-           x-data='{ tagEditorOpen: false, initialTags: {{ news_item_tags | tojson }}, tags: [], init() { this.resetTags(); }, normalizedTags() { const values = Array.isArray(this.initialTags) ? this.initialTags : Object.values(this.initialTags || {}); return values.map(tag => ({ "name": tag.name || "", "tag_type": tag.tag_type || "" })); }, resetTags() { this.tags = this.normalizedTags(); if (this.tags.length === 0) { this.tags.push({ "name": "", "tag_type": "" }); } }, toggleTagEditor() { if (this.tagEditorOpen) { this.resetTags(); this.tagEditorOpen = false; } else { this.resetTags(); this.tagEditorOpen = true; } }, addTag() { this.tags.push({ "name": "", "tag_type": "" }); }, removeTag(index) { this.tags.splice(index, 1); if (this.tags.length === 0) { this.tags.push({ "name": "", "tag_type": "" }); } } }'>
+           x-data='{ tagEditorOpen: false, initialTags: {{ news_item_tags | tojson }}, tags: [], init() { this.resetTags(); }, normalizedTags() { const values = Array.isArray(this.initialTags) ? this.initialTags : Object.values(this.initialTags || {}); return values.map(tag => ({ "name": tag.name || "", "tag_type": tag.tag_type || "" })); }, resetTags() { this.tags = this.normalizedTags(); if (this.tags.length === 0) { this.tags.push({ "name": "", "tag_type": "" }); } }, toggleTagEditor() { if (this.tagEditorOpen) { this.resetTags(); this.tagEditorOpen = false; } else { this.resetTags(); this.tagEditorOpen = true; this.$nextTick(() => this.$refs.tagEditor.scrollIntoView({ behavior: "smooth", block: "start" })); } }, addTag() { this.tags.push({ "name": "", "tag_type": "" }); }, removeTag(index) { this.tags.splice(index, 1); if (this.tags.length === 0) { this.tags.push({ "name": "", "tag_type": "" }); } } }'>
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between gap-2">
         <div class="flex flex-wrap items-start gap-2">
@@ -68,6 +68,7 @@
       {% if edit_tags %}
         {# djlint:off #}
         <form class="rounded-lg border border-base-200 bg-base-200/40 p-3"
+              x-ref="tagEditor"
               x-show="tagEditorOpen"
               x-cloak
               hx-post="{{ url_for('assess.update_news_item_tags', news_item_id=news_item.id) }}"

--- a/src/frontend/tests/playwright/test_e2e_user.py
+++ b/src/frontend/tests/playwright/test_e2e_user.py
@@ -319,6 +319,7 @@ class TestEndToEndUser(BaseE2ETest):
             page.get_by_role("textbox", name="Analyst comments").fill("Test analyst comment")
             news_item_card = page.locator("article[id^='news-item-card-']").first
             news_item_card.get_by_test_id("edit-newsitem-tags").click()
+            expect(news_item_card.get_by_role("heading", name="News item tags")).to_be_in_viewport()
             news_item_card.get_by_test_id("news-item-tag-name-input").fill("tag name")
             news_item_card.get_by_test_id("news-item-tag-value-input").fill("tag value")
             news_item_card.get_by_role("button", name="Add tag").click()


### PR DESCRIPTION
When a user clicks on "Manage Tags" on a News Item card, the page now scrolls down to the opened Tag Editor.