### PR TITLE
fix: make PostgreSQL readiness checks deterministic

### DIFF
--- a/.github/workflows/test_schema_migrate.yaml
+++ b/.github/workflows/test_schema_migrate.yaml
@@ -25,6 +25,7 @@ jobs:
           if git diff --quiet \
             "${{ github.event.pull_request.base.sha }}" \
             "${{ github.event.pull_request.head.sha }}" -- \
+            dev/test_master_to_branch_migration.sh \
             src/core/core/model \
             src/core/migrations \
             src/models; then

--- a/dev/test_master_to_branch_migration.sh
+++ b/dev/test_master_to_branch_migration.sh
@@ -80,7 +80,7 @@ cleanup() {
 
   if [ "${KEEP_MIGRATION_TEST_DB:-0}" != "1" ]; then
     if [ -n "${PG_CONTAINER:-}" ]; then
-      "$CONTAINER_CLI" rm -f "$PG_CONTAINER" >/dev/null 2>&1 || true
+      "$CONTAINER_CLI" rm -f -v "$PG_CONTAINER" >/dev/null 2>&1 || true
     fi
     if [ -n "${MASTER_WORKTREE:-}" ] && [ -d "$MASTER_WORKTREE" ]; then
       git worktree remove --force "$MASTER_WORKTREE" >/dev/null 2>&1 || true
@@ -139,7 +139,6 @@ git worktree add --detach "$MASTER_WORKTREE" "$BASE_REF" >/dev/null
 run_step "Start disposable PostgreSQL with $CONTAINER_CLI"
 "$CONTAINER_CLI" run \
   --detach \
-  --rm \
   --name "$PG_CONTAINER" \
   -e POSTGRES_USER="$PG_USER" \
   -e POSTGRES_PASSWORD="$PG_PASSWORD" \
@@ -147,14 +146,26 @@ run_step "Start disposable PostgreSQL with $CONTAINER_CLI"
   -p 127.0.0.1::5432 \
   "$PG_IMAGE" >/dev/null
 
+POSTGRES_READY=false
 for _ in {1..60}; do
-  if "$CONTAINER_CLI" exec "$PG_CONTAINER" pg_isready -U "$PG_USER" -d postgres >/dev/null 2>&1; then
+  # The image starts a temporary socket-only server while initializing. Probe
+  # TCP so only the final PostgreSQL process can satisfy the readiness check.
+  if "$CONTAINER_CLI" exec "$PG_CONTAINER" pg_isready -h 127.0.0.1 -U "$PG_USER" -d postgres >/dev/null 2>&1; then
+    POSTGRES_READY=true
     break
   fi
   sleep 1
 done
 
-"$CONTAINER_CLI" exec "$PG_CONTAINER" pg_isready -U "$PG_USER" -d postgres >/dev/null 2>&1 || fail "PostgreSQL did not become ready."
+if [ "$POSTGRES_READY" != "true" ]; then
+  echo "PostgreSQL container state:" >&2
+  "$CONTAINER_CLI" inspect \
+    --format 'status={{.State.Status}} running={{.State.Running}} exit_code={{.State.ExitCode}}' \
+    "$PG_CONTAINER" >&2 || true
+  echo "PostgreSQL container logs:" >&2
+  "$CONTAINER_CLI" logs "$PG_CONTAINER" >&2 || true
+  fail "PostgreSQL did not become ready."
+fi
 
 PG_PORT="$("$CONTAINER_CLI" port "$PG_CONTAINER" 5432/tcp | sed -E 's/.*:([0-9]+)$/\1/' | head -n 1)"
 [ -n "$PG_PORT" ] || fail "Could not determine PostgreSQL host port."


### PR DESCRIPTION
## Summary

- Probe PostgreSQL over TCP so the temporary socket-only initialization server cannot satisfy readiness.
- Track a successful probe instead of immediately probing again across the initialization restart window.
- Preserve failed containers long enough to print state and logs, then remove the container and its anonymous volumes during cleanup.
- Run the schema migration workflow when its migration harness changes.

Fixes #1046.

## Root cause

The original `pg_isready` call omitted a host and therefore used the container's Unix socket. The official image briefly starts a socket-only server during first-time initialization, stops it, and then starts the final server. The loop could accept the temporary server, while the immediate second probe landed in the restart gap and failed.

Using `-h 127.0.0.1` makes the probe match the TCP server used by the migration clients. The temporary initialization server explicitly has TCP disabled.

## Validation

- Reproduced the socket-only readiness phase and subsequent flap in 20/20 cold Docker starts using the same `postgres:17-alpine` digest reported in the issue.
- Verified the TCP probe became ready and remained ready in 20/20 cold starts.
- Ran the full released-database-to-branch migration harness successfully.
- Core unit tests: `79 passed`.
- Verified a deliberately early-exiting container reports `status=exited running=false exit_code=0` before cleanup.
- Verified cleanup does not leave anonymous PostgreSQL volumes.
- Passed `bash -n`, ShellCheck, actionlint, pre-commit changed-file hooks, and `git diff --check`.

## Compatibility

The runtime commands and inspected state fields are shared by Docker and Podman. Docker was exercised locally; Podman compatibility was checked against the official command and inspect-state documentation but was not run locally.