### PR TITLE
Refine warning reporting and improve HTTP recovery handling

### DIFF
--- a/docs/agents/collector-http-state.md
+++ b/docs/agents/collector-http-state.md
@@ -7,7 +7,7 @@ RSS/Simple Web conditional requests, ETag/Last-Modified, 304 results, collector 
 ## Contracts
 
 - Scheduled collection replays stored validators only when the configured primary URL still matches. Manual runs bypass conditional headers. ETags (including weak tags) are opaque and apply only to the primary URL; its Last-Modified is replayed on all direct/browser GETs, including articles, digests, attachments, and icons.
-- Only a primary-resource 200 replaces validators. A 304 preserves them and reports `NOT_MODIFIED`, except it must retain a preceding failure, the `rss_feed_empty` reason/message, or an `rss_entry_limit` warning. Unchanged content cannot prove recovery.
+- Only a primary-resource 200 replaces validators. A primary-resource 304 preserves them and reports `NOT_MODIFIED`, except it must retain a preceding failure, the `rss_feed_empty` reason/message, or an RSS entry-limit `WARNING` for the same URL. Unchanged content cannot prove recovery. `HTTPNotModifiedError` identifies the URL and whether it is the primary resource; duplicate-only publication and secondary-resource 304s do not retain prior source health.
 - Validator state is source-keyed runtime data, independent of task retention, exposed as worker-only `http_validators` and returned in task results. Do not put it in editable parameters or derive it from task times.
 - Fetch/parse/publish failures propagate to `collector_task`, persist FAILURE, and prevent post-collection bots. Cleanup must still run and must not return from `finally`.
 

--- a/docs/agents/rss-source-health.md
+++ b/docs/agents/rss-source-health.md
@@ -11,8 +11,9 @@ RSS/Atom detection, feedparser, empty feeds, source status, or RSS entry limits.
 - Preserve validators and prior empty/failure state on 304 as defined in [Collector HTTP State](collector-http-state.md).
 - `rss_collector_max_entries` is a global positive integer, default 42, applying to normal feeds and digest splitting. Admin Settings warns outside 20–100 but permits any positive value.
 - Truncating feed entries reports `WARNING` with `rss_entry_limit` and "Only the newest N feed entries were considered. X items were skipped." Count skipped feed entries before filtering, deduplication, or digest expansion; preserve the existing feed order. Duplicate-only publication still warns when entries were truncated. Successful publication still runs post-collection bots.
-- HTTP 304 retains a prior entry-limit warning. A freshly parsed feed within the limit clears it, including duplicate-only publication. Raising the limit requires a fresh response (manual collection bypasses validators).
-- Warnings count as successful executions for timestamps/statistics and appear in My Tasks, while source badges/details and task rows display warning styling. Warning completion invalidates frontend content caches like success.
+- The warning is appended to the normal collection result, preserving publication or duplicate-only context.
+- A primary-feed HTTP 304 retains a prior entry-limit warning for the same URL. A freshly parsed feed within the limit clears it, including duplicate-only publication. Raising the limit requires a fresh response (manual collection bypasses validators).
+- Warnings update successful-execution timestamps and appear in My Tasks, while source badges/details and task rows display warning styling. Warning completion invalidates frontend content caches like success. Dashboard/history statistics count warnings separately and show warning styling; see [Scheduler Dashboard](scheduler-dashboard.md).
 
 ## Entry Points and Coverage
 

--- a/docs/agents/scheduler-dashboard.md
+++ b/docs/agents/scheduler-dashboard.md
@@ -12,6 +12,7 @@
 - Core filters/orders/pages RQ lists after collecting registry entries; they are not SQL-backed. Endpoints always return paginated `items`/`total_count`, cached separately per endpoint/query.
 - Schedule counts include unique configured cron jobs, registry jobs, and housekeeping without fetching/annotating full rows. Admin Dashboard count must match the full Scheduled Jobs dataset.
 - History statistics arrive as an aggregate mapping, filtered/ordered/paged in frontend; totals/statistics describe the full matching dataset.
