### PR TITLE
Change fixture scope to module for story relevance tests

### DIFF
--- a/src/frontend/tests/playwright/conftest.py
+++ b/src/frontend/tests/playwright/conftest.py
@@ -623,7 +623,7 @@ def stories_date_descending_important(core_request_client):
     yield story_ids
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def stories_relevance_descending(core_request_client, stories_date_descending):
     allow_requests_passthru()
 
@@ -631,7 +631,7 @@ def stories_relevance_descending(core_request_client, stories_date_descending):
     yield [story.get("id") for story in stories_relevance_desc]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def stories_date_descending(core_request_client, stories_session_wrapper):
     allow_requests_passthru()
 
@@ -643,7 +643,7 @@ def stories_date_descending(core_request_client, stories_session_wrapper):
     yield story_ids
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def stories_date_descending_not_important(core_request_client, stories_session_wrapper):
     allow_requests_passthru()
     story_ids = []


### PR DESCRIPTION
This pull request makes a small change to the test fixtures in `src/frontend/tests/playwright/conftest.py` by adjusting the scope of several pytest fixtures from `"session"` to `"module"`. This change ensures that the fixtures are set up and torn down once per test module, rather than once per entire test session, which can help with test isolation and performance in certain scenarios.

- Changed the scope of the `stories_relevance_descending`, `stories_date_descending`, and `stories_date_descending_not_important` pytest fixtures from `"session"` to `"module"` in `conftest.py`. [[1]](diffhunk://#diff-9670e09fa789d4b1ddbff2ecb5b471030d080f5663a73f6886d80b6e52b1803aL626-R634) [[2]](diffhunk://#diff-9670e09fa789d4b1ddbff2ecb5b471030d080f5663a73f6886d80b6e52b1803aL646-R646)…tests

Closes #1086 
