### PR TITLE
Refactor presenter template API to use names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For container and Python dependency SBOM scope and attestations, see [docs/sbom.
 
 An [OpenAPI spec](./src/core/core/static/openapi3_1.yaml) for the REST API is included and can be accessed in a running installation under `config/openapi`.
 
+Presenter template API responses and creation requests use `name` for the filename; list sorting uses `name_asc` or `name_desc`. See the [release notes for deployment coordination](./docs/releasing.md#template-api-contract).
+
 ### Core Health Endpoints
 
 Core exposes two unauthenticated health-related endpoints:

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -41,6 +41,8 @@ Use these files when a task mentions a related feature, workflow, route, model, 
 - [Worker Parameters](worker-parameters.md) - shared parameter registry ownership, configured/effective values, schema-driven forms, secrets, update semantics, and migration rules.
 - [OSINT Source Management](osint-source-management.md) - single and bulk source creation, atomic bulk deletion, shared settings, optional groups, and import-backed transactions.
 
+- [Presenter Template API](template-api.md) - template names, Pydantic responses, sorting, and admin routing.
+
 ## File Format
 
 Each memory should use this structure:

--- a/docs/agents/template-api.md
+++ b/docs/agents/template-api.md
@@ -1,0 +1,22 @@
+# Presenter Template API
+
+## When To Load
+Template service, presenter template administration, template responses, filename sorting.
+
+## Expected Behavior
+Detail/list responses contain `name`, nullable base64 `content`, and `validation_status`. Creation requests use `name`; update/delete routes use the filename. Sorting uses `name_asc` and `name_desc` case-insensitively. Missing or unreadable templates retain their validation status and null content.
+
+## Code Paths
+- Core: `src/core/core/service/template_service.py`, `src/core/core/api/config.py`
+- Client model: `src/models/models/admin.py` (`Template`)
+- Admin UI: `src/frontend/frontend/views/admin_views/template_views.py`, `src/frontend/frontend/templates/template/`
+- Contract: `src/core/core/static/openapi3_1.yaml`
+
+## Data Flow
+Core builds Pydantic `TemplateResponse` objects and serializes them at the HTTP boundary. The frontend `Template` stores `name`; its `id` property supplies the filename to shared admin routing/table actions and the `0` sentinel for unpopulated forms. That property is not a serialized API field.
+
+## Testing
+Core template service tests cover content states, ordering, and a filesystem-backed API lifecycle. The existing admin template management E2E covers creating, editing, and deleting via the UI. Run `./dev/test_push_signoff.sh` for full signoff.
+
+## Pitfalls
+Deploy Core and Frontend together; see `docs/releasing.md`. Preserve null content when serializing missing templates. Keep exception details server-side.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -24,3 +24,9 @@
    ```
 
    Repeat this check for `taranis-frontend` and `taranis-worker`.
+
+## Template API Contract
+
+Deploy matching Core and Frontend images together when upgrading the template API from `id` to `name`. Update external clients to read `name` in template detail/list responses, send `name` in creation requests, and use `order=name_asc` or `order=name_desc`. Content remains base64 encoded, validation status retains its existing fields, and update/delete URLs still contain the filename. Existing template files need no migration.
+
+Pull the selected published images, restart Core and Frontend, verify readiness, then check template listing, sorting, creation, editing, and deletion. If rolling back, restore both image versions and the corresponding client contract together.

--- a/src/core/core/api/config.py
+++ b/src/core/core/api/config.py
@@ -339,10 +339,10 @@ class Templates(MethodView):
     @auth_required("CONFIG_PRODUCT_TYPE_ACCESS")
     def get(self, template_path: str | None = None):
         if template_path:
-            return jsonify(build_template_response(template_path)), 200
+            return jsonify(build_template_response(template_path).model_dump()), 200
 
         # List all templates
-        items = build_templates_list(request.args.get("order"))
+        items = [item.model_dump() for item in build_templates_list(request.args.get("order"))]
         return jsonify({"items": items, "total_count": len(items)}), 200
 
     @auth_required("CONFIG_PRODUCT_TYPE_CREATE")
@@ -350,9 +350,9 @@ class Templates(MethodView):
         # Use shared logic for create/update
         if not request.json:
             return {"error": "No data provided"}, 400
-        template_id = request.json.get("id")
+        template_name = request.json.get("name")
         base64_content = request.json.get("content")
-        response, status = create_or_update_template(template_id, base64_content)
+        response, status = create_or_update_template(template_name, base64_content)
         _invalidate_admin_cache(status)
         return make_response(jsonify(response), status)
 

--- a/src/core/core/service/template_service.py
+++ b/src/core/core/service/template_service.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 
 from jinja2 import DebugUndefined, TemplateSyntaxError, UndefinedError
 from jinja2.sandbox import ImmutableSandboxedEnvironment
+from pydantic import BaseModel
 
 from core.log import logger
 from core.managers.data_manager import (
@@ -23,20 +24,20 @@ class ValidationStatus(TypedDict):
     error_type: str
 
 
-class TemplateResponse(TypedDict):
-    id: str
+class TemplateResponse(BaseModel):
+    name: str
     content: str | None
     validation_status: ValidationStatus
 
 
-def create_or_update_template(template_id, base64_content):
+def create_or_update_template(template_name, base64_content):
     """
     Shared logic for creating or updating a template.
     Decodes base64 content, validates, and saves the template.
     Returns a tuple: (response_dict, status_code)
     """
-    if not template_id or not base64_content:
-        return {"error": "Missing template id or content"}, 400
+    if not template_name or not base64_content:
+        return {"error": "Missing template name or content"}, 400
 
     # Decode content
     try:
@@ -50,16 +51,16 @@ def create_or_update_template(template_id, base64_content):
 
     # Store in file
     try:
-        save_template_content(template_id, template_content)
+        save_template_content(template_name, template_content)
     except InvalidPresenterTemplatePathError:
         return {"error": "Invalid presenter template path"}, 400
     except OSError:
-        logger.exception("Failed to save template %s", template_id)
+        logger.exception("Failed to save template %s", template_name)
         return {"error": "Failed to save template"}, 500
 
     response = {
         "message": "Template updated or created",
-        "path": template_id,
+        "path": template_name,
         "validation_status": validation_status,
     }
     if not validation_status["is_valid"]:
@@ -138,23 +139,19 @@ def _build_validation_and_content(content: TemplateContent) -> tuple[str | None,
     return base64.b64encode(text.encode("utf-8")).decode("utf-8"), validate_template_content(text)
 
 
-def _build_template_response(template_id: str, content: TemplateContent) -> TemplateResponse:
+def _build_template_response(template_name: str, content: TemplateContent) -> TemplateResponse:
     encoded_content, validation_status = _build_validation_and_content(content)
-    return {
-        "id": template_id,
-        "content": encoded_content,
-        "validation_status": validation_status,
-    }
+    return TemplateResponse(name=template_name, content=encoded_content, validation_status=validation_status)
 
 
 def build_template_response(template_path: str) -> TemplateResponse:
-    """Return a template payload with id, base64 content, and validation status."""
+    """Return a template payload with name, base64 content, and validation status."""
     return _build_template_response(template_path, get_template_content(template_path))
 
 
 def build_templates_list(order: str | None = None) -> list[TemplateResponse]:
     """Return API payloads for every stored presenter template."""
-    items = [_build_template_response(template_id, get_template_content(template_id)) for template_id in list_templates()]
-    if order in {"id_asc", "id_desc"}:
-        items.sort(key=lambda item: item["id"].casefold(), reverse=order == "id_desc")
+    items = [_build_template_response(template_name, get_template_content(template_name)) for template_name in list_templates()]
+    if order in {"name_asc", "name_desc"}:
+        items.sort(key=lambda item: item.name.casefold(), reverse=order == "name_desc")
     return items

--- a/src/core/core/static/openapi3_1.yaml
+++ b/src/core/core/static/openapi3_1.yaml
@@ -4961,8 +4961,8 @@ paths:
         schema:
           type: string
           enum:
-          - id_asc
-          - id_desc
+          - name_asc
+          - name_desc
       responses:
         '200':
           description: success
@@ -4977,7 +4977,7 @@ paths:
     post:
       tags:
       - config
-      description: create or update a presenter template (by id in body) and return
+      description: create or update a presenter template (by name in body) and return
         validation status
       operationId: config.config_templates.post
       security:
@@ -10746,7 +10746,7 @@ components:
     template_item:
       type: object
       properties:
-        id:
+        name:
           type: string
         content:
           description: base64 encoded template content; may be empty string when file
@@ -10758,7 +10758,8 @@ components:
         validation_status:
           $ref: '#/components/schemas/validation_status'
       required:
-      - id
+      - name
+      - content
       - validation_status
     template_list_response:
       type: object
@@ -10772,14 +10773,14 @@ components:
     template_write_request:
       type: object
       properties:
-        id:
+        name:
           type: string
           description: template file name (path relative to presenter_templates)
         content:
           type: string
           format: base64
       required:
-      - id
+      - name
       - content
     template_write_response:
       type: object

--- a/src/core/tests/application/admin_console/configuration/test_template_service.py
+++ b/src/core/tests/application/admin_console/configuration/test_template_service.py
@@ -2,6 +2,7 @@ import base64
 
 import pytest
 
+from core.config import Config
 from core.service import template_service
 
 
@@ -35,9 +36,9 @@ def test_build_template_response_handles_real_template_states(
 
     response = template_service.build_template_response("report_template.html")
 
-    assert response["id"] == "report_template.html"
-    assert response["content"] == expected_content
-    assert response["validation_status"]["error_type"] == expected_error_type
+    assert response.name == "report_template.html"
+    assert response.content == expected_content
+    assert response.validation_status["error_type"] == expected_error_type
 
 
 def test_build_templates_list_returns_api_payloads(monkeypatch):
@@ -52,9 +53,9 @@ def test_build_templates_list_returns_api_payloads(monkeypatch):
 
     items = template_service.build_templates_list()
 
-    assert items == [
+    assert [item.model_dump() for item in items] == [
         {
-            "id": "valid.html",
+            "name": "valid.html",
             "content": base64.b64encode(b"Hello {{ name }}").decode("utf-8"),
             "validation_status": {
                 "is_valid": True,
@@ -63,7 +64,7 @@ def test_build_templates_list_returns_api_payloads(monkeypatch):
             },
         },
         {
-            "id": "empty.html",
+            "name": "empty.html",
             "content": "",
             "validation_status": {
                 "is_valid": False,
@@ -72,7 +73,7 @@ def test_build_templates_list_returns_api_payloads(monkeypatch):
             },
         },
         {
-            "id": "invalid.html",
+            "name": "invalid.html",
             "content": None,
             "validation_status": {
                 "is_valid": False,
@@ -84,13 +85,13 @@ def test_build_templates_list_returns_api_payloads(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("order", "expected_ids"),
+    ("order", "expected_names"),
     [
-        ("id_asc", ["alpha.html", "Beta.html", "zulu.html"]),
-        ("id_desc", ["zulu.html", "Beta.html", "alpha.html"]),
+        ("name_asc", ["alpha.html", "Beta.html", "zulu.html"]),
+        ("name_desc", ["zulu.html", "Beta.html", "alpha.html"]),
     ],
 )
-def test_templates_endpoint_orders_by_id(client, auth_header, monkeypatch, order, expected_ids):
+def test_templates_endpoint_orders_by_name(client, auth_header, monkeypatch, order, expected_names):
     templates = ["zulu.html", "alpha.html", "Beta.html"]
     monkeypatch.setattr(template_service, "list_templates", lambda: templates)
     monkeypatch.setattr(template_service, "get_template_content", lambda _: "Hello")
@@ -98,4 +99,34 @@ def test_templates_endpoint_orders_by_id(client, auth_header, monkeypatch, order
     response = client.get("/api/config/templates", query_string={"order": order}, headers=auth_header)
 
     assert response.status_code == 200
-    assert [item["id"] for item in response.json["items"]] == expected_ids
+    assert [item["name"] for item in response.json["items"]] == expected_names
+
+
+def test_templates_api_lifecycle(client, auth_header, monkeypatch, tmp_path):
+    monkeypatch.setattr(Config, "DATA_FOLDER", str(tmp_path))
+    (tmp_path / "presenter_templates").mkdir()
+    name = "report.html"
+    content = base64.b64encode(b"Hello {{ name }}").decode()
+    endpoint = f"/api/config/templates/{name}"
+
+    response = client.post("/api/config/templates", json={"name": name, "content": content}, headers=auth_header)
+    assert response.status_code == 200
+    assert (tmp_path / "presenter_templates" / name).read_text() == "Hello {{ name }}"
+
+    response = client.get(endpoint, headers=auth_header)
+    assert response.status_code == 200
+    assert response.json == {
+        "name": name,
+        "content": content,
+        "validation_status": {"is_valid": True, "error_message": "", "error_type": ""},
+    }
+
+    content = base64.b64encode(b"Updated").decode()
+    assert client.put(endpoint, json={"content": content}, headers=auth_header).status_code == 200
+    assert client.get(endpoint, headers=auth_header).json["content"] == content
+    assert client.delete(endpoint, headers=auth_header).status_code == 200
+    assert client.get(endpoint, headers=auth_header).json == {
+        "name": name,
+        "content": None,
+        "validation_status": {"is_valid": False, "error_message": "Template file not found.", "error_type": "NotFound"},
+    }

--- a/src/frontend/frontend/templates/template/template_form.html
+++ b/src/frontend/frontend/templates/template/template_form.html
@@ -19,7 +19,7 @@
     <input id="id"
            type="text"
            placeholder="Enter filename...*"
-           name="id"
+           name="name"
            value="{{ '' if template.id == '0' else template.id }}"
            required
            pattern="^[\w\.\-]+$"

--- a/src/frontend/frontend/views/admin_views/template_views.py
+++ b/src/frontend/frontend/views/admin_views/template_views.py
@@ -26,7 +26,7 @@ class TemplateView(AdminBaseView):
         from frontend.filters import render_item_validation_status
 
         return [
-            {"title": "Template Name", "field": "id", "sortable": True, "renderer": None},
+            {"title": "Template Name", "field": "name", "sortable": True, "renderer": None},
             {"title": "Validation Status", "field": "validation_status", "sortable": False, "renderer": render_item_validation_status},
         ]
 
@@ -66,4 +66,4 @@ class TemplateView(AdminBaseView):
             raise
         except Exception as exc:
             logger.error(f"Error storing form data: {exc!s}")
-            return None, str(exc)
+            return None, "Failed to save template"

--- a/src/frontend/tests/playwright/conftest.py
+++ b/src/frontend/tests/playwright/conftest.py
@@ -322,7 +322,7 @@ def setup_test_templates(core_request_client):
     uploaded_templates = []
     for test_file in test_data_dir.glob("*.html"):
         payload = {
-            "id": test_file.name,
+            "name": test_file.name,
             "content": base64.b64encode(test_file.read_bytes()).decode("utf-8"),
         }
         core_request_client.post("/config/templates", json_data=payload, timeout_seconds=30)

--- a/src/frontend/tests/unit/views/conftest.py
+++ b/src/frontend/tests/unit/views/conftest.py
@@ -358,7 +358,7 @@ def mock_core_get_item_endpoints(responses_mock, core_payloads, mock_core_get_it
 
     for view_data in mock_core_get_item_endpoint_data.values():
         url = view_data.pop("_url", None)
-        data_id = view_data.get("id", None)
+        data_id = view_data.get("id", view_data.get("name"))
         if not url or not data_id:
             continue
         responses_mock.get(f"{url}/{data_id}", json=view_data)
@@ -370,7 +370,7 @@ def mock_core_get_item_endpoints(responses_mock, core_payloads, mock_core_get_it
 def mock_core_delete_endpoints(responses_mock, mock_core_get_item_endpoint_data):
     for view_data in mock_core_get_item_endpoint_data.values():
         url = view_data.pop("_url", None)
-        data_id = view_data.get("id", None)
+        data_id = view_data.get("id", view_data.get("name"))
         if not url or not data_id:
             continue
         responses_mock.delete(f"{url}/{data_id}", json={"message": "Successfully deleted"})
@@ -381,7 +381,7 @@ def mock_core_delete_endpoints(responses_mock, mock_core_get_item_endpoint_data)
 def mock_core_create_endpoints(responses_mock, mock_core_get_item_endpoint_data):
     for view_data in mock_core_get_item_endpoint_data.values():
         url = view_data.pop("_url", None)
-        data_id = view_data.get("id", None)
+        data_id = view_data.get("id", view_data.get("name"))
         if not url or not data_id:
             continue
         responses_mock.post(f"{url}", json=view_data)
@@ -392,7 +392,7 @@ def mock_core_create_endpoints(responses_mock, mock_core_get_item_endpoint_data)
 def mock_core_update_endpoints(responses_mock, mock_core_get_item_endpoint_data):
     for view_data in mock_core_get_item_endpoint_data.values():
         url = view_data.pop("_url", None)
-        data_id = view_data.get("id", None)
+        data_id = view_data.get("id", view_data.get("name"))
         if not url or not data_id:
             continue
         responses_mock.put(f"{url}/{data_id}", json=view_data)

--- a/src/frontend/tests/unit/views/test_views.py
+++ b/src/frontend/tests/unit/views/test_views.py
@@ -299,7 +299,7 @@ class TestCRUDViews:
         form_formats_from_models,
         authenticated_client,
     ):
-        item_id = str(mock_core_get_item_endpoints[view_name]["id"])
+        item_id = str(view_cls.model(**mock_core_get_item_endpoints[view_name]).id)
         key = view_cls._get_object_key()
         url = view_cls.get_edit_route(**{key: item_id})
         resp = authenticated_client.get(url)

--- a/src/models/models/admin.py
+++ b/src/models/models/admin.py
@@ -421,9 +421,14 @@ class Template(TaranisBaseModel):
     _model_name = "template"
     _pretty_name = "Template"
 
-    id: str
+    name: str
     content: str | None = None
     validation_status: dict | None = None
+
+    @property
+    def id(self) -> str:
+        """Use the filename for shared admin view routes and table actions."""
+        return getattr(self, "name", "0")
 
 
 class AttributeEnum(TaranisBaseModel):


### PR DESCRIPTION
Fixes: #1037

This pull request updates the presenter template API and related code to use `name` instead of `id` as the primary identifier for templates. It also updates the API contract, sorting, frontend, and tests to reflect this change. The update ensures consistency across the backend, OpenAPI spec, admin UI, and documentation, and provides clear deployment instructions for coordinated upgrades.

**Presenter Template API and Model Changes:**

* The template API now uses `name` instead of `id` for template identification in all API responses, creation requests, and sorting. The `TemplateResponse` is now a Pydantic model with a `name` field. Sorting parameters are updated to `name_asc` and `name_desc`, and all backend logic, OpenAPI schema, and tests are updated accordingly. [[1]](diffhunk://#diff-04dc53fc482c3277797ee6a7f9038990fc2d2b6033bb64d2cd1b24399673927bL26-R40) [[2]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL4964-R4965) [[3]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10749-R10749) [[4]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10761-R10762) [[5]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10775-R10783) [[6]](diffhunk://#diff-e1a51744d292b7f772c88b71dc57e5b54c9ff8dcb1398009ddb1a38f729cde44L342-R355) [[7]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L38-R41) [[8]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L55-R58) [[9]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L66-R67) [[10]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L75-R76) [[11]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L87-R132)

* The OpenAPI spec and API documentation are updated to reflect the new contract, including required fields and descriptions for `name` and sorting options. [[1]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL4964-R4965) [[2]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL4980-R4980) [[3]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10749-R10749) [[4]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10761-R10762) [[5]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10775-R10783)

**Frontend and Admin UI Updates:**

* The admin UI and form logic are updated to use `name` instead of `id` for template identification and display. This includes updates to form fields, table columns, and test setup for uploading templates. [[1]](diffhunk://#diff-268c6129c6fd1933030eef775aa11814df1954f9424c4b8037eed477cf7cbd72L22-R22) [[2]](diffhunk://#diff-0a199a41a4792e4f55ab3e428f8308a7518a0df1c960536308c6f984abef0c2bL29-R29) [[3]](diffhunk://#diff-9670e09fa789d4b1ddbff2ecb5b471030d080f5663a73f6886d80b6e52b1803aL325-R325)

**Testing Improvements:**

* Tests are updated to use the new `name` field, including API lifecycle, ordering, and admin UI tests. Additional end-to-end tests are added to cover the full template management lifecycle. [[1]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L38-R41) [[2]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L55-R58) [[3]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L66-R67) [[4]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L75-R76) [[5]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L87-R132)

* Mocking logic for tests is updated to handle both `id` and `name` for compatibility. [[1]](diffhunk://#diff-53b9ee4b783e415dfe75d60806e996e432a175db194f5b0a0b5c68fea317f4c1L361-R361) [[2]](diffhunk://#diff-53b9ee4b783e415dfe75d60806e996e432a175db194f5b0a0b5c68fea317f4c1L373-R373)

**Documentation and Deployment:**

* Documentation is updated to describe the new API contract, expected behavior, code paths, and deployment instructions. Clear guidance is provided for deploying coordinated Core and Frontend upgrades, and for updating external clients. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R69) [[2]](diffhunk://#diff-591c3547e25fbb052e15d1c94b8873677fe73feacef5e8dd1c1a581a53cdb60bR44-R45) [[3]](diffhunk://#diff-61f1673bbc5c744dd2a3d0cab385dade6d30f6fdca539becd8cfb1a375866c94R1-R22) [[4]](diffhunk://#diff-c5175610592ce29ea8498f5df5c11c82d2f2ba273d60d5c13820b25731d72e49R27-R32)

---

**References:**  
[[1]](diffhunk://#diff-04dc53fc482c3277797ee6a7f9038990fc2d2b6033bb64d2cd1b24399673927bL26-R40) [[2]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL4964-R4965) [[3]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10749-R10749) [[4]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10761-R10762) [[5]](diffhunk://#diff-365143c9eaa6771777c296b844a7d6fcba740f8914dd4c0a43b6ee11b9ab9daaL10775-R10783) [[6]](diffhunk://#diff-e1a51744d292b7f772c88b71dc57e5b54c9ff8dcb1398009ddb1a38f729cde44L342-R355) [[7]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L38-R41) [[8]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L55-R58) [[9]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L66-R67) [[10]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L75-R76) [[11]](diffhunk://#diff-fb8710e901c5e8780e86d03d99526f191f4fa009f9036cdfea87af3cd1b5d422L87-R132) [[12]](diffhunk://#diff-268c6129c6fd1933030eef775aa11814df1954f9424c4b8037eed477cf7cbd72L22-R22) [[13]](diffhunk://#diff-0a199a41a4792e4f55ab3e428f8308a7518a0df1c960536308c6f984abef0c2bL29-R29) [[14]](diffhunk://#diff-9670e09fa789d4b1ddbff2ecb5b471030d080f5663a73f6886d80b6e52b1803aL325-R325) [[15]](diffhunk://#diff-53b9ee4b783e415dfe75d60806e996e432a175db194f5b0a0b5c68fea317f4c1L361-R361) [[16]](diffhunk://#diff-53b9ee4b783e415dfe75d60806e996e432a175db194f5b0a0b5c68fea317f4c1L373-R373) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R69) [[18]](diffhunk://#diff-591c3547e25fbb052e15d1c94b8873677fe73feacef5e8dd1c1a581a53cdb60bR44-R45) [[19]](diffhunk://#diff-61f1673bbc5c744dd2a3d0cab385dade6d30f6fdca539becd8cfb1a375866c94R1-R22) [[20]](diffhunk://#diff-c5175610592ce29ea8498f5df5c11c82d2f2ba273d60d5c13820b25731d72e49R27-R32)