+- History and dashboard task totals count `WARNING` separately from successes and failures. Warnings contribute to total outcomes but not the full-success percentage; a warning-only/mixed-success group shows a yellow warning badge instead of All Success. Warnings still update last-success tracking because collection completed without failing.
 - Source/Bot badges use latest persisted results for configured workers, not transient Queue Failures. Select latest statuses in SQL before counting/paging; exclude one-off `simple_web_collector` fetches. Failure filters preserve other query settings and reset pagination.
 - Display UTC values in profile timezone via `format_datetime`. Pass curated failure messages to the browser with Jinja JSON encoding.
 - Core owns `rq:cron:def`: startup treats current source/bot/housekeeping specs as an allowlist and removes other persisted definitions and artifacts.

--- a/src/core/core/model/task.py
+++ b/src/core/core/model/task.py
@@ -210,11 +210,13 @@ class Task(BaseModel):
     @staticmethod
     def _sum_status_counts(task_stats: dict[str, dict[str, Any]]) -> dict[str, int]:
         successes = sum(int(stats.get("successes", 0) or 0) for stats in task_stats.values())
+        warnings = sum(int(stats.get("warnings", 0) or 0) for stats in task_stats.values())
         failures = sum(int(stats.get("failures", 0) or 0) for stats in task_stats.values())
