### PR TITLE
Fix and clean up TAXII testing

### DIFF
--- a/docs/agents/test-design.md
+++ b/docs/agents/test-design.md
@@ -16,7 +16,7 @@ Before keeping a new test, compare existing coverage and extend the nearest rele
 - Put shared builders in `src/core/tests/application/support/` and large data in fixtures or `src/core/tests/test_data/`.
 - Do not create inline fake classes/ad-hoc doubles inside tests or use autouse fixtures. Request fixtures explicitly or use module/class `pytest.mark.usefixtures`.
 - Prefer frontend E2E coverage for cross-component cache invalidation, scheduling, and seeding. Reuse established test selectors; prefer `data-test-id` for new ones.
-- Worker SFTP tests use a real local SSH server. The publisher fixture handles the expected server-side EOF when the client rejects a host key and joins listener/connection threads during teardown. Keep thread warnings fatal in `tests/publishers/test_sftp_publisher.py`; otherwise a leaked SSH thread can report its failure against an unrelated later test (including TAXII).
+- Worker SFTP tests use a real local SSH server. The publisher fixture handles the expected server-side EOF or connection reset when the client rejects a host key and joins listener/connection threads during teardown. Keep thread warnings fatal in `tests/publishers/test_sftp_publisher.py`; otherwise a leaked SSH thread can report its failure against an unrelated later test (including TAXII).
 
 ## Entry Points
 

--- a/docs/agents/test-design.md
+++ b/docs/agents/test-design.md
@@ -16,7 +16,7 @@ Before keeping a new test, compare existing coverage and extend the nearest rele
 - Put shared builders in `src/core/tests/application/support/` and large data in fixtures or `src/core/tests/test_data/`.
 - Do not create inline fake classes/ad-hoc doubles inside tests or use autouse fixtures. Request fixtures explicitly or use module/class `pytest.mark.usefixtures`.
 - Prefer frontend E2E coverage for cross-component cache invalidation, scheduling, and seeding. Reuse established test selectors; prefer `data-test-id` for new ones.
-- Worker SFTP tests use a real local SSH server. The publisher fixture handles the expected server-side EOF or connection reset when the client rejects a host key and joins listener/connection threads during teardown. Keep thread warnings fatal in `tests/publishers/test_sftp_publisher.py`; otherwise a leaked SSH thread can report its failure against an unrelated later test (including TAXII).
+- Worker SFTP tests use a real local SSH server. The `sftp_mock` fixture and `SFTPTestHandler` handle the expected server-side EOF or connection reset when the client rejects a host key and join listener/connection threads during teardown. Keep thread warnings fatal in `src/worker/tests/publishers/test_sftp_publisher.py`; otherwise a leaked SSH thread can report its failure against an unrelated later test (including TAXII).
 
 ## Entry Points
 

--- a/docs/agents/test-design.md
+++ b/docs/agents/test-design.md
@@ -16,6 +16,7 @@ Before keeping a new test, compare existing coverage and extend the nearest rele
 - Put shared builders in `src/core/tests/application/support/` and large data in fixtures or `src/core/tests/test_data/`.
 - Do not create inline fake classes/ad-hoc doubles inside tests or use autouse fixtures. Request fixtures explicitly or use module/class `pytest.mark.usefixtures`.
 - Prefer frontend E2E coverage for cross-component cache invalidation, scheduling, and seeding. Reuse established test selectors; prefer `data-test-id` for new ones.
+- Worker SFTP tests use a real local SSH server. The publisher fixture handles the expected server-side EOF when the client rejects a host key and joins listener/connection threads during teardown. Keep thread warnings fatal in `tests/publishers/test_sftp_publisher.py`; otherwise a leaked SSH thread can report its failure against an unrelated later test (including TAXII).
 
 ## Entry Points
 

--- a/src/worker/tests/publishers/conftest.py
+++ b/src/worker/tests/publishers/conftest.py
@@ -1,9 +1,35 @@
+from threading import Event, current_thread
 from unittest.mock import patch
 
 import mockssh
 import pytest
+from mockssh.server import Handler
 
 from worker import publishers
