### PR TITLE
Centrifugo Version 

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,6 +12,7 @@ Deployment options:
 Replace every `CHANGE_ME_...` value before deployment.
 
 Always required:
+
 - In `kubernetes/00-config.yaml` (or `helm/values.yaml`), set `GRANIAN_HOST`.
 - In `kubernetes/01-secrets.yaml` (or `helm/values.yaml`), set `JWT_SECRET_KEY`, `API_KEY`, `CENTRIFUGO_API_KEY`, `CENTRIFUGO_CONNECT_PROXY_SECRET`, `PRE_SEED_PASSWORD_ADMIN`, `PRE_SEED_PASSWORD_USER`, `DB_URL`, `DB_DATABASE`, `DB_USER`, `DB_PASSWORD`, `REDIS_URL`, `CENTRIFUGO_REDIS_URL`, and `REDIS_PASSWORD`. Keep the two Centrifugo secrets distinct from each other and from existing application keys.
 - The raw manifest provides `TARANIS_BASE_PATH: /`; set it only when serving the application below a subpath.
@@ -19,6 +20,7 @@ Always required:
 - The raw manifest keeps the public realtime endpoint at `/sse`; ingress rewrites it to Centrifugo's `/connection/uni_sse`.
 
 Optional `llm-bot` overlay:
+
 - In `kubernetes/00-config.yaml`, set `LLM_BASE_URL`; optionally set `LLM_TIMEOUT` and `LLM_MODEL`.
 - In `kubernetes/01-secrets.yaml`, set `BOT_API_KEY`; optionally set `LLM_API_KEY` for providers that require one.
 - For Helm, set `config.llmBaseUrl`; optionally set `config.llmTimeout`, `config.llmModel`, and `secrets.llmApiKey`.
@@ -26,7 +28,7 @@ Optional `llm-bot` overlay:
 
 ## Images
 
-Core uses `ghcr.io/taranis-ai/taranis-core`, `taranis-frontend`, `taranis-ingress`, and `taranis-worker` (for `collector`, `worker`, and `cron`). Realtime uses the pinned `centrifugo/centrifugo:v6.9.1` image.
+Core uses `ghcr.io/taranis-ai/taranis-core`, `taranis-frontend`, `taranis-ingress`, and `taranis-worker` (for `collector`, `worker`, and `cron`). Realtime uses the pinned `centrifugo/centrifugo:v6.9` image.
 Optional overlay uses `ghcr.io/taranis-ai/taranis-llm-bot:latest`.
 Pin explicit tags for production.
 

--- a/deploy/argocd/values-example.yaml
+++ b/deploy/argocd/values-example.yaml
@@ -49,7 +49,7 @@ images:
     tag: latest
   centrifugo:
     repository: centrifugo/centrifugo
-    tag: v6.9.1
+    tag: v6.9
   ingress:
     tag: latest
   worker:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -84,7 +84,7 @@ images:
     tag: latest
   centrifugo:
     repository: centrifugo/centrifugo
-    tag: v6.9.1
+    tag: v6.9
   ingress:
     repository: ghcr.io/taranis-ai/taranis-ingress
     tag: latest

--- a/deploy/kubernetes/30-deployments-core.yaml
+++ b/deploy/kubernetes/30-deployments-core.yaml
@@ -183,7 +183,7 @@ spec:
       terminationGracePeriodSeconds: 45
       containers:
         - name: centrifugo
-          image: centrifugo/centrifugo:v6.9.1
+          image: centrifugo/centrifugo:v6.9
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/deploy/kubernetes/30-deployments-core.yaml
+++ b/deploy/kubernetes/30-deployments-core.yaml
@@ -184,7 +184,7 @@ spec:
       containers:
         - name: centrifugo
           image: centrifugo/centrifugo:v6.9
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           envFrom:
             - configMapRef:
                 name: centrifugo-env

--- a/dev/compose.yml
+++ b/dev/compose.yml
@@ -34,7 +34,7 @@ services:
       retries: 3
 
   centrifugo:
-    image: "centrifugo/centrifugo:v6.9.1"
+    image: "centrifugo/centrifugo:v6.9"
     depends_on:
       redis:
         condition: service_healthy

--- a/docker/compose-variations/compose.minimal.yml
+++ b/docker/compose-variations/compose.minimal.yml
@@ -196,7 +196,7 @@ services:
         max-file: "10"
 
   centrifugo:
-    image: "centrifugo/centrifugo:v6.9.1"
+    image: "centrifugo/centrifugo:v6.9"
     deploy:
       restart_policy:
         condition: always

--- a/docker/compose-variations/compose.ppn.yml
+++ b/docker/compose-variations/compose.ppn.yml
@@ -292,7 +292,7 @@ services:
         max-file: "10"
 
   centrifugo:
-    image: "centrifugo/centrifugo:v6.9.1"
+    image: "centrifugo/centrifugo:v6.9"
     deploy:
       restart_policy:
         condition: always

--- a/docker/compose-variations/compose.tor.yml
+++ b/docker/compose-variations/compose.tor.yml
@@ -253,7 +253,7 @@ services:
         max-file: "10"
 
   centrifugo:
