### PR TITLE
Add JSON environment preseeding for initial settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ For production deployments, see our [Deployment Guide using docker compose](http
 
 For existing Celery/RabbitMQ deployments, see the [RQ Migration Guide](./dev/rq_migration_guide.md).
 
+To preseed global settings on a fresh instance, set core’s `PRE_SEED_SETTINGS` environment variable to a flat JSON object. See [settings preseeding](docker/README.md#settings-preseeding) for an example and restart behavior.
+
 ## Contributions
 
 We welcome contributions from the community! If you're interested in contributing to Taranis AI, please read our [Development Setup Guide](./dev/README.md) to get started.

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,6 +28,23 @@ cp env.sample .env
 
 Open file `.env` and defaults if needed
 
+### Settings preseeding
+
+Before the first startup, pass `PRE_SEED_SETTINGS` to the core container as a flat JSON object using the keys stored in Admin Settings. Any subset (or all settings) can be supplied; omitted keys retain their built-in defaults. For example, add this Compose override:
+
+```yaml
+services:
+  core:
+    environment:
+      PRE_SEED_SETTINGS: '{"default_timezone":"Europe/Vienna","rss_collector_max_entries":100,"default_bot_lookback_days":0,"onboarding_enabled":false}'
+```
+
+For a directly launched core process, export the same JSON value as `PRE_SEED_SETTINGS`. In Kubernetes or Helm, add it to the core container's environment (use a Secret if values contain credentials).
+
+Preseeding applies only when the persistent settings row does not exist. Restarts and upgrades preserve saved settings, including administrator edits; they do not merge newly supplied seed keys into an existing row. An empty object `{}` or an unset variable uses normal defaults. Use a JSON object, not the API's `{"settings": {...}}` wrapper. Invalid JSON and non-object values are rejected during configuration loading. Timezone, entry-limit, lookback, and onboarding values use the existing settings validators during initialization.
+
+An explicit `onboarding_enabled` seed overrides `SKIP_INITIAL_USER_ONBOARDING` and is copied to the initial users. After initialization, use Admin Settings to change values. Removing the variable does not undo persisted settings; no database migration is required.
+
 ## Startup & Usage
 
 Start-up application

--- a/docs/agents/initial-user-onboarding.md
+++ b/docs/agents/initial-user-onboarding.md
@@ -8,6 +8,8 @@ Initial database setup, pre-seeded users, onboarding tasks, `pre_seed_default_us
 
 `SKIP_INITIAL_USER_ONBOARDING` defaults to `false` and presets the persistent global `onboarding_enabled` setting only while that setting is missing. A value of `true` presets onboarding to disabled; later changes in Admin Settings remain authoritative.
 
+`PRE_SEED_SETTINGS` accepts a flat JSON object for any global settings. `Settings.initialize()` applies it only when no singleton settings row exists, filling omitted keys with normal defaults. An explicit `onboarding_enabled` seed overrides `SKIP_INITIAL_USER_ONBOARDING` and is copied to existing initial users. Subsequent startup preserves persisted settings and does not merge seed values. JSON parsing is handled by Pydantic Settings; initialization reuses existing timezone, integer, and boolean validators. Environment parsing and persistence/restart coverage live in `src/core/tests/test_settings.py`; deployment examples are in `docker/README.md`.
+
 Changing the global setting updates every existing user's `profile.onboarding_enabled` value. An administrator can then override individual users in Admin Users, including enabling one user while the global setting remains disabled. New users inherit the current global value unless the create form explicitly overrides it.
 
 Disabling onboarding suppresses pending tasks without changing completed, dismissed, or pending task state. An actual global value change replaces all existing per-user enabled flags; submitting the unchanged global value preserves individual overrides.

--- a/src/core/core/config.py
+++ b/src/core/core/config.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any, Literal
 from urllib.parse import urlparse, urlunparse
@@ -8,7 +9,7 @@ from models.cache_contract import (
     CACHE_KEY_PREFIX_DEFAULT,
 )
 from pydantic import Field, SecretStr, ValidationInfo, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 def mask_db_uri(uri: str) -> str:
@@ -147,6 +148,12 @@ class Settings(BaseSettings):
     PRE_SEED_PASSWORD_ADMIN: str = "admin"
     PRE_SEED_PASSWORD_USER: str = "user"
     SKIP_INITIAL_USER_ONBOARDING: bool = False
+    PRE_SEED_SETTINGS: Annotated[dict[str, Any], NoDecode] = Field(default_factory=dict, repr=False)
+
+    @field_validator("PRE_SEED_SETTINGS", mode="before")
+    @classmethod
+    def parse_pre_seed_settings(cls, value: Any) -> Any:
+        return json.loads(value) if isinstance(value, str) else value
 
     REDIS_URL: str = "redis://localhost:6379"
     REDIS_PASSWORD: SecretStr | None = None

--- a/src/core/core/model/settings.py
+++ b/src/core/core/model/settings.py
@@ -98,7 +98,15 @@ class Settings(BaseModel):
             onboarding_missing = "onboarding_enabled" not in (settings.settings or {})
             settings.settings = cls.with_defaults(settings.settings)
         else:
-            settings = cls()
+            seed = cls._normalize_update_data(Config.PRE_SEED_SETTINGS)
+            for key in ("default_bot_lookback_days", "rss_collector_max_entries"):
+                if key in seed:
+                    seed[key] = cls._validate_non_negative_int(seed[key])
+            if seed.get("rss_collector_max_entries") == 0:
+                raise ValueError("Invalid RSS collector entry limit")
+            if "onboarding_enabled" in seed:
+                seed["onboarding_enabled"] = cls._validate_bool(seed["onboarding_enabled"])
+            settings = cls(seed)
             onboarding_missing = True
             db.session.add(settings)
 

--- a/src/core/tests/test_settings.py
+++ b/src/core/tests/test_settings.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 from flask import Flask
 from pydantic import SecretStr, ValidationError
+from pydantic_settings import SettingsError
 
 from core.config import Settings
 
@@ -264,3 +267,46 @@ def test_sqlalchemy_pool_recycle_accepts_minus_one(clear_pool_env_vars):
 
     assert settings.SQLALCHEMY_POOL_RECYCLE == -1
     assert settings.SQLALCHEMY_ENGINE_OPTIONS["pool_recycle"] == -1
+
+
+@pytest.mark.parametrize("payload", ["{", "[]", "null", '"value"'])
+def test_pre_seed_settings_requires_json_object(monkeypatch, payload):
+    monkeypatch.setenv("PRE_SEED_SETTINGS", payload)
+
+    with pytest.raises((SettingsError, ValidationError)):
+        Settings()
+
+
+def test_pre_seed_settings_initialization(session, admin_user, monkeypatch):
+    from core.model.settings import Config
+    from core.model.settings import Settings as PersistentSettings
+
+    seed = {
+        "default_timezone": " Europe/Vienna ",
+        "rss_collector_max_entries": 100,
+        "default_bot_lookback_days": 0,
+        "onboarding_enabled": False,
+        "default_collector_proxy": "http://proxy:8080",
+    }
+    monkeypatch.setenv("PRE_SEED_SETTINGS", json.dumps(seed))
+    config = Settings()
+    monkeypatch.setattr(Config, "PRE_SEED_SETTINGS", config.PRE_SEED_SETTINGS)
+    session.delete(PersistentSettings.get_settings_entry())
+    session.flush()
+
+    PersistentSettings.initialize()
+    session.expire_all()
+
+    expected = PersistentSettings.with_defaults({**seed, "default_timezone": "Europe/Vienna"})
+    assert PersistentSettings.get_settings() == expected
+    assert admin_user.profile["onboarding_enabled"] is False
+    assert config.PRE_SEED_SETTINGS == seed
+
+    _, status = PersistentSettings.update({"settings": {"rss_collector_max_entries": 25}})
+    assert status == 200
+    monkeypatch.setattr(Config, "PRE_SEED_SETTINGS", {"rss_collector_max_entries": 200, "onboarding_enabled": True})
+    PersistentSettings.initialize()
+    session.expire_all()
+
+    assert PersistentSettings.get_settings() == {**expected, "rss_collector_max_entries": 25}
+    assert admin_user.profile["onboarding_enabled"] is False


### PR DESCRIPTION
This pull request introduces a new mechanism for preseeding global settings in the application using a flat JSON object via the `PRE_SEED_SETTINGS` environment variable. This allows administrators to initialize any subset of global settings on first startup, improving deployment flexibility and automation. The changes include updates to documentation, configuration parsing, model initialization, and comprehensive tests to validate the new behavior.

**Settings Preseeding Feature**

* Added support for passing a flat JSON object in the `PRE_SEED_SETTINGS` environment variable to preseed global settings on a fresh instance. The preseeding only applies when no persistent settings exist and does not merge with existing settings. Documentation was updated with usage examples and caveats. (`README.md`, `docker/README.md`, `docs/agents/initial-user-onboarding.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19) [[2]](diffhunk://#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49R31-R47) [[3]](diffhunk://#diff-bcbb9a8f9ff45ce3df47e209d40472a2ede0e77daa069ec53f0001e608dc99c9R11-R12)
* In `src/core/core/config.py`, added the `PRE_SEED_SETTINGS` config option, parsing it as a JSON object and validating its type before application. (`src/core/core/config.py`) [[1]](diffhunk://#diff-d83509487bf2951d3b720ae55b65e3a199f16bad8ded349323a8c7cbcbf6354fR1) [[2]](diffhunk://#diff-d83509487bf2951d3b720ae55b65e3a199f16bad8ded349323a8c7cbcbf6354fL11-R12) [[3]](diffhunk://#diff-d83509487bf2951d3b720ae55b65e3a199f16bad8ded349323a8c7cbcbf6354fR151-R156)

**Settings Initialization Logic**

* Updated `Settings.initialize()` to apply preseeding logic: validates and applies the provided settings only if no settings row exists, with type checks and value validation for specific keys. (`src/core/core/model/settings.py`)

**Testing and Validation**

* Added tests to ensure only valid JSON objects are accepted for `PRE_SEED_SETTINGS`, and to verify correct initialization and persistence behavior. Tests also confirm that preseeding does not override existing settings on restart. (`src/core/tests/test_settings.py`) [[1]](diffhunk://#diff-a84ccd2c1a3407daac8926073b927e00e26fcbb375f303e31cc47a8a12930571R1-R6) [[2]](diffhunk://#diff-a84ccd2c1a3407daac8926073b927e00e26fcbb375f303e31cc47a8a12930571R270-R312)