### PR TITLE
fix: avoid Assess popup when no stories are added

### DIFF
--- a/src/core/core/api/worker.py
+++ b/src/core/core/api/worker.py
@@ -46,7 +46,7 @@ class AddNewsItems(MethodView):
             return {"error": "Expected a list of news items"}, 400
         logger.debug(f"Received {len(json_data)} news items for worker ingestion")
         result, status = Story.add_news_items(json_data)
-        if 200 <= status < 300:
+        if 200 <= status < 300 and result.get("news_item_ids"):
             realtime_publisher.assess_changed()
         invalidate_frontend_cache_on_success(status, scopes=(SCOPE_ASSESS_VIEWS, SCOPE_STORY_REPORT_VIEWS))
         return result, status

--- a/src/core/tests/application/worker_pipeline/test_worker_api.py
+++ b/src/core/tests/application/worker_pipeline/test_worker_api.py
@@ -22,6 +22,24 @@ def _expected_story_tag_names(story: dict) -> set[str]:
 class TestWorkerApi:
     base_uri = "/api/worker"
 
+    @pytest.mark.parametrize(
+        ("add_result", "should_notify"),
+        [
+            ({"story_ids": ["story-1"], "news_item_ids": ["news-1"], "message": "1 News item added successfully"}, True),
+            ({"story_ids": [], "news_item_ids": [], "message": "All news items were skipped"}, False),
+        ],
+    )
+    def test_news_item_ingestion_notifies_only_when_items_are_added(self, client, api_header, monkeypatch, add_result, should_notify):
+        assess_changed = Mock()
+        monkeypatch.setattr("core.api.worker.Story.add_news_items", lambda _: (add_result, 200))
+        monkeypatch.setattr("core.api.worker.realtime_publisher.assess_changed", assess_changed)
+
+        response = client.post(f"{self.base_uri}/news-items", json=[{"id": "news-1"}], headers=api_header)
+
+        assert response.status_code == 200
+        assert response.get_json() == add_result
+        assert assess_changed.call_count == int(should_notify)
+
     def test_rss_source_includes_global_entry_limit(self, client, api_header, fake_source, monkeypatch):
         monkeypatch.setattr(
             "core.model.osint_source.Settings.get_settings",


### PR DESCRIPTION
## Summary

Fixes #1055.

The worker ingestion endpoint broadcast `assess.changed` for every successful collector submission, including collections where every item was skipped. This made Assess show a misleading “new stories” popup.

## Changes

- Broadcast the Assess realtime event only when ingestion reports at least one added news item.
- Add a worker API regression test covering both added items and an all-skipped collection.

## Compatibility

Successful ingestion responses and cache invalidation are unchanged. Only the realtime Assess notification is suppressed when no news item was added.

## Tests

- `python -m pytest -c pyproject.toml tests/application/worker_pipeline/test_worker_api.py -q` (55 passed)
- `ruff check core tests` (passed)
- `ruff format --check core/api/worker.py tests/application/worker_pipeline/test_worker_api.py` (passed after formatting)
- `pyright core/api/worker.py` (0 errors)
- `python -m compileall -q src/core/core/api/worker.py src/core/tests/application/worker_pipeline/test_worker_api.py` (passed)
- `git diff --check` (passed)
- Full core pytest reached 100%; 18 existing Windows-environment errors occurred because the repository test harness and terminal summary use POSIX-path assumptions. The changed worker API tests passed.

## Limitations

`pyrefly` was not run because its locked Python 3.14 package download stalled in the Windows environment. The repository's required local environment was installed with `uv`; the targeted type check was completed with `pyright`.