-        total = successes + failures
+        total = successes + warnings + failures
 
         return {
             "successes": successes,
+            "warnings": warnings,
             "failures": failures,
             "total": total,
             "success_pct": int((successes * 100) / total) if total else 0,
@@ -222,7 +224,7 @@ class Task(BaseModel):
 
     @classmethod
     def get_status_totals(cls) -> dict[str, int]:
-        """Return overall success and failure counts for current worker status."""
+        """Return overall outcome counts for current worker status."""
         return cls._sum_status_counts(cls.get_status_counts_by_task())
 
     @classmethod
@@ -301,6 +303,7 @@ class Task(BaseModel):
                 entry: dict[str, Any] = {
                     "failures": 0,
                     "successes": 0,
+                    "warnings": 0,
                     "success_pct": 0,
                     "total": 0,
                     "worker_type": row.worker_type or task_type,
@@ -333,13 +336,16 @@ class Task(BaseModel):
 
             if row.status in cls.FAILURE_STATUSES:
                 entry["failures"] += 1
+            elif row.status == "WARNING":
+                entry["warnings"] += 1
             elif row.status in cls.SUCCESS_STATUSES:
                 entry["successes"] += 1
 
         for entry in data.values():
             failures = int(entry.get("failures") or 0)
             successes = int(entry.get("successes") or 0)
-            total = failures + successes
+            warnings = int(entry.get("warnings") or 0)
+            total = failures + successes + warnings
             entry["failures"] = failures
             entry["successes"] = successes
             entry["total"] = total
@@ -349,13 +355,16 @@ class Task(BaseModel):
     @staticmethod
     def _build_task_status_badge(stats: dict[str, Any]) -> dict[str, str]:
         successes = int(stats.get("successes") or 0)
+        warnings = int(stats.get("warnings") or 0)
         failures = int(stats.get("failures") or 0)
-        total_runs = int(stats.get("total") or successes + failures)
+        total_runs = int(stats.get("total") or successes + warnings + failures)
         success_pct = int(stats.get("success_pct") or 0)
 
         if total_runs == 0:
             return {"variant": "ghost", "label": "No Runs"}
         if failures == 0:
+            if warnings:
+                return {"variant": "warning", "label": "Warning"}
             return {"variant": "success", "label": "All Success"}
         if failures == 1 and total_runs == 1:
             return {"variant": "warning", "label": "First Failure"}
@@ -397,6 +406,7 @@ class Task(BaseModel):
             "task_stats": task_stats,
             "totals": {
                 "successes": totals["successes"],
+                "warnings": totals["warnings"],
                 "failures": totals["failures"],
                 "overall_success_rate": totals["success_pct"],
             },

--- a/src/core/tests/application/admin_console/configuration/test_task_statistics.py
+++ b/src/core/tests/application/admin_console/configuration/test_task_statistics.py
@@ -10,6 +10,8 @@ from core.model.task import Task
     [
         ({"successes": 0, "failures": 0, "total": 0}, "No Runs", "ghost"),
         ({"successes": 3, "failures": 0, "total": 3}, "All Success", "success"),
+        ({"successes": 0, "warnings": 1, "failures": 0, "total": 1}, "Warning", "warning"),
+        ({"successes": 3, "warnings": 1, "failures": 0, "total": 4}, "Warning", "warning"),
         ({"successes": 0, "failures": 1, "total": 1}, "First Failure", "warning"),
         ({"successes": 8, "failures": 2, "total": 10, "success_pct": 80}, "Mostly Success", "warning"),
         ({"successes": 0, "failures": 2, "total": 2, "success_pct": 0}, "Some Failures", "warning"),
@@ -55,7 +57,14 @@ def test_get_task_statistics_includes_worker_metadata(monkeypatch):
     assert task_stats["last_success"] == last_success.isoformat()
 
 
-def test_get_status_counts_by_task_counts_latest_worker_outcomes_once(app):
+@pytest.mark.parametrize(
+    ("latest_status", "message", "reason"),
+    [
+        ("FAILURE", "boom", "collection_failed"),
+        ("WARNING", "Collection limited", "rss_entry_limit"),
+    ],
+)
+def test_get_status_counts_by_task_counts_latest_worker_outcomes_once(app, latest_status, message, reason):
     from core.model.task import Task
 
     task_ids = [
@@ -92,8 +101,8 @@ def test_get_status_counts_by_task_counts_latest_worker_outcomes_once(app):
                     "task": "collector_task",
                     "worker_id": "source-1",
                     "worker_type": "rss_collector",
-                    "status": "FAILURE",
-                    "result": {"message": "boom", "reason": "collection_failed", "retryable": False, "data": {"source_id": "source-1"}},
+                    "status": latest_status,
+                    "result": {"message": message, "reason": reason, "retryable": False, "data": {"source_id": "source-1"}},
                 }
             )
 
@@ -103,13 +112,15 @@ def test_get_status_counts_by_task_counts_latest_worker_outcomes_once(app):
             rss_stats_with_timestamps = stats_with_timestamps["rss_collector"]
 
             assert rss_stats["successes"] == 1
-            assert rss_stats["failures"] == 1
+            assert rss_stats["failures"] == int(latest_status == "FAILURE")
+            assert rss_stats["warnings"] == int(latest_status == "WARNING")
             assert rss_stats["total"] == 2
             assert rss_stats["success_pct"] == 50
             assert "last_run" not in rss_stats
             assert "last_success" not in rss_stats
             assert rss_stats_with_timestamps["successes"] == 1
-            assert rss_stats_with_timestamps["failures"] == 1
+            assert rss_stats_with_timestamps["failures"] == int(latest_status == "FAILURE")
+            assert rss_stats_with_timestamps["warnings"] == int(latest_status == "WARNING")
             assert rss_stats_with_timestamps["total"] == 2
             assert rss_stats_with_timestamps["success_pct"] == 50
             assert rss_stats_with_timestamps["last_run"] is not None
@@ -186,6 +197,7 @@ def test_get_status_totals_counts_latest_worker_statuses(app):
             assert stats[test_worker_type]["failures"] == 1
             assert totals == {
                 "successes": sum(task_stats["successes"] for task_stats in stats.values()),
+                "warnings": sum(task_stats["warnings"] for task_stats in stats.values()),
                 "failures": sum(task_stats["failures"] for task_stats in stats.values()),
                 "total": sum(task_stats["total"] for task_stats in stats.values()),
                 "success_pct": int((totals["successes"] * 100) / totals["total"]),

--- a/src/core/tests/application/worker_pipeline/test_worker_api.py
+++ b/src/core/tests/application/worker_pipeline/test_worker_api.py
@@ -1010,8 +1010,8 @@ class TestWorkerTaskResults:
                 if Task.get(task_id):
                     Task.delete(task_id)
 
-    @pytest.mark.parametrize("status", ["NOT_MODIFIED", "WARNING"])
-    def test_collector_completed_updates_last_success_and_task_statistics(self, client, api_header, app, fake_source, status):
+    @pytest.mark.parametrize("status, counter", [("NOT_MODIFIED", "successes"), ("WARNING", "warnings")])
+    def test_collector_completed_updates_last_success_and_task_statistics(self, client, api_header, app, fake_source, status, counter):
         from core.model.osint_source import CollectorHTTPState
         from core.model.task import Task
 
@@ -1059,9 +1059,9 @@ class TestWorkerTaskResults:
 
             history = history_response.get_json()
             collector_stats = history["task_stats"]["rss_collector"]
-            assert collector_stats["successes"] >= 1
-            assert collector_stats["total"] >= collector_stats["successes"]
-            assert history["totals"]["successes"] >= 1
+            assert collector_stats[counter] >= 1
+            assert collector_stats["total"] >= collector_stats[counter]
+            assert history["totals"][counter] >= 1
         finally:
             with app.app_context():
                 if Task.get(task_id):

--- a/src/frontend/frontend/templates/admin_dashboard/task_status_totals.html
+++ b/src/frontend/frontend/templates/admin_dashboard/task_status_totals.html
@@ -7,6 +7,10 @@
         <span class="ml-1">success</span>
       </div>
       <div>
+        <span class="badge badge-warning">{{ totals.warnings }}</span>
+        <span class="ml-1">warning</span>
+      </div>
+      <div>
         <span class="badge badge-error">{{ totals.failures }}</span>
         <span class="ml-1">failure</span>
       </div>

--- a/src/frontend/frontend/templates/schedule/execution_history.html
+++ b/src/frontend/frontend/templates/schedule/execution_history.html
@@ -48,6 +48,8 @@
         {% set badge = stats.status_badge %}
         {% if badge %}
           <span class="badge badge-{{ badge.variant }} badge-sm">{{ badge.label }}</span>
+        {% elif stats.warnings and stats.failures == 0 %}
+          <span class="badge badge-warning badge-sm">Warning</span>
         {% elif stats.failures == 0 %}
           <span class="badge badge-success badge-sm">All Success</span>
         {% elif stats.success_pct >= 80 %}
@@ -73,6 +75,7 @@
       <td>
         <div class="flex gap-2">
           <div class="badge badge-success w-20">✓ {{ stats.successes }}</div>
+          <div class="badge badge-warning w-20" title="Warnings">⚠ {{ stats.warnings }}</div>
           <div class="badge badge-error w-20">✗ {{ stats.failures }}</div>
           <div class="badge badge-ghost min-w-16 justify-end text-right">{{ stats.success_pct }}%</div>
         </div>
@@ -84,6 +87,10 @@
     <div class="stat">
       <div class="stat-title">Total Successes</div>
       <div class="stat-value text-success">{{ total_successes }}</div>
+    </div>
+    <div class="stat">
+      <div class="stat-title">Total Warnings</div>
+      <div class="stat-value text-warning">{{ total_warnings }}</div>
     </div>
     <div class="stat">
       <div class="stat-title">Total Failures</div>

--- a/src/frontend/frontend/views/admin_views/scheduler_views.py
+++ b/src/frontend/frontend/views/admin_views/scheduler_views.py
@@ -27,6 +27,7 @@ def _task_stats_page(task_history: TaskHistoryResponse) -> CacheObject:
             "last_run": stats.last_run,
             "last_success": stats.last_success,
             "successes": stats.successes,
+            "warnings": stats.warnings,
             "failures": stats.failures,
             "success_pct": stats.success_pct,
         }
@@ -84,7 +85,7 @@ class SchedulerView(AdminBaseView):
             queues = persistence.get_objects(QueueStatus)
             worker_stats = persistence.get_object(WorkerStats)
             jobs = active_jobs = failed_jobs = task_stats = None
-            total_successes = total_failures = overall_success_rate = 0
+            total_successes = total_warnings = total_failures = overall_success_rate = 0
 
             paging_data = parse_paging_data()
             match selected_tab:
@@ -100,6 +101,7 @@ class SchedulerView(AdminBaseView):
                         raise ValueError("Failed to load scheduler execution history")
                     task_stats = _task_stats_page(history)
                     total_successes = history.totals.successes
+                    total_warnings = history.totals.warnings
                     total_failures = history.totals.failures
                     overall_success_rate = history.totals.overall_success_rate
 
@@ -113,6 +115,7 @@ class SchedulerView(AdminBaseView):
                     "failed_jobs": failed_jobs,
                     "task_stats": task_stats,
                     "total_successes": total_successes,
+                    "total_warnings": total_warnings,
                     "total_failures": total_failures,
                     "overall_success_rate": overall_success_rate,
                     "initial_tab": selected_tab,
@@ -212,6 +215,7 @@ class ScheduleHistoryAPI(MethodView):
                 "schedule/execution_history.html",
                 task_stats=_task_stats_page(task_history),
                 total_successes=task_history.totals.successes,
+                total_warnings=task_history.totals.warnings,
                 total_failures=task_history.totals.failures,
                 overall_success_rate=task_history.totals.overall_success_rate,
             )

--- a/src/models/models/dashboard.py
+++ b/src/models/models/dashboard.py
@@ -34,6 +34,7 @@ class CoreHealth(TaranisBaseModel):
 
 class TaskStatusTotals(BaseModel):
     successes: int = 0
+    warnings: int = 0
     failures: int = 0
     total: int = 0
     success_pct: int = 0

--- a/src/models/models/task.py
+++ b/src/models/models/task.py
@@ -199,6 +199,7 @@ class TaskHistoryStats(TaranisBaseModel):
     last_run_display: str | None = None
     last_success_display: str | None = None
     successes: int = 0
+    warnings: int = 0
     failures: int = 0
     total: int = 0
     success_pct: int = 0
@@ -207,6 +208,7 @@ class TaskHistoryStats(TaranisBaseModel):
 
 class TaskHistoryTotals(TaranisBaseModel):
     successes: int = 0
+    warnings: int = 0
     failures: int = 0
     overall_success_rate: int = 0
 

--- a/src/worker/tests/collectors/test_collector_tasks.py
+++ b/src/worker/tests/collectors/test_collector_tasks.py
@@ -189,8 +189,16 @@ def test_empty_rss_feed_result_is_preserved_after_not_modified_response(current_
     assert feed_requests[-1].headers["If-None-Match"] == validators["etag"]
 
 
-@pytest.mark.parametrize("publish_message", ["News items added", "All news items were skipped"])
-def test_rss_entry_limit_warning_and_recovery(current_job, requests_mock, publish_message):
+@pytest.mark.parametrize(
+    ("publish_message", "result_prefix", "recovered_status", "expected_bot_runs"),
+    [
+        ("News items added", "'Source 1': News items added", "SUCCESS", 1),
+        ("All news items were skipped", "No changes: All news items were skipped", "NOT_MODIFIED", 0),
+    ],
+)
+def test_rss_entry_limit_warning_and_recovery(
+    current_job, requests_mock, publish_message, result_prefix, recovered_status, expected_bot_runs
+):
     feed_url = "https://example.com/feed"
     source = {
         "id": "source-1",
@@ -201,7 +209,10 @@ def test_rss_entry_limit_warning_and_recovery(current_job, requests_mock, publis
     }
     entries = "".join(f"<item><title>Item {i}</title><description>Content {i}</description></item>" for i in range(3))
     feed = f"<rss version='2.0'><channel><title>Feed</title>{entries}</channel></rss>"
-    requests_mock.get(feed_url, [{"text": feed, "headers": {"ETag": '"feed"'}}, {"status_code": 304}, {"text": feed}])
+    requests_mock.get(
+        feed_url,
+        [{"text": feed, "headers": {"ETag": '"feed"'}}, {"status_code": 304}, {"status_code": 304}, {"text": feed}],
+    )
     requests_mock.get("https://example.com/favicon.ico", status_code=404)
     source_endpoint = f"{Config.TARANIS_CORE_URL}/worker/osint-sources/source-1"
     requests_mock.get(source_endpoint, json=source)
@@ -210,27 +221,38 @@ def test_rss_entry_limit_warning_and_recovery(current_job, requests_mock, publis
     requests_mock.post(f"{Config.TARANIS_CORE_URL}/tasks", json={"message": "saved"})
 
     warning = "Only the newest 2 feed entries were considered. 1 items were skipped."
-    assert collector_tasks.collector_task("source-1") == warning
+    expected_message = f"{result_prefix} {warning}"
+    assert collector_tasks.collector_task("source-1") == expected_message
     payload = requests_mock.request_history[-1].json()
     assert payload["status"] == current_job.meta["status"] == "WARNING"
     assert payload["result"]["reason"] == "rss_entry_limit"
     assert payload["result"]["retryable"] is False
     published = next(request.json() for request in requests_mock.request_history if request.url.endswith("/worker/news-items"))
     assert [item["title"] for item in published] == ["Item 0", "Item 1"]
-    assert bots.call_count == (1 if publish_message == "News items added" else 0)
-
-    source["status"] = payload
-    source["http_validators"] = payload["result"]["data"]["http_validators"]
-    requests_mock.get(source_endpoint, json=source)
-    assert collector_tasks.collector_task("source-1") == warning
-    assert requests_mock.request_history[-1].json()["status"] == "WARNING"
+    assert bots.call_count == expected_bot_runs
 
     source["rss_collector_max_entries"] = 3
+    for _ in range(2):
+        source["status"] = payload
+        source["http_validators"] = payload["result"]["data"]["http_validators"]
+        requests_mock.get(source_endpoint, json=source)
+        assert collector_tasks.collector_task("source-1") == expected_message
+        payload = requests_mock.request_history[-1].json()
+        assert payload["status"] == "WARNING"
+
+    source["status"] = payload
     requests_mock.get(source_endpoint, json=source)
     collector_tasks.collector_task("source-1", manual=True)
     payload = requests_mock.request_history[-1].json()
-    assert payload["status"] == ("SUCCESS" if publish_message == "News items added" else "NOT_MODIFIED")
+    assert payload["status"] == recovered_status
     assert payload["result"]["reason"] != "rss_entry_limit"
+    assert warning not in payload["result"]["message"]
+    assert bots.call_count == expected_bot_runs * 2
+
+    feed_requests = [request for request in requests_mock.request_history if request.url == feed_url]
+    assert feed_requests[1].headers["If-None-Match"] == '"feed"'
+    assert feed_requests[2].headers["If-None-Match"] == '"feed"'
+    assert "If-None-Match" not in feed_requests[3].headers
 
 
 def test_rss_parse_failure_cleans_up_persists_failure_and_skips_bots(
@@ -294,6 +316,20 @@ def test_rss_parse_failure_is_not_reclassified_as_not_modified(current_job, requ
     assert feed_requests[-1].headers["If-None-Match"] == '"invalid-feed"'
     task_requests = [request for request in requests_mock.request_history if request.method == "POST"]
     assert task_requests[-1].json()["status"] == "FAILURE"
+
+    source["parameters"]["USE_FEED_CONTENT"] = True
+    requests_mock.get(
+        feed_url,
+        text="<rss version='2.0'><channel><title>Recovered</title><item><title>Existing item</title></item></channel></rss>",
+    )
+    requests_mock.post(f"{Config.TARANIS_CORE_URL}/worker/news-items", json={"message": "All news items were skipped"})
+
+    collector_tasks.collector_task("source-1", manual=True)
+
+    recovered = requests_mock.request_history[-1].json()
+    assert recovered["status"] == "NOT_MODIFIED"
+    assert recovered["result"]["reason"] == "collector_not_modified"
+    assert recovered["result"]["message"] == "No changes: All news items were skipped"
 
 
 def test_fetch_single_news_item_accepts_simple_web_source_payload_and_persists_success_result(current_job, requests_mock, monkeypatch):

--- a/src/worker/worker/collectors/base_web_collector.py
+++ b/src/worker/worker/collectors/base_web_collector.py
@@ -27,6 +27,13 @@ def parse_datetime(value: str) -> datetime.datetime | None:
     return None
 
 
+class HTTPNotModifiedError(NoChangeError):
+    def __init__(self, url: str, *, primary_resource: bool):
+        super().__init__(f"{url} was not modified")
+        self.url = url
+        self.primary_resource = primary_resource
+
+
 class BaseWebCollector(BaseCollector):
     def __init__(self):
         super().__init__()
@@ -98,7 +105,7 @@ class BaseWebCollector(BaseCollector):
         if response.status_code == 200 and not response.content:
             logger.info(f"Request to {url} got Response 200 OK, but returned no content")
         if response.status_code == 304:
-            raise NoChangeError(f"{url} was not modified")
+            raise HTTPNotModifiedError(url, primary_resource=primary_request)
         if response.status_code == 429:
             raise requests.exceptions.HTTPError("Got Response 429 Too Many Requests. Try decreasing REFRESH_INTERVAL.")
         response.raise_for_status()

--- a/src/worker/worker/collectors/collector_tasks.py
+++ b/src/worker/worker/collectors/collector_tasks.py
@@ -11,6 +11,7 @@ from rq import get_current_job
 
 import worker.collectors
 from worker.collectors.base_collector import BaseCollector, NoChangeError
+from worker.collectors.base_web_collector import HTTPNotModifiedError
 from worker.collectors.mastodon_collector import MastodonCollectorError
 from worker.collectors.rss_collector import EmptyRSSFeedError, RSSCollector
 from worker.core_api import CoreApi, build_failure_task_result, build_success_task_result, build_task_result
@@ -152,7 +153,7 @@ def collector_task(osint_source_id: str, manual: bool = False):
     with collector_log_fmt(logger, formatter):
         try:
             collection_result = collector_impl.collect(source, manual)
-            result_message = f"'{source.get('name')}': {collection_result}"
+            result_message = f"'{source.get('name')}': {collection_result if collection_result is not None else 'Collection completed'}"
         except EmptyRSSFeedError as e:
             result_message = f"RSS feed {e.feed_url} is valid but currently contains no entries"
             logger.info(result_message)
@@ -171,7 +172,7 @@ def collector_task(osint_source_id: str, manual: bool = False):
                 return _persist_and_return_result(
                     job,
                     core_api,
-                    warning,
+                    f"No changes: {e.message} {warning}",
                     worker_id=osint_source_id,
                     worker_type=worker_type,
                     meta_status="WARNING",
@@ -179,34 +180,37 @@ def collector_task(osint_source_id: str, manual: bool = False):
                     data=_collector_result_data(osint_source_id, manual, collector_impl),
                 )
             previous_status = source.get("status")
-            if isinstance(previous_status, dict):
+            if isinstance(e, HTTPNotModifiedError) and e.primary_resource and isinstance(previous_status, dict):
                 previous_result = previous_status.get("result")
                 previous_result = previous_result if isinstance(previous_result, dict) else {}
                 previous_task_status = previous_status.get("status")
                 preserve_http_failure = previous_task_status == "FAILURE" and bool(getattr(collector_impl, "http_validators", None))
                 preserve_empty_feed = previous_task_status == "NOT_MODIFIED" and previous_result.get("reason") == "rss_feed_empty"
+                previous_data = previous_result.get("data")
+                previous_data = previous_data if isinstance(previous_data, dict) else {}
+                previous_validators = previous_data.get("http_validators")
                 preserve_entry_limit = (
                     previous_task_status == "WARNING"
                     and previous_result.get("reason") == "rss_entry_limit"
                     and isinstance(collector_impl, RSSCollector)
-                    and collector_impl.skipped_entries is None
+                    and isinstance(previous_validators, dict)
+                    and previous_validators.get("url") == e.url
                 )
                 preserve_previous_result = preserve_http_failure or preserve_empty_feed or preserve_entry_limit
                 if preserve_previous_result:
-                    previous_data = previous_result.get("data")
-                    result_data = dict(previous_data) if isinstance(previous_data, dict) else {}
+                    result_data = dict(previous_data)
                     result_data.update(_collector_result_data(osint_source_id, manual, collector_impl))
                     return _persist_and_return_result(
                         job,
                         core_api,
-                        str(previous_result.get("message") or f"No changes: {e}"),
+                        str(previous_result.get("message") or f"No changes: {e.message}"),
                         worker_id=osint_source_id,
                         worker_type=worker_type,
                         meta_status=previous_task_status,
                         reason=previous_result.get("reason"),
                         data=result_data,
                     )
-            result_message = f"No changes: {e}"
+            result_message = f"No changes: {e.message}"
             return _persist_and_return_result(
                 job,
                 core_api,
@@ -262,7 +266,7 @@ def collector_task(osint_source_id: str, manual: bool = False):
     if isinstance(collector_impl, RSSCollector) and (warning := collector_impl.entry_limit_warning):
         task_status = "WARNING"
         reason = "rss_entry_limit"
-        result_message = warning
+        result_message = f"{result_message} {warning}"
         if job:
             job.meta["status"] = task_status
             job.meta["message"] = result_message


### PR DESCRIPTION

This pull request introduces first-class support for tracking and displaying task executions with a "WARNING" status, in addition to "SUCCESS" and "FAILURE", throughout the collector, scheduler dashboard, and statistics pipelines. It ensures warnings are correctly counted, surfaced in the UI, and included in backend statistics and tests. The documentation is updated to clarify the semantics and handling of warnings, especially for RSS entry limits and HTTP 304 results.

**Backend: Task Status and Statistics**

* The task model and statistics logic now treat "WARNING" as a distinct status: warnings are counted separately, included in totals, and reflected in success percentages and badge variants. [[1]](diffhunk://#diff-aa127aaf3480428a90c023fde6247578768410d4d4693bd2150ec3334d2706cdR213-R227) [[2]](diffhunk://#diff-aa127aaf3480428a90c023fde6247578768410d4d4693bd2150ec3334d2706cdR306) [[3]](diffhunk://#diff-aa127aaf3480428a90c023fde6247578768410d4d4693bd2150ec3334d2706cdR339-R348) [[4]](diffhunk://#diff-aa127aaf3480428a90c023fde6247578768410d4d4693bd2150ec3334d2706cdR358-R367) [[5]](diffhunk://#diff-aa127aaf3480428a90c023fde6247578768410d4d4693bd2150ec3334d2706cdR409)
* Tests are updated and expanded to check for correct warning counting and badge display, ensuring accurate statistics for all status types. [[1]](diffhunk://#diff-685b55e53de749b977a5460f13bea43f886c8789f117a67e612dbe05881f46e9R13-R14) [[2]](diffhunk://#diff-685b55e53de749b977a5460f13bea43f886c8789f117a67e612dbe05881f46e9L58-R67) [[3]](diffhunk://#diff-685b55e53de749b977a5460f13bea43f886c8789f117a67e612dbe05881f46e9L95-R105) [[4]](diffhunk://#diff-685b55e53de749b977a5460f13bea43f886c8789f117a67e612dbe05881f46e9L106-R123) [[5]](diffhunk://#diff-685b55e53de749b977a5460f13bea43f886c8789f117a67e612dbe05881f46e9R200) [[6]](diffhunk://#diff-e2f5d01435b974baccfd90492346cab166221eeb14fac7e0371b56ee5542cf63L1013-R1014) [[7]](diffhunk://#diff-e2f5d01435b974baccfd90492346cab166221eeb14fac7e0371b56ee5542cf63L1062-R1064)

**Frontend: Dashboard and Execution History**

* The admin dashboard and schedule execution history pages now display warning counts and badges, both in summary totals and per-task breakdowns, with appropriate styling. [[1]](diffhunk://#diff-0e32b120c8500d6415db8fe0b84c5185aab11f3676f24dcc1593fb17bde6c83aR9-R12) [[2]](diffhunk://#diff-d74e7d28ecfd7ffb3ca9879f4b692d0df48c705ce6257adc0d62dfe99c1f7885R51-R52) [[3]](diffhunk://#diff-d74e7d28ecfd7ffb3ca9879f4b692d0df48c705ce6257adc0d62dfe99c1f7885R78) [[4]](diffhunk://#diff-d74e7d28ecfd7ffb3ca9879f4b692d0df48c705ce6257adc0d62dfe99c1f7885R91-R94)
* Backend view logic is updated to pass warning counts to templates for rendering. [[1]](diffhunk://#diff-27913b7d4ab7446467efc82399d53a2488519d4d6e2586b9ccca8379950031b2R30) [[2]](diffhunk://#diff-27913b7d4ab7446467efc82399d53a2488519d4d6e2586b9ccca8379950031b2L87-R88) [[3]](diffhunk://#diff-27913b7d4ab7446467efc82399d53a2488519d4d6e2586b9ccca8379950031b2R104) [[4]](diffhunk://#diff-27913b7d4ab7446467efc82399d53a2488519d4d6e2586b9ccca8379950031b2R118)

**Documentation: RSS Collector and Source Health**

* Documentation is clarified to describe how warnings (especially RSS entry-limit warnings and HTTP 304 handling) are retained, cleared, and surfaced in the UI and statistics, including new dashboard behaviors. [[1]](diffhunk://#diff-c681777c284721124500ee69f54049b2af1745da2fa0516d7775d454ab77f913L10-R10) [[2]](diffhunk://#diff-ea31cfc3e2213da5548f9fba99c8699bf41897e0234adaeaf7bcd60767ebf78aL14-R16) [[3]](diffhunk://#diff-1cc60154fb33f4b1b940f43f99ab917e033bc68ba36e4190eb43f1ac46accd3eR15)

These changes ensure that warning outcomes are consistently handled, visible, and actionable across the application, improving both operational clarity and user experience.