+
+
+class SFTPTestHandler(Handler):
+    def __init__(self, server, client_conn):
+        super().__init__(server, client_conn)
+        self.finished = Event()
+        server.handlers.append(self)
+
+    def run(self):
+        self.thread = current_thread()
+        try:
+            self.transport.start_server(server=self)
+            channels = []
+            while self.transport.is_active():
+                channel = self.transport.accept(timeout=0.1)
+                if channel is not None:
+                    # Paramiko runs the SFTP subsystem; no SSH command thread is needed.
+                    channels.append(channel)
+        except EOFError:
+            # Rejecting a changed host key disconnects during SSH negotiation.
+            pass
+        finally:
+            self.transport.close()
+            self.finished.set()
 
 
 class MockProduct:
@@ -170,7 +196,7 @@ def smtp_mock():
 
 
 @pytest.fixture
-def sftp_mock(request):
+def sftp_mock():
     import glob
     import os
 
@@ -179,8 +205,24 @@ def sftp_mock(request):
     users = {
         "user": {"type": "password", "password": "password"},
     }
-    with mockssh.Server(users) as s:  # type: ignore
-        yield s
+    server = mockssh.Server(users)  # type: ignore
+    server.handler_cls = SFTPTestHandler
+    server.handlers = []
+    listener_thread = None
+    try:
+        with server:
+            listener_thread = server._thread
+            yield server
+    finally:
+        # mockssh closes its listener but does not join any of its threads.
+        if listener_thread is not None:
+            listener_thread.join(timeout=5)
+            assert not listener_thread.is_alive(), "SFTP listener did not stop"
+        for handler in server.handlers:
+            handler.transport.close()
+            assert handler.finished.wait(timeout=5), "SFTP handler did not stop"
+            handler.thread.join(timeout=5)
+            assert not handler.thread.is_alive(), "SFTP handler thread did not stop"
 
     for product in glob.glob(f"{product_text['title']}*"):
         os.remove(product)

--- a/src/worker/tests/publishers/conftest.py
+++ b/src/worker/tests/publishers/conftest.py
@@ -24,7 +24,7 @@ class SFTPTestHandler(Handler):
                 if channel is not None:
                     # Paramiko runs the SFTP subsystem; no SSH command thread is needed.
                     channels.append(channel)
-        except EOFError:
+        except (EOFError, ConnectionResetError):
             # Rejecting a changed host key disconnects during SSH negotiation.
             pass
         finally:

--- a/src/worker/tests/publishers/test_sftp_publisher.py
+++ b/src/worker/tests/publishers/test_sftp_publisher.py
@@ -5,6 +5,9 @@ import pytest
 from mockssh.server import SERVER_KEY_PATH
 
 
+pytestmark = pytest.mark.filterwarnings("error::pytest.PytestUnhandledThreadExceptionWarning")
+
+
 @pytest.mark.parametrize("accept_any", [False, True], ids=["pinned-key", "accept-any-key"])
 def test_sftp_publisher_publish(sftp_publisher, get_product_mock, sftp_mock, accept_any):
     from tests.publishers.publishers_data import product_text


### PR DESCRIPTION
This pull request improves the reliability and cleanup of SFTP publisher tests by ensuring all SSH server threads are properly managed and terminated, preventing test contamination from leaked threads. It introduces a custom SFTP handler, enhances fixture teardown, and enforces stricter thread warning handling.

**SFTP Test Infrastructure Improvements:**

* Added a custom `SFTPTestHandler` to ensure all SFTP server handler threads are tracked and properly terminated after each test, preventing interference with unrelated tests.
* Modified the `sftp_mock` fixture to use the new handler, explicitly join the listener and handler threads during teardown, and assert their termination, improving test isolation and reliability. [[1]](diffhunk://#diff-f797195334367b9e3e2e5e42ffff2ff17e255625cf4ccaca520e6c7ed962ac77L173-R199) [[2]](diffhunk://#diff-f797195334367b9e3e2e5e42ffff2ff17e255625cf4ccaca520e6c7ed962ac77L182-R225)

**Test Reliability Enhancements:**

* Set `pytestmark` in `test_sftp_publisher.py` to treat unhandled thread warnings as errors, making thread leaks immediately visible during test runs.

**Documentation Update:**

* Updated `test-design.md` to document the use of a real local SSH server for SFTP tests, the improved fixture teardown, and the importance of keeping thread warnings fatal to avoid test contamination.