-    image: "centrifugo/centrifugo:v6.9.1"
+    image: "centrifugo/centrifugo:v6.9"
     deploy:
       restart_policy:
         condition: always

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -300,7 +300,7 @@ services:
         max-file: "10"
 
   centrifugo:
-    image: "centrifugo/centrifugo:v6.9.1"
+    image: "centrifugo/centrifugo:v6.9"
     deploy:
       restart_policy:
         condition: always

--- a/docs/agents/realtime-events.md
+++ b/docs/agents/realtime-events.md
@@ -6,7 +6,7 @@ Centrifugo, SSE, `/sse`, `/connection/uni_sse`, realtime events, `EventSource`, 
 
 ## Expected Behavior
 
-- Centrifugo `v6.9.1` is the only realtime broker. The image tag is pinned in Compose, raw Kubernetes, and the existing Helm chart.
+- Centrifugo `v6.9` is the only realtime broker. Compose, raw Kubernetes, and the existing Helm chart intentionally use the rolling `v6.9` tag so deployments receive current `6.9.x` patch releases automatically.
 - Browsers use the same-origin public `${TARANIS_BASE_PATH}sse` URL. NGINX rewrites only that route to Centrifugo's `/connection/uni_sse`, forwards authentication/origin headers, and disables buffering and caching.
 - Centrifugo's client port is internal to the deployment. Its API, health, and metrics handlers use a separate internal port; admin, debug, Swagger, WebSocket, health, and metrics routes are not proxied publicly.
 - Centrifugo uses the existing Redis instance with the dedicated `taranis:realtime` prefix.
@@ -57,7 +57,7 @@ When a worker persists a terminal `source_preview_<source_id>` task for a user, 
 - The general Docker-backed frontend E2E suite disables realtime in both frontend and core because its test stack does not start Centrifugo; broker behavior is covered by the focused browser module and deployment checks above.
 - Render Compose variants with `docker compose ... config`.
 - Render the chart with `helm template` and raw manifests with `kubectl kustomize deploy/kubernetes`.
-- Start the pinned Centrifugo image from each rendered environment and verify health plus an authenticated broadcast; Centrifugo validates environment configuration on startup.
+- Start the configured Centrifugo `v6.9` image from each rendered environment and verify health plus an authenticated broadcast; Centrifugo validates environment configuration on startup.
 
 ## Pitfalls
 


### PR DESCRIPTION
This pull request updates the Centrifugo realtime broker version across all deployment and documentation files. The main change is switching from the explicitly pinned `v6.9.1` image tag to the rolling `v6.9` tag, ensuring deployments automatically receive the latest `6.9.x` patch releases. Documentation is updated to reflect this change and clarify the versioning approach.

**Centrifugo version update across environments:**

* All Docker Compose files (`docker/compose.yml`, `dev/compose.yml`, and `docker/compose-variations/compose.minimal.yml`, `compose.ppn.yml`, `compose.tor.yml`) now use the `centrifugo/centrifugo:v6.9` image tag instead of `v6.9.1`. [[1]](diffhunk://#diff-45bbb4f23e5ce9f69cefb061e34f0c64f59f4fcae4e13b4fce4408f45fb50d3bL303-R303) [[2]](diffhunk://#diff-179aaaa54e90c327e1f24333cdd54163b98fd92fdcdf94a383ae7a2e709748a9L37-R37) [[3]](diffhunk://#diff-3dc35d0a1183a541b6bc3d9ca989231e2865dbddacdc1ba6b01bb4c785f59112L199-R199) [[4]](diffhunk://#diff-f7612460ff81e7fc901f31102e20fed3d9f026da82a686b6e0241dd9238090bfL295-R295) [[5]](diffhunk://#diff-903e50ef75ce3a7e9f3f80f8d50ca146af1f926eaba6849056eb7121a211d18eL256-R256)
* Kubernetes and Helm deployment files (`deploy/kubernetes/30-deployments-core.yaml`, `deploy/helm/values.yaml`, `deploy/argocd/values-example.yaml`) are updated to use the `v6.9` tag for Centrifugo. [[1]](diffhunk://#diff-f41c0fb094f878127f5a58870ad33fbb983db6824033613f9054c512463213c7L186-R186) [[2]](diffhunk://#diff-5c751dcc8462e7d812cc776668da9d8bcc501dc3ff0364796105053389ae013cL87-R87) [[3]](diffhunk://#diff-6d5bedcb51d2494949d3ffdeac5d3f1100533580c7b1714173f42328e842ee71L52-R52)

**Documentation and configuration updates:**

* The deployment documentation (`deploy/README.md`) and realtime events documentation (`docs/agents/realtime-events.md`) are revised to explain the use of the rolling `v6.9` tag and the rationale for automatic patch updates. [[1]](diffhunk://#diff-0db16276644fc4f21eae05d761a230f6438feca8b7c0a92427c9d3b3ea85726aR15-R31) [[2]](diffhunk://#diff-1148355923c7e4dbfd103916ff64409224d0478708e205ee323492aefc087060L9-R9) [[3]](diffhunk://#diff-1148355923c7e4dbfd103916ff64409224d0478708e205ee323492aefc087060L60-R60)